### PR TITLE
Change lastAddressQueryHeight type check to 'number'

### DIFF
--- a/src/common/types.js
+++ b/src/common/types.js
@@ -45,7 +45,7 @@ export class WalletLocalData {
       if (typeof data.blockHeight === 'number') {
         this.blockHeight = data.blockHeight
       }
-      if (typeof data.lastAddressQueryHeight === 'string') {
+      if (typeof data.lastAddressQueryHeight === 'number') {
         this.lastAddressQueryHeight = data.lastAddressQueryHeight
       }
       if (typeof data.publicKey === 'string') this.publicKey = data.publicKey


### PR DESCRIPTION
Checking against "string" causes the constructor to never load the query height and so it always initializes to 0 and we end up querying all transactions on login