### PR TITLE
Hold more than one pending transaction for XLM

### DIFF
--- a/src/eos/eosEngine.js
+++ b/src/eos/eosEngine.js
@@ -601,8 +601,6 @@ export class EosEngine extends CurrencyEngine {
         transactionJson
       }
     }
-    // this.pendingTransactionsMap = {}
-    // this.pendingTransactionsMap[idInternal] = transaction
 
     this.log('EOS transaction prepared')
     this.log(


### PR DESCRIPTION
Fixes swap error when multiple makeSpends are called but anything other than the latest one is used for signTx/broadcastTx