### PR TITLE
Fix fluttering ETH confirmation status

### DIFF
--- a/src/common/engine.js
+++ b/src/common/engine.js
@@ -258,10 +258,14 @@ class CurrencyEngine {
       const edgeTx = transactionsArray[idx]
 
       if (
-        edgeTx.blockHeight !== edgeTransaction.blockHeight ||
-        edgeTx.networkFee !== edgeTransaction.networkFee ||
-        edgeTx.nativeAmount !== edgeTransaction.nativeAmount ||
-        edgeTx.date !== edgeTransaction.date
+        edgeTx.blockHeight < edgeTransaction.blockHeight ||
+        (
+          edgeTx.blockHeight === edgeTransaction.blockHeight && (
+            edgeTx.networkFee !== edgeTransaction.networkFee ||
+            edgeTx.nativeAmount !== edgeTransaction.nativeAmount ||
+            edgeTx.date !== edgeTransaction.date
+          )
+        )
       ) {
         if (edgeTx.date !== edgeTransaction.date) {
           needsResort = true


### PR DESCRIPTION
Only update a transaction if the blockHeight increases or is the same and date, amount, or fee changes