### PR TITLE
Multicast ether APIs

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -21,6 +21,24 @@ function addHexPrefix (value: string) {
   }
 }
 
+function shuffleArray (array: Array<any>) {
+  let currentIndex = array.length
+  let temporaryValue, randomIndex
+
+  // While there remain elements to shuffle...
+  while (currentIndex !== 0) {
+    // Pick a remaining element...
+    randomIndex = Math.floor(Math.random() * currentIndex)
+    currentIndex -= 1
+
+    // And swap it with the current element.
+    temporaryValue = array[currentIndex]
+    array[currentIndex] = array[randomIndex]
+    array[randomIndex] = temporaryValue
+  }
+
+  return array
+}
 function validateObject (object: any, schema: any) {
   const result = validate(object, schema)
 
@@ -171,6 +189,7 @@ export {
   getDenomInfo,
   asyncWaterfall,
   snooze,
+  shuffleArray,
   snoozeReject,
   getEdgeInfoServer,
   promiseAny

--- a/src/ethereum/ethInfo.js
+++ b/src/ethereum/ethInfo.js
@@ -8,7 +8,7 @@ import type { EthereumSettings } from './ethTypes.js'
 export const imageServerUrl = 'https://developer.airbitz.co/content'
 
 const otherSettings: EthereumSettings = {
-  etherscanApiServers: ['https://api.etherscan.io'],
+  etherscanApiServers: ['https://api.etherscan.io', 'https://blockscout.com/eth/mainnet'],
   blockcypherApiServers: ['https://api.blockcypher.com'],
   superethServers: ['https://supereth1.edgesecure.co:8443'],
   iosAllowedTokens: { REP: true, WINGS: true, HUR: true, IND: true, USDT: true }

--- a/src/ethereum/ethInfo.js
+++ b/src/ethereum/ethInfo.js
@@ -8,7 +8,10 @@ import type { EthereumSettings } from './ethTypes.js'
 export const imageServerUrl = 'https://developer.airbitz.co/content'
 
 const otherSettings: EthereumSettings = {
-  etherscanApiServers: ['https://api.etherscan.io', 'https://blockscout.com/eth/mainnet'],
+  etherscanApiServers: [
+    'https://api.etherscan.io',
+    'https://blockscout.com/eth/mainnet'
+  ],
   blockcypherApiServers: ['https://api.blockcypher.com'],
   superethServers: ['https://supereth1.edgesecure.co:8443'],
   iosAllowedTokens: { REP: true, WINGS: true, HUR: true, IND: true, USDT: true }


### PR DESCRIPTION
Utilize multiple ether APIs for blockchain queries

Fixes stuck loading of ether wallets due to rate limiting from APIs. This PR adds use of Blockscout and Infura in addition to etherscan
