### PR TITLE
Implement fix for insufficient token balance causing error

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -21,12 +21,12 @@ import {
   asyncWaterfall,
   bufToHex,
   getEdgeInfoServer,
+  isHex,
   normalizeAddress,
   promiseAny,
   shuffleArray,
   toHex,
-  validateObject,
-  isHex
+  validateObject
 } from '../common/utils.js'
 import { currencyInfo } from './ethInfo.js'
 import { calcMiningFee } from './ethMiningFees.js'
@@ -909,7 +909,10 @@ export class EthereumEngine extends CurrencyEngine {
       if (bns.gt(nativeNetworkFee, balanceEth)) {
         throw ErrorInsufficientFundsMoreEth
       }
-
+      const balanceToken = this.walletLocalData.totalBalances[currencyCode]
+      if (bns.gt(nativeAmount, balanceToken)) {
+        throw new InsufficientFundsError()
+      }
       nativeNetworkFee = '0' // Do not show a fee for token transactions.
       nativeAmount = bns.mul(nativeAmount, '-1')
     }


### PR DESCRIPTION
The purpose of this task is to get the Ethereum plugin to throw an error (insufficient funds) when there is not enough of a token balance to cover the transaction amount.

Asana Task: https://app.asana.com/0/361770107085503/1113213741273785/f