### PR TITLE
Add ability to detect and mark dropped transactions

### DIFF
--- a/src/common/types.js
+++ b/src/common/types.js
@@ -27,6 +27,7 @@ export class WalletLocalData {
   publicKey: string
   totalBalances: { [currencyCode: string]: string }
   enabledTokens: Array<string>
+  lastCheckedTxsDropped: number
   otherData: Object
 
   constructor (jsonString: string | null, primaryCurrency: string) {
@@ -34,6 +35,7 @@ export class WalletLocalData {
     const totalBalances: { [currencyCode: string]: string } = {}
     this.totalBalances = totalBalances
     this.lastAddressQueryHeight = 0
+    this.lastCheckedTxsDropped = 0
     this.otherData = {}
     this.publicKey = ''
     this.enabledTokens = [primaryCurrency]
@@ -42,6 +44,9 @@ export class WalletLocalData {
 
       if (typeof data.blockHeight === 'number') {
         this.blockHeight = data.blockHeight
+      }
+      if (typeof data.lastCheckedTxsDropped === 'number') {
+        this.lastCheckedTxsDropped = data.lastCheckedTxsDropped
       }
       if (typeof data.lastAddressQueryHeight === 'number') {
         this.lastAddressQueryHeight = data.lastAddressQueryHeight

--- a/src/eos/eosEngine.js
+++ b/src/eos/eosEngine.js
@@ -136,6 +136,7 @@ export class EosEngine extends CurrencyEngine {
       })
       const blockHeight = result.head_block_num
       if (this.walletLocalData.blockHeight !== blockHeight) {
+        this.checkDroppedTransactionsThrottled()
         this.walletLocalData.blockHeight = blockHeight
         this.walletLocalDataDirty = true
         this.currencyEngineCallbacks.onBlockHeightChanged(
@@ -184,7 +185,7 @@ export class EosEngine extends CurrencyEngine {
       txid: trx_id,
       date: Date.parse(block_time) / 1000,
       currencyCode,
-      blockHeight: block_num,
+      blockHeight: block_num > 0 ? block_num : 0,
       nativeAmount,
       networkFee: '0',
       parentNetworkFee: '0',
@@ -204,7 +205,7 @@ export class EosEngine extends CurrencyEngine {
   processTransactionFullNode (action: EosTransaction): number {
     const ourReceiveAddresses = []
     const date = Date.parse(action.block_time) / 1000
-    const blockHeight = action.block_num
+    const blockHeight = action.block_num > 0 ? action.block_num : 0
     if (!action.action_trace || !action.account_action_seq) {
       this.log(
         'Invalid EOS transaction data. No action_trace or account_action_seq'

--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -164,6 +164,7 @@ export class EthereumEngine extends CurrencyEngine {
         const blockHeight: number = parseInt(jsonObj.result, 16)
         this.log(`Got block height ${blockHeight}`)
         if (this.walletLocalData.blockHeight !== blockHeight) {
+          this.checkDroppedTransactionsThrottled()
           this.walletLocalData.blockHeight = blockHeight // Convert to decimal
           this.walletLocalDataDirty = true
           this.currencyEngineCallbacks.onBlockHeightChanged(
@@ -319,11 +320,13 @@ export class EthereumEngine extends CurrencyEngine {
       tokenRecipientAddress: null
     }
 
+    let blockHeight = parseInt(tx.blockNumber)
+    if (blockHeight < 0) blockHeight = 0
     const edgeTransaction: EdgeTransaction = {
       txid: tx.hash,
       date: parseInt(tx.timeStamp),
       currencyCode,
-      blockHeight: parseInt(tx.blockNumber),
+      blockHeight,
       nativeAmount: netNativeAmount,
       networkFee: nativeNetworkFee,
       ourReceiveAddresses,
@@ -437,7 +440,7 @@ export class EthereumEngine extends CurrencyEngine {
       txid: addHexPrefix(tx.hash),
       date: epochTime,
       currencyCode: 'ETH',
-      blockHeight: tx.block_height,
+      blockHeight: 0,
       nativeAmount,
       networkFee: tx.fees.toString(10),
       ourReceiveAddresses,

--- a/src/stellar/stellarEngine.js
+++ b/src/stellar/stellarEngine.js
@@ -178,7 +178,7 @@ export class StellarEngine extends CurrencyEngine {
       txid: tx.transaction_hash,
       date,
       currencyCode,
-      blockHeight: rawTx.ledger_attr, // API shows no ledger number ??
+      blockHeight: rawTx.ledger_attr > 0 ? rawTx.ledger_attr : 0, // API shows no ledger number ??
       nativeAmount,
       networkFee,
       parentNetworkFee: '0',
@@ -329,6 +329,7 @@ export class StellarEngine extends CurrencyEngine {
       .then(r => {
         const blockHeight = r.records[0].sequence
         if (this.walletLocalData.blockHeight !== blockHeight) {
+          this.checkDroppedTransactionsThrottled()
           this.walletLocalData.blockHeight = blockHeight
           this.walletLocalDataDirty = true
           this.currencyEngineCallbacks.onBlockHeightChanged(

--- a/src/xrp/xrpEngine.js
+++ b/src/xrp/xrpEngine.js
@@ -102,6 +102,7 @@ export class XrpEngine extends CurrencyEngine {
         const blockHeight: number = jsonObj.validatedLedger.ledgerVersion
         this.log(`Got block height ${blockHeight}`)
         if (this.walletLocalData.blockHeight !== blockHeight) {
+          this.checkDroppedTransactionsThrottled()
           this.walletLocalData.blockHeight = blockHeight // Convert to decimal
           this.walletLocalDataDirty = true
           this.currencyEngineCallbacks.onBlockHeightChanged(
@@ -125,7 +126,8 @@ export class XrpEngine extends CurrencyEngine {
       for (const bc of balanceChanges) {
         const currencyCode: string = bc.currency
         const date: number = Date.parse(tx.outcome.timestamp) / 1000
-        const blockHeight: number = tx.outcome.ledgerVersion
+        const blockHeight: number =
+          tx.outcome.ledgerVersion > 0 ? tx.outcome.ledgerVersion : 0
 
         const exchangeAmount: string = bc.value
         if (exchangeAmount.slice(0, 1) !== '-') {

--- a/test/engine/engine.txs.js
+++ b/test/engine/engine.txs.js
@@ -1,0 +1,67 @@
+const ETH = [
+  {
+    txid: '001',
+    date: 1555550000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '002',
+    date: 1555560000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '003',
+    date: 1555570000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '004',
+    date: 1555580000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '005',
+    date: 1555590000,
+    blockHeight: 0,
+    otherParams: {}
+  }
+]
+
+const DAI = [
+  {
+    txid: '101',
+    date: 1555650000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '102',
+    date: 1555660000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '103',
+    date: 1555670000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '104',
+    date: 1555680000,
+    blockHeight: 0,
+    otherParams: {}
+  },
+  {
+    txid: '105',
+    date: 1555690000,
+    blockHeight: 0,
+    otherParams: {}
+  }
+]
+
+export const engineTestTxs = { ETH, DAI }


### PR DESCRIPTION
* Mark dropped transactions with blockHeight = -1 and nativeAmount = '0'
* Sanitize transaction queries to ensure blockheights from APIs are non-negative
* Add tests for addTransaction to test txidMap, txidList, and transactionList
* Check for dropped transactions when network blockheight changes but no more than once per day