### PR TITLE
Remove `ErrorInsufficientFundsMoreEth`

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -893,11 +893,6 @@ export class EthereumEngine extends CurrencyEngine {
       otherParams = ethParams
     }
 
-    const ErrorInsufficientFundsMoreEth = new Error(
-      'Insufficient ETH for transaction fee'
-    )
-    ErrorInsufficientFundsMoreEth.name = 'ErrorInsufficientFundsMoreEth'
-
     let nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
     const balanceEth = this.walletLocalData.totalBalances[
       this.currencyInfo.currencyCode
@@ -916,7 +911,7 @@ export class EthereumEngine extends CurrencyEngine {
       parentNetworkFee = nativeNetworkFee
 
       if (bns.gt(nativeNetworkFee, balanceEth)) {
-        throw ErrorInsufficientFundsMoreEth
+        throw new InsufficientFundsError('Insufficient ETH for transaction fee')
       }
       const balanceToken = this.walletLocalData.totalBalances[currencyCode]
       if (bns.gt(nativeAmount, balanceToken)) {

--- a/src/rsk/rskEngine.js
+++ b/src/rsk/rskEngine.js
@@ -767,11 +767,6 @@ export class RskEngine extends CurrencyEngine {
       otherParams = ethParams
     }
 
-    const ErrorInsufficientFundsMoreEth = new Error(
-      'Insufficient RBTC for transaction fee'
-    )
-    ErrorInsufficientFundsMoreEth.name = 'ErrorInsufficientFundsMoreEth'
-
     let nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
     const balanceEth = this.walletLocalData.totalBalances[
       this.currencyInfo.currencyCode
@@ -790,7 +785,9 @@ export class RskEngine extends CurrencyEngine {
       parentNetworkFee = nativeNetworkFee
 
       if (bns.gt(nativeNetworkFee, balanceEth)) {
-        throw ErrorInsufficientFundsMoreEth
+        throw new InsufficientFundsError(
+          'Insufficient RBTC for transaction fee'
+        )
       }
       const balanceToken = this.walletLocalData.totalBalances[currencyCode]
       if (bns.gt(nativeAmount, balanceToken)) {


### PR DESCRIPTION
The core only understands `InsufficientFundsError`, so this weird error type is causing bad swap experiences for customers.