### PR TITLE
Upgrade to upstream Ripple libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "base-x": "^1.0.4",
     "biggystring": "^3.0.0",
     "bip39": "^3.0.2",
-    "edge-ripple-lib": "^1.0.0-beta.2",
+    "ripple-lib": "^1.0.0",
+    "ripple-keypairs": "^0.10.0",
     "eosjs": "^16.0.9",
     "esm": "^3.2.4",
     "ethereumjs-abi": "^0.6.4",
@@ -98,7 +99,8 @@
     "webpack-cli": "^3.2.3"
   },
   "resolutions": {
-    "scrypt.js": "0.3.0"
+    "scrypt.js": "0.3.0",
+    "ripple-binary-codec": "0.2.3"
   },
   "importSort": {
     ".js, .es": {

--- a/src/xrp/xrpPlugin.js
+++ b/src/xrp/xrpPlugin.js
@@ -15,8 +15,8 @@ import {
   type EdgeParsedUri,
   type EdgeWalletInfo
 } from 'edge-core-js/types'
-import keypairs from 'edge-ripple-keypairs'
-import { RippleAPI } from 'edge-ripple-lib'
+import keypairs from 'ripple-keypairs'
+import { RippleAPI } from 'ripple-lib'
 import parse from 'url-parse'
 
 import { CurrencyPlugin } from '../common/plugin.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,10 +810,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@types/lodash@^4.14.85":
-  version "4.14.109"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.109.tgz#b1c4442239730bf35cabaf493c772b18c045886d"
-  integrity sha512-hop8SdPUEzbcJm6aTsmuwjIYQo1tqLseKCM+s2bBqTU2gErwI4fE+aqUVOlscPSQbKHKgtMMPoC+h4AIGOJYvw==
+"@types/lodash@^4.14.136":
+  version "4.14.138"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
+  integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
 
 "@types/node@*":
   version "10.1.4"
@@ -2789,36 +2789,6 @@ edge-core-js@^0.15.11:
     ws "^5.1.1"
     yaob "^0.3.3"
 
-edge-ripple-keypairs@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/edge-ripple-keypairs/-/edge-ripple-keypairs-0.0.1.tgz#734f39733132a11098a70b93c58f27740e15740c"
-  integrity sha512-AA+Y/0r6+MACci28Ccvgz7JT/Krz072PXakgsPo5cR+Wc6rvFK0a0T5c6NBuFHQiQr4TJv278LmXhJiJvcJ7hA==
-  dependencies:
-    babel-runtime "^5.8.20"
-    bn.js "^3.1.1"
-    brorand "^1.0.5"
-    elliptic "^6.4.0"
-    hash.js "^1.0.3"
-    ripple-address-codec "^2.0.1"
-
-edge-ripple-lib@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/edge-ripple-lib/-/edge-ripple-lib-1.0.0-beta.2.tgz#927036dcc91048cb274bbe8a92534365e13ef89e"
-  integrity sha512-61gW94w1mR+OX+hldR4T5YTB3g009iwIBl5lIfDVTEH3OX7iDN8TdOlIlVPHp0QxGHa842wIsyciTd9q9WP5mQ==
-  dependencies:
-    "@types/lodash" "^4.14.85"
-    "@types/ws" "^3.2.0"
-    bignumber.js "^4.1.0"
-    edge-ripple-keypairs "^0.0.1"
-    https-proxy-agent "2.2.1"
-    jsonschema "1.2.2"
-    lodash "^4.17.4"
-    ripple-address-codec "^2.0.1"
-    ripple-binary-codec "^0.1.13"
-    ripple-hashes "^0.3.1"
-    ripple-lib-transactionparser "^0.6.2"
-    ws "^3.3.1"
-
 electron-to-chromium@^1.3.103:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
@@ -2828,6 +2798,16 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+elliptic@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-5.2.1.tgz#fa294b6563c6ddbc9ba3dc8594687ae840858f10"
+  integrity sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=
+  dependencies:
+    bn.js "^3.1.1"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
 
 elliptic@^6.0.0, elliptic@^6.2.3:
   version "6.4.1"
@@ -5286,7 +5266,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7110,36 +7090,66 @@ ripple-address-codec@^2.0.1:
     hash.js "^1.0.3"
     x-address-codec "^0.7.0"
 
-ripple-binary-codec@^0.1.0, ripple-binary-codec@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.1.13.tgz#c68951405a17a71695551e789966ff376da552e4"
-  integrity sha1-xolRQFoXpxaVVR54mWb/N22lUuQ=
+ripple-binary-codec@0.2.1, ripple-binary-codec@0.2.2, ripple-binary-codec@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.3.tgz#ca16ba39bb8f32fce693b63947eb8b3e1dd8ca2c"
+  integrity sha512-1HptJcjcEvmD35dO3DaKhXxYoZYMu4k+D2khmuSctQ8ATUoktKRoBpe1x/+zK5bCHKu7Ep2iAzCaDmjJM9zr1g==
   dependencies:
     babel-runtime "^6.6.1"
     bn.js "^4.11.3"
     create-hash "^1.1.2"
     decimal.js "^5.0.8"
     inherits "^2.0.1"
-    lodash "^4.12.0"
+    lodash "^4.17.15"
     ripple-address-codec "^2.0.1"
 
-ripple-hashes@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ripple-hashes/-/ripple-hashes-0.3.1.tgz#f2f46f1ff05e6487500a99839019114cd2482411"
-  integrity sha1-8vRvH/BeZIdQCpmDkBkRTNJIJBE=
+ripple-hashes@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ripple-hashes/-/ripple-hashes-0.3.2.tgz#f3ac3b1832cec6d0bac07e82acc10a0a6a1cc84e"
+  integrity sha512-1Emm/raLNChNR5nVoQPJ7NWQpHr8jJjIZDoug4ukw4RZ3+eehO5nyx86a+MaQKAeAc1nJRFwVjBvh9SeYpelYw==
   dependencies:
     bignumber.js "^4.1.0"
     create-hash "^1.1.2"
     ripple-address-codec "^2.0.1"
-    ripple-binary-codec "^0.1.0"
+    ripple-binary-codec "0.2.1"
 
-ripple-lib-transactionparser@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.6.2.tgz#eb117834816cab3398445a74ec3cacec95b6b5fa"
-  integrity sha1-6xF4NIFsqzOYRFp07Dys7JW2tfo=
+ripple-keypairs@^0.10.0, ripple-keypairs@^0.10.1:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/ripple-keypairs/-/ripple-keypairs-0.10.2.tgz#b3a1d1e2fca85a11c5224b2a7e6da506c19720d0"
+  integrity sha512-NvY+jCrhtpy7ox2unZTIfOfSrUWqVTq+tfCTqgDD8XZ957JGwHBlL5osYAypkTWed/JglH5hggxw14NTKEZzGA==
+  dependencies:
+    babel-runtime "^5.8.20"
+    bn.js "^3.1.1"
+    brorand "^1.0.5"
+    elliptic "^5.1.0"
+    hash.js "^1.0.3"
+    ripple-address-codec "^2.0.1"
+
+ripple-lib-transactionparser@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.7.1.tgz#5ececb1e03d65d05605343f4b9dbb76d1089145b"
+  integrity sha1-Xs7LHgPWXQVgU0P0udu3bRCJFFs=
   dependencies:
     bignumber.js "^4.1.0"
     lodash "^4.17.4"
+
+ripple-lib@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ripple-lib/-/ripple-lib-1.3.1.tgz#39c74a3957c9eccc048d913be4219172cced209e"
+  integrity sha512-zc727pvbVHw+XtOtIJQBR4cT5XeNyVxtJO8S5JoPcdqtC/SVeUlr9hJCwOtGq1opipxntIn1Phr0iJxtyDxVIw==
+  dependencies:
+    "@types/lodash" "^4.14.136"
+    "@types/ws" "^3.2.0"
+    bignumber.js "^4.1.0"
+    https-proxy-agent "2.2.1"
+    jsonschema "1.2.2"
+    lodash "^4.17.4"
+    ripple-address-codec "^2.0.1"
+    ripple-binary-codec "0.2.2"
+    ripple-hashes "0.3.2"
+    ripple-keypairs "^0.10.1"
+    ripple-lib-transactionparser "0.7.1"
+    ws "^3.3.1"
 
 rlp@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This requires Node v10, and won't work with v12 or v11 unless you pass `--ignore-engines` to `yarn`. I have filed https://github.com/ripple/ripple-binary-codec/pull/33 to fix this, so maybe we wait for that to go in before we merge this?