### PR TITLE
Fix stuck BNB account balance progress bug

### DIFF
--- a/src/binance/bnbEngine.js
+++ b/src/binance/bnbEngine.js
@@ -171,6 +171,13 @@ export class BinanceEngine extends CurrencyEngine {
         }
       }
     } catch (e) {
+      // fetching of account balances for uninitiate accounts returns 404 (throws error)
+      if (
+        this.tokenCheckTransactionsStatus.BNB === 1 &&
+        this.transactionList.BNB.length === 0
+      ) {
+        this.updateBalance('BNB', '0')
+      }
       this.log(`Error checking BNB address balance`)
     }
   }


### PR DESCRIPTION
The API endpoint for checking a balance for an account with no previous transactions causes a `404` error which gets caught, and inside of that catch clause we update the balance as `0` if the wallet literally has zero transactions (you can't have a balance without having transactions).