### PR TITLE
Tron Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ripple-lib": "^1.0.0",
     "stellar-sdk": "^0.11.0",
     "tezos-uri": "^1.0.3",
+    "tronweb": "^2.7.4",
     "uri-js": "^3.0.2",
     "url-parse": "^1.4.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { makeRskPlugin } from './rsk/rskPlugin.js'
 import { makeStellarPlugin } from './stellar/stellarPlugin.js'
 import { makeTezosPlugin } from './tezos/tezosPlugin.js'
 import { makeRipplePlugin } from './xrp/xrpPlugin.js'
+import { makeTronPlugin } from './tron/tronPlugin.js'
 
 const plugins = {
   eos: makeEosPlugin,
@@ -23,7 +24,8 @@ const plugins = {
   stellar: makeStellarPlugin,
   tezos: makeTezosPlugin,
   rsk: makeRskPlugin,
-  binance: makeBinancePlugin
+  binance: makeBinancePlugin,
+  tron: makeTronPlugin
 }
 
 if (

--- a/src/tron/tronEngine.js
+++ b/src/tron/tronEngine.js
@@ -176,7 +176,7 @@ export class TronEngine extends CurrencyEngine {
     // isSpend Tx
     if (fromAddr === publicKey) {
       // if it's a send to one's self
-      if (tx.owner_address === toAddr) {
+      if (fromAddr === toAddr) {
         // Spend to self. netNativeAmount is just the fee
         netNativeAmount = bns.mul(nativeNetworkFee, '-1')
       } else {
@@ -189,14 +189,13 @@ export class TronEngine extends CurrencyEngine {
       // ourReceiveAddresses.push(this.walletLocalData.publicKey.toLowerCase())
     }
 
-    const otherParams: Object = {}
+    const otherParams: TronTxOtherParams = {}
 
     let blockHeight = tx.blockNumber
     if (blockHeight < 0) blockHeight = 0
-    const unixTimestamp = new Date(tx.block_timestamp)
     const edgeTransaction: EdgeTransaction = {
       txid: tx.txID,
-      date: unixTimestamp.getTime(),
+      date: tx.block_timestamp,
       currencyCode,
       blockHeight,
       nativeAmount: netNativeAmount,
@@ -302,7 +301,7 @@ export class TronEngine extends CurrencyEngine {
 
     if (checkAddressSuccess) {
       this.tokenCheckTransactionsStatus[currencyCode] = 1
-      // this.updateOnAddressesChecked()
+      this.updateOnAddressesChecked()
       return true
     } else {
       return false
@@ -325,7 +324,6 @@ export class TronEngine extends CurrencyEngine {
     }
 
     for (const currencyCode of this.walletLocalData.enabledTokens) {
-      this.log('enabled Token: ', currencyCode)
       promiseArray.push(this.checkTransactionsFetch(startTime, currencyCode))
     }
 
@@ -514,6 +512,7 @@ export class TronEngine extends CurrencyEngine {
     )
     // this.log(`SUCCESS TRX broadcastTx\n${JSON.stringify(signedTx, null, 2)}`)
     edgeTransaction.signedTx = signedTx
+    // edgeTransaction.signedTx = JSON.stringify(signedTx, null, 2)
     return edgeTransaction
   }
 

--- a/src/tron/tronEngine.js
+++ b/src/tron/tronEngine.js
@@ -1,0 +1,523 @@
+import { bns } from 'biggystring'
+import { InsufficientFundsError } from 'edge-core-js/types'
+import TronWeb from 'tronweb'
+
+import { CurrencyEngine } from '../common/engine.js'
+import {
+  asyncWaterfall,
+  getDenomInfo,
+  shuffleArray,
+  validateObject
+} from '../common/utils.js'
+import { currencyInfo } from './tronInfo.js'
+import { TronPlugin } from './tronPlugin.js'
+import {
+  TronApiAccountBalance,
+  TronApiGetTransactions,
+  TronApiNodeInfo,
+  TxInfoSchema
+} from './tronSchema.js'
+
+const tronWeb = new TronWeb({
+  fullHost: 'https://api.trongrid.io'
+})
+
+const PRIMARY_CURRENCY = currencyInfo.currencyCode
+const ACCOUNT_POLL_MILLISECONDS = 20000
+const BLOCKCHAIN_POLL_MILLISECONDS = 20000
+const TRANSACTION_POLL_MILLISECONDS = 10000 // was 3000
+const ADDRESS_QUERY_LOOKBACK_BLOCKS = 15 * 60 * 24 // ~ one day. 3-5 sec block time
+const NUM_TRANSACTIONS_TO_QUERY = 200
+const TIMESTAMP_BEFORE_TRX_LAUNCH = 1529920269000 // 2019-04-01, TRX launched on 6/25/2018 09:51:09
+const TRANSACTION_QUERY_TIME_WINDOW = 1000 * 60 * 60 * 24 * 3 * 28 // 3 months
+// const NATIVE_UNIT_MULTIPLIER = '1000000'
+
+export class TronEngine extends CurrencyEngine {
+  constructor (
+    currencyPlugin,
+    walletInfo,
+    initOptions,
+    opts, // EdgeCurrencyEngineOptions
+    fetchCors
+  ) {
+    super(currencyPlugin, walletInfo, opts, fetchCors)
+    this.fetchCors = fetchCors
+  }
+
+  async fetchGet (url) {
+    const options = { method: 'GET' }
+    const response = await this.fetchCors(url, options)
+    if (!response.ok) {
+      throw new Error(
+        `The server returned error code ${response.status} for ${url}`
+      )
+    }
+    return response.json()
+  }
+
+  async fetchPost (url, params = {}) {
+    const options = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(params)
+    }
+    const response = await this.fetchCors(url, options)
+    if (!response.ok) {
+      this.log(`The server returned error code ${response.status} for ${url}`)
+      throw new Error(
+        `6 The server returned error code ${response.status} for ${url}`
+      )
+    }
+    return response.json()
+  }
+
+  async checkBlockchainInnerLoop () {
+    try {
+      const jsonObj = await this.multicastServers(
+        'trx_blockNumber',
+        '/wallet/getnowblock'
+      )
+      const valid = validateObject(jsonObj, TronApiNodeInfo, this.log)
+      if (valid) {
+        const blockHeight = jsonObj.block_header.raw_data.number // timestamp
+        // this.log(`Got block height ${blockHeight}`)
+        if (this.walletLocalData.blockHeight !== blockHeight) {
+          this.checkDroppedTransactionsThrottled()
+          this.walletLocalData.blockHeight = blockHeight // Convert to decimal
+          this.walletLocalDataDirty = true
+          this.currencyEngineCallbacks.onBlockHeightChanged(
+            this.walletLocalData.blockHeight
+          )
+        }
+      }
+    } catch (err) {
+      this.log('Error fetching height: ' + err)
+    }
+  }
+
+  updateBalance (tk, balance) {
+    if (typeof this.walletLocalData.totalBalances[tk] === 'undefined') {
+      this.walletLocalData.totalBalances[tk] = '0'
+    }
+    if (!bns.eq(balance, this.walletLocalData.totalBalances[tk])) {
+      this.walletLocalData.totalBalances[tk] = balance
+      this.log(tk + ': token Address balance: ' + balance)
+      this.currencyEngineCallbacks.onBalanceChanged(tk, balance)
+    }
+    this.tokenCheckBalanceStatus[tk] = 1
+    this.updateOnAddressesChecked()
+  }
+
+  async checkAccountInnerLoop () {
+    const address = this.walletLocalData.publicKey
+    const url = '/v1/accounts/'
+    const finalUrl = `${url}${tronWeb.address.toHex(address)}`
+    try {
+      const jsonObj = await this.multicastServers('trx_getBalance', finalUrl)
+      const valid = validateObject(jsonObj, TronApiAccountBalance, this.log)
+      // if (valid) {
+      //   this.updateBalance('TRX', jsonObj.data[0].balance.toString())
+      //   for (const tk of this.walletLocalData.enabledTokens) {
+      //     for (const balance of jsonObj.data[0].asset) {
+      //       if (balance.key === tk) {
+      //         const denom = getDenomInfo(this.currencyInfo, tk)
+      //         if (!denom) {
+      //           this.log(`Received unsupported currencyCode: ${tk}`)
+      //           break
+      //         }
+      //         const nativeAmount = bns.mul(balance.value, denom.multiplier)
+      //         this.updateBalance(tk, nativeAmount)
+      //       }
+      //     }
+      //   }
+      // }
+      if (valid) {
+        this.updateBalance('TRX', jsonObj.data[0].balance.toString())
+      } else {
+        this.log(
+          'checkAccountInnerLoop: Error getting balance. Received: ',
+          jsonObj.data
+        )
+      }
+    } catch (e) {
+      this.log('Error checking TRX address balance: ', e)
+    }
+  }
+
+  processTronApiTransaction (tx, currencyCode) {
+    const publicKey = this.walletLocalData.publicKey.toLowerCase()
+    let netNativeAmount // Amount received into wallet
+    const ourReceiveAddresses = []
+    const nativeNetworkFee = '0'
+    const {
+      amount,
+      owner_address,
+      to_address
+    } = tx.raw_data.contract[0].parameter.value
+    const nativeValue = amount.toString()
+    const fromAddr = tronWeb.address.fromHex(owner_address).toLowerCase()
+    const toAddr = tronWeb.address.fromHex(to_address).toLowerCase()
+
+    // isSpend Tx
+    if (fromAddr === publicKey) {
+      // if it's a send to one's self
+      if (tx.fromAddr === toAddr) {
+        // Spend to self. netNativeAmount is just the fee
+        netNativeAmount = bns.mul(nativeNetworkFee, '-1')
+      } else {
+        // set amount to spending amount
+        netNativeAmount = bns.mul(nativeValue, '-1')
+      }
+    } else {
+      // Receive transaction
+      netNativeAmount = bns.add('0', nativeValue)
+      // ourReceiveAddresses.push(this.walletLocalData.publicKey.toLowerCase())
+    }
+
+    const otherParams = {}
+
+    let blockHeight = tx.blockNumber
+    if (blockHeight < 0) blockHeight = 0
+    const unixTimestamp = new Date(tx.block_timestamp)
+    const edgeTransaction = {
+      txid: tx.txID,
+      date: unixTimestamp.getTime(),
+      currencyCode,
+      blockHeight,
+      nativeAmount: netNativeAmount,
+      networkFee: nativeNetworkFee,
+      ourReceiveAddresses, // blank if you sent money otherwise array of addresses that are yours in this transaction
+      signedTx: '',
+      otherParams
+    }
+
+    this.addTransaction(currencyCode, edgeTransaction)
+  }
+
+  async checkTransactionsFetch (startTime, currencyCode) {
+    const publicKey = this.walletLocalData.publicKey
+    let checkAddressSuccess = true
+    let start = startTime
+    let end = 0
+    const now = Date.now()
+    try {
+      // this.log('checkTransactionsFetch start of while loop')
+      while (end !== now && checkAddressSuccess) {
+        // loop from startTime to current time by 3-month increments
+        end = start + TRANSACTION_QUERY_TIME_WINDOW
+        if (end > now) end = now
+        // this.log(
+        //   'checkTransactionsFetch outer loop: ',
+        //   start,
+        //   ' and end: ',
+        //   end
+        // )
+        for (let offset = 0; ; offset += NUM_TRANSACTIONS_TO_QUERY) {
+          // this.log('checkTransactionsFetch inner loop, offset is: ', offset)
+          const url1 = '/v1/accounts/' + tronWeb.address.toHex(publicKey)
+          const url2 = `${url1}/transactions?only_confirmed=true&limit=${NUM_TRANSACTIONS_TO_QUERY}`
+          const finalUrl = `${url2}&min_timestamp=${start}&max_timestamp=${end}&search_internal=false`
+          const transactionsResults = await this.multicastServers(
+            'trx_getTransactions',
+            finalUrl
+          )
+          const valid = validateObject(
+            transactionsResults,
+            TronApiGetTransactions
+          )
+          if (valid) {
+            for (const transaction of transactionsResults.data) {
+              if (
+                transaction.raw_data.contract[0].type !== 'TransferContract'
+              ) {
+                this.log('is NOT TransferContract')
+                break
+              }
+
+              // getting blocknumber
+              const jsonObj = await this.multicastServers(
+                'trx_txBlockNumber',
+                '/wallet/gettransactioninfobyid',
+                { value: transaction.txID }
+              )
+
+              const valid = validateObject(jsonObj, TxInfoSchema)
+              if (valid) {
+                transaction.blockNumber = jsonObj.blockNumber
+              }
+
+              this.processTronApiTransaction(transaction, currencyCode)
+            }
+            if (transactionsResults.data.length < NUM_TRANSACTIONS_TO_QUERY) {
+              break
+            }
+          } else {
+            checkAddressSuccess = false
+            this.log('checkTransactionsFetch inner loop invalid query results.')
+            break
+          }
+        }
+        start = end
+      }
+    } catch (e) {
+      this.log(
+        `Error checkTransactionsFetch ${currencyCode}: ${
+          this.walletLocalData.publicKey
+        }`,
+        e
+      )
+    }
+
+    if (checkAddressSuccess) {
+      this.tokenCheckTransactionsStatus[currencyCode] = 1
+      // this.updateOnAddressesChecked()
+      return true
+    } else {
+      return false
+    }
+  }
+
+  async checkTransactionsInnerLoop () {
+    const blockHeight = Date.now()
+    let startTime: number = TIMESTAMP_BEFORE_TRX_LAUNCH
+    const promiseArray = []
+
+    if (
+      this.walletLocalData.lastAddressQueryHeight >
+      ADDRESS_QUERY_LOOKBACK_BLOCKS
+    ) {
+      // Only query for transactions as far back as ADDRESS_QUERY_LOOKBACK_BLOCKS from the last time we queried transactions
+      startTime =
+        this.walletLocalData.lastAddressQueryHeight -
+        ADDRESS_QUERY_LOOKBACK_BLOCKS
+    }
+
+    for (const currencyCode of this.walletLocalData.enabledTokens) {
+      this.log('enabled Token: ', currencyCode)
+      promiseArray.push(this.checkTransactionsFetch(startTime, currencyCode))
+    }
+
+    let resultArray = []
+    try {
+      resultArray = await Promise.all(promiseArray)
+    } catch (e) {
+      this.log('Failed to query transactions')
+      this.log(e.name)
+      this.log(e.message)
+    }
+    let successCount = 0
+    for (const r of resultArray) {
+      if (r) successCount++
+    }
+    if (successCount === promiseArray.length) {
+      this.walletLocalData.lastAddressQueryHeight = blockHeight
+    }
+    if (this.transactionsChangedArray.length > 0) {
+      this.currencyEngineCallbacks.onTransactionsChanged(
+        this.transactionsChangedArray
+      )
+      this.transactionsChangedArray = []
+    }
+  }
+
+  async multicastServers (func, ...params) {
+    let out = { result: '', server: 'no server' }
+    let funcs
+
+    switch (func) {
+      case 'trx_txBlockNumber':
+      case 'trx_blockNumber':
+        funcs = this.currencyInfo.defaultSettings.otherSettings.tronApiServers.map(
+          server => async () => {
+            const result = await this.fetchPost(server + params[0], params[1])
+            if (typeof result !== 'object') {
+              const msg = `Invalid return value ${func} in ${server}`
+              this.log(msg)
+              throw new Error(msg)
+            }
+            return { server, result }
+          }
+        )
+        // Randomize array
+        funcs = shuffleArray(funcs)
+        out = await asyncWaterfall(funcs)
+        break
+
+      case 'trx_getBalance':
+      case 'trx_getTransactions':
+        funcs = this.currencyInfo.defaultSettings.otherSettings.tronApiServers.map(
+          server => async () => {
+            const result = await this.fetchGet(server + params[0])
+            if (typeof result !== 'object') {
+              const msg = `Invalid return value ${func} in ${server}`
+              this.log(msg)
+              throw new Error(msg)
+            }
+            return { server, result }
+          }
+        )
+        // Randomize array
+        funcs = shuffleArray(funcs)
+        out = await asyncWaterfall(funcs)
+        this.log(func, ': return value:', out.result)
+        break
+    }
+    this.log(`TRX multicastServers ${func} ${out.server} won`)
+
+    return out.result
+  }
+
+  // async clearBlockchainCache () {
+  //   await super.clearBlockchainCache()
+  //   this.otherData.nextNonce = '0'
+  //   this.otherData.unconfirmedNextNonce = '0'
+  // }
+
+  // // ****************************************************************************
+  // // Public methods
+  // // ****************************************************************************
+
+  async startEngine () {
+    this.engineOn = true
+    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS)
+    // this.addToLoop('checkUpdateNetworkFees', NETWORKFEES_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
+    super.startEngine()
+  }
+
+  async resyncBlockchain () {
+    await this.killEngine()
+    await this.clearBlockchainCache()
+    await this.startEngine()
+  }
+
+  async makeSpend (edgeSpendInfoIn) {
+    try {
+      this.log('makeSpend edgeSpendInfoIn: ', edgeSpendInfoIn)
+      const { edgeSpendInfo, currencyCode } = super.makeSpend(edgeSpendInfoIn)
+      this.log('edgeSpendInfo, currencyCode', edgeSpendInfo, currencyCode)
+      const networkFee = '0'
+      const nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
+      const balanceTrx = this.walletLocalData.totalBalances[
+        this.currencyInfo.currencyCode
+      ]
+
+      if (bns.gt(nativeAmount, balanceTrx)) {
+        throw new InsufficientFundsError()
+      }
+
+      // Tron can only have one output
+      if (edgeSpendInfo.spendTargets.length !== 1) {
+        throw new Error('Error: only one output allowed')
+      }
+
+      const spendTarget = edgeSpendInfo.spendTargets[0]
+      const publicAddress = spendTarget.publicAddress
+      // TODO: for tokens. otherParams is used for contract addresses etc
+      const data =
+        spendTarget.otherParams != null ? spendTarget.otherParams.data : void 0
+
+      let otherParams = {}
+
+      // if TRON
+      if (currencyCode === PRIMARY_CURRENCY) {
+        // builds tx, but does NOT send it
+        const trxParams = await tronWeb.transactionBuilder.sendTrx(
+          publicAddress,
+          nativeAmount,
+          this.walletLocalData.publicKey
+        )
+
+        otherParams = trxParams
+        // if Token
+      } else {
+        let contractAddress = ''
+        if (data) {
+          contractAddress = publicAddress
+        } else {
+          const tokenInfo = this.getTokenInfo(currencyCode)
+          if (!tokenInfo || typeof tokenInfo.contractAddress !== 'string') {
+            throw new Error(
+              'Error: Token not supported or invalid contract address'
+            )
+          }
+
+          contractAddress = tokenInfo.contractAddress
+        }
+
+        // for Tokens:
+        // builds tx, but does NOT send it
+        const trxParams = await tronWeb.transactionBuilder.sendToken(
+          publicAddress,
+          nativeAmount,
+          contractAddress,
+          this.walletLocalData.publicKey
+        )
+        otherParams = trxParams
+      }
+      const edgeNativeAmount = bns.mul(nativeAmount, '-1')
+
+      // **********************************
+      // Create the unsigned EdgeTransaction
+
+      const edgeTransaction = {
+        txid: '', // txid
+        date: 0, // date
+        currencyCode, // currencyCode
+        blockHeight: 0, // blockHeight
+        nativeAmount: edgeNativeAmount, // nativeAmount
+        networkFee, // networkFee, supposedly fixed
+        ourReceiveAddresses: [], // ourReceiveAddresses
+        signedTx: '', // signedTx
+        otherParams // otherParams
+      }
+
+      return edgeTransaction
+    } catch (e) {
+      this.log('makeSpend error: ', e)
+    }
+  }
+
+  async signTx (edgeTransaction) {
+    const privKey = this.walletInfo.keys.tronKey
+
+    const signedTx = await tronWeb.trx.sign(
+      edgeTransaction.otherParams,
+      privKey
+    )
+    // this.log(`SUCCESS TRX broadcastTx\n${JSON.stringify(signedTx, null, 2)}`)
+    edgeTransaction.signedTx = signedTx
+    return edgeTransaction
+  }
+
+  async broadcastTx (edgeTransaction) {
+    const trxSignedTransaction = edgeTransaction.signedTx
+    const response = await tronWeb.trx.sendRawTransaction(trxSignedTransaction)
+
+    if (typeof response.result === 'boolean' && response.result === true) {
+      // this.log(`SUCCESS broadcastTx\n${JSON.stringify(response)}`)
+      edgeTransaction.txid = response.transaction.txID
+    }
+    return edgeTransaction
+  }
+
+  getDisplayPrivateSeed () {
+    if (this.walletInfo.keys && this.walletInfo.keys.tronMnemonic) {
+      return this.walletInfo.keys.tronMnemonic
+    }
+    return this.walletInfo.keys.tronKey
+  }
+
+  getDisplayPublicSeed () {
+    if (this.walletInfo.keys && this.walletInfo.keys.publicKey) {
+      return this.walletInfo.keys.publicKey
+    }
+    return ''
+  }
+}
+
+export { CurrencyEngine }

--- a/src/tron/tronInfo.js
+++ b/src/tron/tronInfo.js
@@ -1,0 +1,36 @@
+export const imageServerUrl = 'https://developer.airbitz.co/content'
+
+const otherSettings = {
+  tronApiServers: ['https://api.trongrid.io'],
+  tronTestNetServers: ['https://api.shasta.trongrid.io']
+}
+
+const defaultSettings = {
+  otherSettings
+}
+
+export const currencyInfo = {
+  // Basic currency information:
+  currencyCode: 'TRX',
+  displayName: 'Tron',
+  pluginName: 'tron',
+  walletType: 'wallet:tron',
+
+  defaultSettings,
+
+  addressExplorer: 'https://tronscan.org/#/address/%s',
+  transactionExplorer: 'https://tronscan.org/#/transaction/%s',
+  blockExplorer: 'https://tronscan.org/#/block/%s',
+
+  denominations: [
+    // An array of Objects of the possible denominations for this currency
+    {
+      name: 'TRX',
+      multiplier: '1000000',
+      symbol: 'T'
+    }
+  ],
+  symbolImage: `${imageServerUrl}/tron-logo-solo-64.png`,
+  symbolImageDarkMono: `${imageServerUrl}/tron-logo-solo-64.png`,
+  metaTokens: []
+}

--- a/src/tron/tronInfo.js
+++ b/src/tron/tronInfo.js
@@ -1,15 +1,22 @@
+/* global */
+// @flow
+
+import type { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import type { TronSettings } from './tronTypes.js'
+
 export const imageServerUrl = 'https://developer.airbitz.co/content'
 
-const otherSettings = {
-  tronApiServers: ['https://api.trongrid.io'],
-  tronTestNetServers: ['https://api.shasta.trongrid.io']
+const otherSettings: TronSettings = {
+  tronApiServers: ['https://api.trongrid.io']
+  // tronApiServers: ['https://api.shasta.trongrid.io']
 }
 
-const defaultSettings = {
+const defaultSettings: any = {
   otherSettings
 }
 
-export const currencyInfo = {
+export const currencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'TRX',
   displayName: 'Tron',

--- a/src/tron/tronPlugin.js
+++ b/src/tron/tronPlugin.js
@@ -1,13 +1,8 @@
-/* global fetch */
 // @flow
 
-import { Buffer } from 'buffer'
 import { bns } from 'biggystring'
 import { entropyToMnemonic, mnemonicToSeed, validateMnemonic } from 'bip39'
-import EthereumUtil from 'ethereumjs-util'
-import ethWallet from 'ethereumjs-wallet'
-import hdkey from 'ethereumjs-wallet/hdkey'
-import TronWeb from 'tronweb'
+import { Buffer } from 'buffer'
 import {
   type EdgeCorePluginOptions,
   type EdgeCurrencyEngine,
@@ -19,6 +14,9 @@ import {
   type EdgeParsedUri,
   type EdgeWalletInfo
 } from 'edge-core-js/types'
+import EthereumUtil from 'ethereumjs-util'
+import hdkey from 'ethereumjs-wallet/hdkey'
+import TronWeb from 'tronweb'
 
 import { CurrencyPlugin } from '../common/plugin.js'
 import { getDenomInfo } from '../common/utils.js'
@@ -33,7 +31,7 @@ export class TronPlugin extends CurrencyPlugin {
     super(io, 'tron', currencyInfo)
   }
 
-  async importPrivateKey(userInput: string): Promise<Object> {
+  async importPrivateKey (userInput: string): Promise<Object> {
     if (/^(0x)?[0-9a-fA-F]{64}$/.test(userInput)) {
       // It looks like a private key, so validate the hex:
       const tronKeyBuffer = Buffer.from(userInput.replace(/^0x/, ''), 'hex')
@@ -76,12 +74,12 @@ export class TronPlugin extends CurrencyPlugin {
   }
 
   async _mnemonicToTronKey (mnemonic: string): Promise<string> {
-      const myMnemonicToSeed = mnemonicToSeed(mnemonic).toString('hex')
-      const hdwallet = hdkey.fromMasterSeed(myMnemonicToSeed)
-      const walletHDpath = "m/44'/195'/0'/0" // 195 = Tron
-      const wallet = hdwallet.derivePath(walletHDpath).getWallet()
-      const tronKey = wallet.getPrivateKeyString().replace('0x', '')
-      return tronKey
+    const myMnemonicToSeed = mnemonicToSeed(mnemonic).toString('hex')
+    const hdwallet = hdkey.fromMasterSeed(myMnemonicToSeed)
+    const walletHDpath = "m/44'/195'/0'/0" // 195 = Tron
+    const wallet = hdwallet.derivePath(walletHDpath).getWallet()
+    const tronKey = wallet.getPrivateKeyString().replace('0x', '')
+    return tronKey
   }
 
   async derivePublicKey (walletInfo: EdgeWalletInfo): Promise<Object> {
@@ -151,7 +149,7 @@ export class TronPlugin extends CurrencyPlugin {
 export function makeTronPlugin (
   opts: EdgeCorePluginOptions
 ): EdgeCurrencyPlugin {
-  const { io, initOptions } = opts
+  const { io } = opts
   const fetchCors = getFetchCors(opts)
 
   let toolsPromise: Promise<TronPlugin>
@@ -166,13 +164,7 @@ export function makeTronPlugin (
     opts: EdgeCurrencyEngineOptions
   ): Promise<EdgeCurrencyEngine> {
     const tools = await makeCurrencyTools()
-    const currencyEngine = new TronEngine(
-      tools,
-      walletInfo,
-      initOptions,
-      opts,
-      fetchCors
-    )
+    const currencyEngine = new TronEngine(tools, walletInfo, opts, fetchCors)
 
     // Do any async initialization necessary for the engine
     await currencyEngine.loadEngine(tools, walletInfo, opts)
@@ -180,6 +172,7 @@ export function makeTronPlugin (
     // This is just to make sure otherData is Flow type checked
     currencyEngine.otherData = currencyEngine.walletLocalData.otherData
 
+    // $FlowFixMe not undefined
     const out: EdgeCurrencyEngine = currencyEngine
 
     return out

--- a/src/tron/tronPlugin.js
+++ b/src/tron/tronPlugin.js
@@ -1,0 +1,148 @@
+import { Buffer } from 'buffer'
+import { bns } from 'biggystring'
+import { entropyToMnemonic } from 'bip39'
+import ethWallet from 'ethereumjs-wallet'
+import TronWeb from 'tronweb'
+
+import { CurrencyPlugin } from '../common/plugin.js'
+import { getDenomInfo } from '../common/utils.js'
+import { getFetchCors } from '../react-native-io.js'
+import { TronEngine } from './tronEngine.js'
+import { currencyInfo } from './tronInfo.js'
+
+const tronWeb = new TronWeb({ fullHost: 'https://api.trongrid.io' })
+
+export class TronPlugin extends CurrencyPlugin {
+  constructor (io) {
+    super(io, 'tron', currencyInfo)
+  }
+
+  async importPrivateKey (passPhrase: string): Promise<Object> {
+    const strippedPassPhrase = passPhrase.replace('0x', '').replace(/ /g, '')
+    const buffer = Buffer.from(strippedPassPhrase, 'hex')
+    if (buffer.length !== 32) throw new Error('Private key wrong length')
+    const tronKey = buffer.toString('hex')
+    const wallet = ethWallet.fromPrivateKey(buffer)
+    wallet.getAddressString()
+    return {
+      tronMnemonic: passPhrase,
+      tronKey
+    }
+  }
+
+  async createPrivateKey (walletType) {
+    const type = walletType.replace('wallet:', '')
+
+    if (type === 'tron') {
+      const { io } = this
+      const cryptoObj = {
+        randomBytes: size => {
+          const array = io.random(size)
+          return Buffer.from(array)
+        }
+      }
+      ethWallet.overrideCrypto(cryptoObj)
+
+      const wallet = ethWallet.generate(false)
+      const tronKey = wallet.getPrivateKeyString().replace('0x', '')
+      return { tronKey }
+    } else {
+      throw new Error('InvalidWalletType')
+    }
+  }
+
+  async derivePublicKey (walletInfo) {
+    const type = walletInfo.type.replace('wallet:', '')
+    if (type === 'tron') {
+      const publicKey = tronWeb.address.fromPrivateKey(walletInfo.keys.tronKey)
+      return { publicKey }
+    } else {
+      throw new Error('InvalidWalletType')
+    }
+  }
+
+  async parseUri (uri, currencyCode, customTokens) {
+    const networks = { tron: true }
+
+    const { parsedUri, edgeParsedUri } = this.parseUriCommon(
+      currencyInfo,
+      uri,
+      networks,
+      currencyCode || 'TRX',
+      customTokens
+    )
+    let address = ''
+    if (edgeParsedUri.publicAddress) {
+      address = edgeParsedUri.publicAddress
+    }
+
+    const valid = tronWeb.isAddress(address || '')
+    if (!valid) {
+      throw new Error('InvalidPublicAddressError')
+    }
+
+    edgeParsedUri.uniqueIdentifier = parsedUri.query.memo || undefined
+    return edgeParsedUri
+  }
+
+  async encodeUri (obj, customTokens) {
+    const { publicAddress, nativeAmount, currencyCode } = obj
+    const valid = tronWeb.isAddress(publicAddress || '')
+    if (!valid) {
+      throw new Error('InvalidPublicAddressError')
+    }
+    let amount
+    if (typeof nativeAmount === 'string') {
+      const denom = getDenomInfo(
+        currencyInfo,
+        currencyCode || 'TRX',
+        customTokens
+      )
+      if (!denom) {
+        throw new Error('InternalErrorInvalidCurrencyCode')
+      }
+      amount = bns.div(nativeAmount, denom.multiplier, 18)
+    }
+    const encodedUri = this.encodeUriCommon(obj, 'tron', amount)
+    return encodedUri
+  }
+}
+
+export function makeTronPlugin (opts) {
+  const { io, initOptions } = opts
+  const fetchCors = getFetchCors(opts)
+
+  let toolsPromise
+  function makeCurrencyTools () {
+    if (toolsPromise != null) return toolsPromise
+    toolsPromise = Promise.resolve(new TronPlugin(io, getFetchCors(opts)))
+    return toolsPromise
+  }
+
+  async function makeCurrencyEngine (walletInfo, opts) {
+    const tools = await makeCurrencyTools()
+    const currencyEngine = new TronEngine(
+      tools,
+      walletInfo,
+      initOptions,
+      opts,
+      fetchCors
+    )
+
+    // Do any async initialization necessary for the engine
+    await currencyEngine.loadEngine(tools, walletInfo, opts)
+
+    // This is just to make sure otherData is Flow type checked
+    currencyEngine.otherData = currencyEngine.walletLocalData.otherData
+
+    const out = currencyEngine
+
+    return out
+  }
+
+  return {
+    currencyInfo,
+    makeCurrencyEngine,
+    makeCurrencyTools
+  }
+}

--- a/src/tron/tronSchema.js
+++ b/src/tron/tronSchema.js
@@ -104,33 +104,21 @@ export const NetworkFeesSchema = {
   items: {
     type: 'object',
     properties: {
-      getMaintenanceTimeInterval: { type: 'number' },
-      getAccountUpgradeCost: { type: 'number' },
-      getCreateAccountFee: { type: 'number' },
-      getTransactionFee: { type: 'number' },
-      getAssetIssueFee: { type: 'number' },
-      getWitnessPayPerBlock: { type: 'number' },
-      getWitnessStandbyAllowance: { type: 'number' },
-      getCreateNewAccountFeeInSystemContract: { type: 'number' },
-      getCreateNewAccountBandwidthRate: { type: 'number' },
-      getAllowCreationOfContracts: { type: 'number' },
-      getRemoveThePowerOfTheGr: { type: 'number' },
-      getEnergyFee: { type: 'number' },
-      getExchangeCreateFee: { type: 'number' },
-      getMaxCpuTimeOfOneTx: { type: 'number' },
-      getAllowUpdateAccountName: { type: 'number' },
-      getAllowSameTokenName: { type: 'number' },
-      getAllowDelegateResource: { type: 'number' },
-      getTotalEnergyLimit: { type: 'number' },
-      getAllowTvmTransferTrc10: { type: 'number' },
-      getTotalEnergyCurrentLimit: { type: 'number' },
-      getAllowMultiSign: { type: 'number' },
-      getAllowAdaptiveEnergy: { type: 'number' },
-      getTotalEnergyTargetLimit: { type: 'number' },
-      getTotalEnergyAverageUsage: { type: 'number' },
-      getUpdateAccountPermissionFee: { type: 'number' },
-      getMultiSignFee: { type: 'number' }
+      key: { type: 'string' },
+      value: { type: 'number' }
     },
-    required: ['getCreateAccountFee', 'getTransactionFee']
+    required: ['key']
   }
+}
+
+export const TronAccountResources = {
+  type: 'object',
+  properties: {
+    TotalEnergyLimit: { type: 'number' },
+    TotalEnergyWeight: { type: 'number' },
+    TotalNetLimit: { type: 'number' },
+    TotalNetWeight: { type: 'number' },
+    freeNetLimit: { type: 'number' }
+  },
+  required: ['freeNetLimit']
 }

--- a/src/tron/tronSchema.js
+++ b/src/tron/tronSchema.js
@@ -16,7 +16,8 @@ export const TronApiNodeInfo = {
         },
         required: ['number'],
         witness_signature: { type: 'string' }
-      }
+      },
+      required: ['raw_data']
     }
   },
   required: ['blockID', 'block_header']

--- a/src/tron/tronSchema.js
+++ b/src/tron/tronSchema.js
@@ -1,0 +1,99 @@
+export const TronApiNodeInfo = {
+  type: 'object',
+  properties: {
+    blockID: { type: 'string' },
+    block_header: {
+      type: 'object',
+      properties: {
+        raw_data: {
+          type: 'object',
+          number: { type: 'number' },
+          txTrieRoot: { type: 'string' },
+          witness_address: { type: 'string' },
+          parentHash: { type: 'string' },
+          version: { type: 'number' },
+          timestamp: { type: 'number' }
+        },
+        required: ['number'],
+        witness_signature: { type: 'string' }
+      }
+    }
+  },
+  required: ['blockID', 'block_header']
+}
+
+export const TronApiAccountBalance = {
+  type: 'object',
+  properties: {
+    data: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          balance: { type: 'number' },
+          free_net_usage: { type: 'number' },
+          trc20: { type: 'array' }
+        },
+        required: ['balance']
+      }
+    }
+  }
+}
+
+export const TronApiGetTransactions = {
+  type: 'object',
+  properties: {
+    data: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          raw_data: {
+            type: 'object',
+            properties: {
+              contract: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  parameter: {
+                    type: 'object',
+                    properties: {
+                      value: {
+                        type: 'object',
+                        properties: {
+                          amount: { type: 'number' },
+                          owner_address: { type: 'string' },
+                          to_address: { type: 'string' }
+                        },
+                        required: ['amount', 'owner_address', 'to_address']
+                      }
+                    },
+                    required: ['value']
+                  }
+                  // type: { type: 'string' }
+                }
+                // required: ['parameter']
+              }
+            },
+            required: ['contract']
+          }
+        }
+      }
+    },
+    required: ['raw_data']
+  },
+  required: ['data']
+}
+
+export const TxInfoSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    fee: { type: 'number' },
+    blockNumber: { type: 'number' },
+    blocktimeStamp: { type: 'number' },
+    contractResult: { type: 'array' },
+    receipt: { type: 'object' }
+  },
+  required: ['blockNumber']
+}

--- a/src/tron/tronSchema.js
+++ b/src/tron/tronSchema.js
@@ -98,3 +98,39 @@ export const TxInfoSchema = {
   },
   required: ['blockNumber']
 }
+
+export const NetworkFeesSchema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      getMaintenanceTimeInterval: { type: 'number' },
+      getAccountUpgradeCost: { type: 'number' },
+      getCreateAccountFee: { type: 'number' },
+      getTransactionFee: { type: 'number' },
+      getAssetIssueFee: { type: 'number' },
+      getWitnessPayPerBlock: { type: 'number' },
+      getWitnessStandbyAllowance: { type: 'number' },
+      getCreateNewAccountFeeInSystemContract: { type: 'number' },
+      getCreateNewAccountBandwidthRate: { type: 'number' },
+      getAllowCreationOfContracts: { type: 'number' },
+      getRemoveThePowerOfTheGr: { type: 'number' },
+      getEnergyFee: { type: 'number' },
+      getExchangeCreateFee: { type: 'number' },
+      getMaxCpuTimeOfOneTx: { type: 'number' },
+      getAllowUpdateAccountName: { type: 'number' },
+      getAllowSameTokenName: { type: 'number' },
+      getAllowDelegateResource: { type: 'number' },
+      getTotalEnergyLimit: { type: 'number' },
+      getAllowTvmTransferTrc10: { type: 'number' },
+      getTotalEnergyCurrentLimit: { type: 'number' },
+      getAllowMultiSign: { type: 'number' },
+      getAllowAdaptiveEnergy: { type: 'number' },
+      getTotalEnergyTargetLimit: { type: 'number' },
+      getTotalEnergyAverageUsage: { type: 'number' },
+      getUpdateAccountPermissionFee: { type: 'number' },
+      getMultiSignFee: { type: 'number' }
+    },
+    required: ['getCreateAccountFee', 'getTransactionFee']
+  }
+}

--- a/src/tron/tronTypes.js
+++ b/src/tron/tronTypes.js
@@ -1,0 +1,21 @@
+// @flow
+
+export type TronSettings = {
+  tronApiServers: Array<string>,
+}
+
+export type TronApiTransaction = {
+  amount: number,
+  owner_address: string,
+  to_address: string,
+  blockNumber: number,
+  block_timestamp: number,
+  txID: string
+}
+
+export type TronTxOtherParams = {
+  visible: boolean,
+  txID: string,
+  raw_data: Object,
+  raw_data_hex: string
+}

--- a/test/plugin/fixtures.js
+++ b/test/plugin/fixtures.js
@@ -1,5 +1,147 @@
 export default [
   {
+    pluginName: 'tron',
+    WALLET_TYPE: 'wallet:tron',
+    'Test Currency code': 'TRX',
+    key: [
+      39,
+      190,
+      34,
+      129,
+      208,
+      32,
+      145,
+      88,
+      191,
+      217,
+      226,
+      98,
+      183,
+      16,
+      52,
+      150,
+      52,
+      53,
+      31,
+      137,
+      164,
+      40,
+      236,
+      146,
+      128,
+      107,
+      129,
+      59,
+      192,
+      240,
+      40,
+      238
+    ],
+    xpub: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+    key_length: 64,
+    'invalid key name': {
+      type: 'wallet:tron',
+      keys: { tronKeyz: '12345678abcd' }
+    },
+    'invalid wallet type': {
+      type: 'wallet:tronz',
+      keys: { tronKey: '12345678abcd' }
+    },
+    parseUri: {
+      'address only': [
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+      ],
+      'invalid address': [
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE1',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2B',
+        'GMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+      ],
+      'uri address': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+      ],
+      'uri address with amount': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=12.34567',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        '12345670',
+        'TRX'
+      ],
+      'uri address with unique identifier': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?memo=1234567',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        'TRX',
+        '1234567'
+      ],
+      'uri address with amount & label': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=12.34567&label=Johnny%20Tron',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        '12345670',
+        'TRX',
+        'Johnny Tron'
+      ],
+      'uri address with amount, label & message': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=12.34567&label=Johnny%20Tron&message=Hellow%20Tron%20World',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        '12345670',
+        'TRX',
+        'Johnny Tron',
+        'Hello Tron World'
+      ],
+      'uri address with unsupported param': [
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=12.34567&unsupported=I%20am%20unsupported',
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+        '12345670',
+        'TRX'
+      ]
+    },
+    encodeUri: {
+      'address only': [
+        {
+          publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+        },
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+      ],
+      'weird address': [
+        {
+          publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+        },
+        'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE'
+      ],
+      'invalid address': [
+        { publicAddress: 'BGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE' },
+        { publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2B' },
+        { publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BEw' }
+      ],
+      'address & amount': [
+        {
+          publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+          nativeAmount: '12345678000000'
+        },
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=12345678'
+      ],
+      'address, amount, and label': [
+        {
+          publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+          nativeAmount: '12300',
+          currencyCode: 'TRX',
+          label: 'Johnny Tron'
+        },
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=0.0123&label=Johnny%20Tron'
+      ],
+      'address, amount, label, & message': [
+        {
+          publicAddress: 'TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE',
+          nativeAmount: '12300',
+          currencyCode: 'TRX',
+          label: 'Johnny Tron',
+          message: 'Hello World, I miss you !'
+        },
+        'tron:TGMgNz9gEhwXEXZ3to5VdZxEKwkDD3R2BE?amount=0.0123&label=Johnny%20Tron&message=Hello%20World,%20I%20miss%20you%20!'
+      ]
+    }
+  },
+  {
     pluginName: 'binance',
     WALLET_TYPE: 'wallet:binance',
     'Test Currency code': 'BNB',


### PR DESCRIPTION
Notes to the updated PR:

The biggest change are the transaction fees. Every Tron user has a daily amount of free transactions. These are pulled using `trx_getAccountResource`. As long as the users `resources.freeNetLimit` is higher than `268`, the transaction is for free.

In case the account, the user sends tokens to is not yet activated, an activation fee of 0.1 TRX will be added. See more details below.

The costs for account activation and transaction per byte are pulled from the network using `async checkUpdateNetworkFees`. It’s unit is SUN (1 SUN = 0.000001 TRX) and are converted to TRX using `tronWeb.fromSun(myvalue)`. 

Acitivation fee for not activated receiving accounts: 100000 SUN

Transaction cost per byte: 10 SUN

For a tron transfer you need to pay for 268 bytes (`raw_data_hex.length`)

These base values won’t be changed anytime soon.

From the docs:

"The TRON network grants every account a free pool of Bandwidth Points for free transactions every 24 hours. To engage in transactions more frequently requires freezing TRX for additional bandwidth points, or paying the fee in TRX.

There are 5000 bandwidth points for free per account per day. When an account hasn’t frozen any balance, or when its bandwidth points have run out, complimentary bandwidth points can be used”

https://developers.tron.network/docs/bandwith

---

In case you want to start testing on shasta test net with free money, prepend 'shasta' to the link in tronEngine.js, tronPlugin.js and tronInfo.js

const tronWeb = new TronWeb({
  fullHost: 'https://api.trongrid.io'
})

--> api.shasta.trongrid.io

free shasta money: https://www.trongrid.io/shasta

Tron Metamask Alternative: https://github.com/TronLink/tronlink-extension