### PR TITLE
RBF support for ETH, RSK, and ETH tokens

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -322,6 +322,35 @@ export class EthereumEngine extends CurrencyEngine {
   async makeSpend(edgeSpendInfoIn: EdgeSpendInfo) {
     const { edgeSpendInfo, currencyCode } = super.makeSpend(edgeSpendInfoIn)
 
+    /**
+    For RBF transactions, get the gas price and limit (fees) of the existing 
+    transaction as well as the current nonce. The fees and the nonce will be 
+    used instead of the calculated equivalents.
+    */
+    let rbfGasPrice: string
+    let rbfGasLimit: string
+    let rbfNonce: string
+    const rbfTxid =
+      edgeSpendInfo.rbfTxid && normalizeAddress(edgeSpendInfo.rbfTxid)
+    if (rbfTxid) {
+      const rbfTxIndex = this.findTransaction(currencyCode, rbfTxid)
+
+      if (rbfTxIndex > -1) {
+        const rbfTrx = this.transactionList[currencyCode][rbfTxIndex]
+
+        if (rbfTrx.otherParams) {
+          const { gasPrice, gas, nonceUsed } = rbfTrx.otherParams
+          rbfGasPrice = bns.mul(gasPrice, '2')
+          rbfGasLimit = gas
+          rbfNonce = nonceUsed
+        }
+      }
+
+      if (!rbfGasPrice || !rbfGasLimit || !rbfNonce) {
+        throw new Error('Missing data to complete RBF transaction.')
+      }
+    }
+
     // Ethereum can only have one output
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
@@ -338,13 +367,25 @@ export class EthereumEngine extends CurrencyEngine {
 
     let otherParams: Object = {}
 
-    const miningFees = calcMiningFee(
-      edgeSpendInfo,
-      this.walletLocalData.otherData.networkFees,
-      this.currencyInfo
-    )
-    const { gasPrice, useDefaults } = miningFees
-    let { gasLimit } = miningFees
+    let gasPrice: string
+    let gasLimit: string
+    let useDefaults: boolean = false
+
+    // Use RBF gas price and gas limit when present, otherwise, calculate mining fees
+    if (rbfGasPrice && rbfGasLimit) {
+      gasPrice = rbfGasPrice
+      gasLimit = rbfGasLimit
+    } else {
+      const miningFees = calcMiningFee(
+        edgeSpendInfo,
+        this.walletLocalData.otherData.networkFees,
+        this.currencyInfo
+      )
+      gasPrice = miningFees.gasPrice
+      gasLimit = miningFees.gasLimit
+      useDefaults = miningFees.useDefaults
+    }
+
     const defaultGasLimit = gasLimit
     let nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
 
@@ -360,6 +401,7 @@ export class EthereumEngine extends CurrencyEngine {
         cumulativeGasUsed: '0',
         errorVal: 0,
         tokenRecipientAddress: null,
+        nonceArg: rbfNonce,
         data: data
       }
       otherParams = ethParams
@@ -388,6 +430,7 @@ export class EthereumEngine extends CurrencyEngine {
         cumulativeGasUsed: '0',
         errorVal: 0,
         tokenRecipientAddress: publicAddress,
+        nonceArg: rbfNonce,
         data
       }
       otherParams = ethParams
@@ -540,13 +583,17 @@ export class EthereumEngine extends CurrencyEngine {
     } else {
       nativeAmountHex = bns.mul('-1', edgeTransaction.nativeAmount, 16)
     }
-    const nonceArg = otherParams.nonceArg
-    let nonceHex = nonceArg && toHex(nonceArg)
-    if (!nonceHex) {
+
+    // Nonce:
+
+    const nonceArg: string = otherParams.nonceArg
+    let nonce: string = nonceArg
+    if (!nonce) {
       // Use an unconfirmed nonce if
       // 1. We have unconfirmed spending txs in the transaction list
       // 2. It is greater than the confirmed nonce
       // 3. Is no more than 5 higher than confirmed nonce
+      // Othewise, use the next nonce
       if (
         this.walletLocalData.numUnconfirmedSpendTxs &&
         bns.gt(
@@ -559,7 +606,7 @@ export class EthereumEngine extends CurrencyEngine {
           this.walletLocalData.otherData.nextNonce
         )
         if (bns.lte(diff, '5')) {
-          nonceHex = toHex(this.walletLocalData.otherData.unconfirmedNextNonce)
+          nonce = this.walletLocalData.otherData.unconfirmedNextNonce
           this.walletLocalData.otherData.unconfirmedNextNonce = bns.add(
             this.walletLocalData.otherData.unconfirmedNextNonce,
             '1'
@@ -570,15 +617,18 @@ export class EthereumEngine extends CurrencyEngine {
           e.name = 'ErrorExcessivePendingSpends'
           throw e
         }
+      } else {
+        nonce = this.walletLocalData.otherData.nextNonce
+        this.walletLocalData.otherData.unconfirmedNextNonce = bns.add(
+          this.walletLocalData.otherData.nextNonce,
+          '1'
+        )
       }
     }
-    if (!nonceHex) {
-      nonceHex = toHex(this.walletLocalData.otherData.nextNonce)
-      this.walletLocalData.otherData.unconfirmedNextNonce = bns.add(
-        this.walletLocalData.otherData.nextNonce,
-        '1'
-      )
-    }
+    // Convert nonce to hex for tsParams
+    const nonceHex = toHex(nonce)
+
+    // Data:
 
     let data
     if (otherParams.data != null) {
@@ -596,6 +646,8 @@ export class EthereumEngine extends CurrencyEngine {
       data = '0x' + Buffer.from(dataArray).toString('hex')
       nativeAmountHex = '0x00'
     }
+
+    // Tx Parameters:
 
     const txParams = {
       nonce: nonceHex,
@@ -623,6 +675,9 @@ export class EthereumEngine extends CurrencyEngine {
     edgeTransaction.signedTx = bufToHex(tx.serialize())
     edgeTransaction.txid = bufToHex(tx.hash())
     edgeTransaction.date = Date.now() / 1000
+    if (edgeTransaction.otherParams) {
+      edgeTransaction.otherParams.nonceUsed = nonce
+    }
 
     return edgeTransaction
   }

--- a/src/ethereum/ethTypes.js
+++ b/src/ethereum/ethTypes.js
@@ -142,6 +142,7 @@ export type EthereumTxOtherParams = {
   errorVal: number,
   tokenRecipientAddress: string | null,
   nonceUsed?: string,
+  rbfTxid?: string,
   data?: string | null
 }
 

--- a/src/ethereum/ethTypes.js
+++ b/src/ethereum/ethTypes.js
@@ -141,6 +141,7 @@ export type EthereumTxOtherParams = {
   cumulativeGasUsed?: string,
   errorVal: number,
   tokenRecipientAddress: string | null,
+  nonceUsed?: string,
   data?: string | null
 }
 


### PR DESCRIPTION
* Modifies `ethEngine.js`
* Adds support for new `rbfTxid` field in `EdgeSpendInfo` in `makeSpend`
* Adds new `nonceUsed` for `EthereumTxOtherParams`
* `makeSpend` uses replaced transaction's fee and nonce
* Saves `nonceUsed` in the `otherParams` field for an ETH `EdgeTransaction`