### PR TITLE
Overestimate all spends to contracts

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -424,7 +424,7 @@ export class EthereumEngine extends CurrencyEngine {
           [contractAddress || publicAddress, 'latest']
         )
 
-        if (bns.gt(parseInt(getCodeResult.result, 16).toString(), '0')) {
+        if (getCodeResult.result.result !== '0x') {
           const estimateGasResult = await this.ethNetwork.multicastServers(
             'eth_estimateGas',
             [estimateGasParams]
@@ -440,11 +440,8 @@ export class EthereumEngine extends CurrencyEngine {
             parseInt(estimateGasResult.result.result, 16).toString(),
             '0'
           )
-
-          // Over estimate gas limit for token transactions
-          if (currencyCode !== this.currencyInfo.currencyCode) {
-            gasLimit = bns.mul(gasLimit, '2')
-          }
+          // Overestimate gas limit to reduce chance of failure when sending to a contract
+          gasLimit = bns.mul(gasLimit, '2')
         } else {
           gasLimit = '21000'
         }


### PR DESCRIPTION
This PR also includes a small bug fix on line 427 when evaluating the getCode response. All spends, regardless of getCode value, were going into the estimateGas path because parseInt was returning NaN and biggystring evaluates NaN as greater than 0. 