### PR TITLE
wip: If the user specifies a nonce, use that

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -555,7 +555,6 @@ export class EthereumEngine extends CurrencyEngine {
     }
 
     // Nonce:
-
     const nonceArg: string = otherParams.nonceArg
     let nonce: string = nonceArg
     if (!nonce) {
@@ -588,11 +587,7 @@ export class EthereumEngine extends CurrencyEngine {
           throw e
         }
       } else {
-        nonce = this.walletLocalData.otherData.nextNonce
-        this.walletLocalData.otherData.unconfirmedNextNonce = bns.add(
-          this.walletLocalData.otherData.nextNonce,
-          '1'
-        )
+        nonce = otherParams.nonceArg
       }
     }
     // Convert nonce to hex for tsParams


### PR DESCRIPTION
The nonce for RBF must be the nonce of the replaced transaction.

There are also situations when working with smart contracts where it is important to craft a sequence of transactions with increasing nonces, sign them, and then send them at once. This requires explicit nonce control.

So, if the user is providing a nonce, just use it, and don't mess around with other stuff.