### PR TITLE
Added error when XRP destination tag exceed 9 characters

### DIFF
--- a/src/pluginError.js
+++ b/src/pluginError.js
@@ -1,0 +1,32 @@
+// @flow
+
+export const pluginErrorCodes = [400, 403, 404]
+export const pluginErrorName = {
+  XRP_ERROR: 'XrpError'
+}
+
+export class PluginError extends Error {
+  list: Array<{ field: string, message: string }>
+  labelCode: string
+  errorCode: number
+  json: any
+
+  constructor(
+    message: string,
+    name?: string,
+    code?: number,
+    labelCode?: string,
+    json?: any
+  ) {
+    super(message)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PluginError)
+    }
+
+    this.name = name ?? 'PluginError'
+    if (code) this.errorCode = code
+    if (labelCode) this.labelCode = labelCode
+    if (json) this.json = json
+  }
+}

--- a/src/xrp/xrpEngine.js
+++ b/src/xrp/xrpEngine.js
@@ -15,6 +15,11 @@ import {
 
 import { CurrencyEngine } from '../common/engine.js'
 import { cleanTxLogs, getOtherParams, validateObject } from '../common/utils.js'
+import {
+  PluginError,
+  pluginErrorCodes,
+  pluginErrorName
+} from '../pluginError.js'
 import { currencyInfo } from './xrpInfo.js'
 import { XrpPlugin } from './xrpPlugin.js'
 import {
@@ -34,6 +39,7 @@ const TRANSACTION_POLL_MILLISECONDS = 3000
 const ADDRESS_QUERY_LOOKBACK_BLOCKS = 30 * 60 // ~ one minute
 
 const PRIMARY_CURRENCY = currencyInfo.currencyCode
+const MAX_DESTINATION_TAG_LENGTH = 9
 
 type XrpParams = {
   preparedTx: Object
@@ -51,6 +57,7 @@ type XrpFunction =
   | 'preparePayment'
   | 'sign'
   | 'submit'
+
 export class XrpEngine extends CurrencyEngine {
   xrpPlugin: XrpPlugin
   otherData: XrpWalletOtherData
@@ -429,6 +436,18 @@ export class XrpEngine extends CurrencyEngine {
         )
       } else {
         throw new Error('Error invalid destinationtag')
+      }
+
+      if (
+        edgeSpendInfo.spendTargets[0].otherParams.uniqueIdentifier.length >
+        MAX_DESTINATION_TAG_LENGTH
+      ) {
+        throw new PluginError(
+          'XRP Destination Tag must be 9 characters or less',
+          pluginErrorName.XRP_ERROR,
+          pluginErrorCodes[0],
+          currencyInfo.defaultSettings.errorCodes.UNIQUE_IDENTIFIER_EXCEEDS_LENGTH
+        )
       }
     }
     const payment = {

--- a/src/xrp/xrpInfo.js
+++ b/src/xrp/xrpInfo.js
@@ -16,7 +16,10 @@ const otherSettings: XrpSettings = {
 
 const defaultSettings: any = {
   otherSettings,
-  fee: '0.00001'
+  fee: '0.00001',
+  errorCodes: {
+    UNIQUE_IDENTIFIER_EXCEEDS_LENGTH: 'UNIQUE_IDENTIFIER_EXCEEDS_LENGTH'
+  }
 }
 
 export const currencyInfo: EdgeCurrencyInfo = {


### PR DESCRIPTION
NOTE: should merge with https://github.com/EdgeApp/edge-react-gui/pull/2541

Sidenote: Will be better if there is a way to export the `UniqueIdentifierExceedsLengthError` like in the edge-core-js