### PR TITLE
Set fee in preparePayment instructions and remove unused type from transaction schema

### DIFF
--- a/src/xrp/xrpEngine.js
+++ b/src/xrp/xrpEngine.js
@@ -477,7 +477,7 @@ export class XrpEngine extends CurrencyEngine {
           'preparePayment',
           this.walletLocalData.publicKey,
           payment,
-          { maxLedgerVersionOffset: 300 }
+          { maxLedgerVersionOffset: 300, fee: this.otherData.recommendedFee }
         )
         break
       } catch (err) {

--- a/src/xrp/xrpSchema.js
+++ b/src/xrp/xrpSchema.js
@@ -55,7 +55,6 @@ export const XrpGetTransactionsSchema = {
   items: {
     type: 'object',
     properties: {
-      type: { type: 'string' },
       address: { type: 'string' },
       id: { type: 'string' },
       outcome: {


### PR DESCRIPTION
This PR addresses two issues. First is to remove the unused "type" value from the transaction schema which was throwing when the SDK returned null for an unrecognized tx type (like delete account). 

The other is to pass the recommended fee to preparePayment in the "instructions" object. preparePayment calls getFee which can fail depending on the type of server, reporting or p2p, the SDK is connected to. https://github.com/ripple/rippled/issues/3812#issuecomment-816871100