### PR TITLE
Fix regression caused by EIP-681 parseUri implementation

### DIFF
--- a/src/ethereum/ethPlugin.js
+++ b/src/ethereum/ethPlugin.js
@@ -276,14 +276,6 @@ export class EthereumPlugin extends CurrencyPlugin {
               ? biggyScience(parameters.value)
               : edgeParsedUri.nativeAmount
 
-          // If currencyCode is not the same as the default currencyCode from the currencyInfo
-          if (
-            currencyCode != null &&
-            currencyCode !== this.currencyInfo.currencyCode
-          ) {
-            throw new Error('InternalErrorInvalidCurrencyCode')
-          }
-
           return { ...edgeParsedUri, publicAddress, nativeAmount }
         }
         default: {

--- a/test/plugin/fixtures.js
+++ b/test/plugin/fixtures.js
@@ -379,6 +379,12 @@ export default [
         '0x04b6b3bcbc16a5fb6a20301d650f8def513122a8',
         '0x04b6b3bcbc16a5fb6a20301d650f8def513122a8'
       ],
+      'address with provided currency code': {
+        args: ['0x04b6b3bcbc16a5fb6a20301d650f8def513122a8', 'USDC'],
+        output: {
+          publicAddress: '0x04b6b3bcbc16a5fb6a20301d650f8def513122a8'
+        }
+      },
       'checksum address only': [
         '0x3C40cbb7F82A7E1bc83C4E3E98590b19e0e1bf07',
         '0x3c40cbb7f82a7e1bc83c4e3e98590b19e0e1bf07'

--- a/test/plugin/plugin.test.js
+++ b/test/plugin/plugin.test.js
@@ -267,6 +267,7 @@ for (const fixture of fixtures) {
     }
     */
     ;[
+      'address only with provided currency code',
       'uri eip681 payment address',
       'uri eip681 payment address with pay prefix',
       'uri eip681 payment address using scientific notation',
@@ -280,6 +281,8 @@ for (const fixture of fixtures) {
         const parsedUri = await tools.parseUri(...caseFixtures.args)
 
         Object.entries(caseFixtures.output).forEach(([key, value]) => {
+          if (caseName === 'address only with provided currency code')
+            console.log(';;', parsedUri)
           assert.equal(parsedUri[key], value)
         })
       })


### PR DESCRIPTION
Checking that the currencyCode matches the parent currency for regular
address sends is not necessary and clearly causes an issue with token
sends using an address only (no URI scheme).