### PR TITLE
Add a Failsafe Call to signTypedData_v4

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -256,8 +256,15 @@ export class EthereumEngine extends CurrencyEngine {
     this.otherMethods = {
       personal_sign: params => this.utils.signMessage(params[0]),
       eth_sign: params => this.utils.signMessage(params[1]),
-      eth_signTypedData: params =>
-        this.utils.signTypedData(JSON.parse(params[1])),
+      eth_signTypedData: params => {
+        try {
+          return this.utils.signTypedData(JSON.parse(params[1]))
+        } catch (e) {
+          // It's possible that the dApp makes the wrong call.
+          // Try to sign using the latest signTypedData_v4 method.
+          return this.otherMethods.eth_signTypedData_v4(params)
+        }
+      },
       eth_signTypedData_v4: params =>
         signTypedData_v4(Buffer.from(this.getDisplayPrivateSeed(), 'hex'), {
           data: JSON.parse(params[1])


### PR DESCRIPTION
For Rarible or other dApps that call the old signTypedData method out of spec,
make a fallback call to see if they meant to use the newest signTypedData_v4.

Created NFT with 'edgeqa' wallet: https://rarible.com/token/0xc9154424B823b10579895cCBE442d41b9Abd96Ed:38190754646147306018708889713384028227784092577956748593609608676919981637636?tab=details

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201531572537963