### PR TITLE
Add new tokens

### DIFF
--- a/src/common/engine.js
+++ b/src/common/engine.js
@@ -664,6 +664,12 @@ export class CurrencyEngine {
     for (const token of tokens) {
       if (this.walletLocalData.enabledTokens.indexOf(token) === -1) {
         this.walletLocalData.enabledTokens.push(token)
+        // Initialize balance
+        this.walletLocalData.totalBalances[token] = '0'
+        this.currencyEngineCallbacks.onBalanceChanged(
+          token,
+          this.walletLocalData.totalBalances[token]
+        )
         this.walletLocalDataDirty = true
       }
     }

--- a/src/ethereum/avaxInfo.js
+++ b/src/ethereum/avaxInfo.js
@@ -87,7 +87,206 @@ export const currencyInfo: EdgeCurrencyInfo = {
       symbol: 'AVAX'
     }
   ],
-  metaTokens: []
+  metaTokens: [
+    {
+      currencyCode: 'PNG',
+      currencyName: 'Pangolin',
+      denominations: [
+        {
+          name: 'PNG',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x60781C2586D68229fde47564546784ab3fACA982'
+    },
+    {
+      currencyCode: 'PEFI',
+      currencyName: 'Penguin Finance',
+      denominations: [
+        {
+          name: 'PEFI',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xe896CDeaAC9615145c0cA09C8Cd5C25bced6384c'
+    },
+    {
+      currencyCode: 'XAVA',
+      currencyName: 'Avalaunch',
+      denominations: [
+        {
+          name: 'XAVA',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xd1c3f94DE7e5B45fa4eDBBA472491a9f4B166FC4'
+    },
+    {
+      currencyCode: 'BIFI',
+      currencyName: 'Beefy Finance',
+      denominations: [
+        {
+          name: 'BIFI',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xd6070ae98b8069de6B494332d1A1a81B6179D960'
+    },
+    {
+      currencyCode: 'BNB',
+      currencyName: 'Binance',
+      denominations: [
+        {
+          name: 'BNB',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x264c1383EA520f73dd837F915ef3a732e204a493'
+    },
+    {
+      currencyCode: 'YAK',
+      currencyName: 'Yield Yak',
+      denominations: [
+        {
+          name: 'YAK',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x59414b3089ce2AF0010e7523Dea7E2b35d776ec7'
+    },
+    {
+      currencyCode: 'JOE',
+      currencyName: 'Joe Token',
+      denominations: [
+        {
+          name: 'JOE',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd'
+    },
+    {
+      currencyCode: 'TIME',
+      currencyName: 'Wonderland',
+      denominations: [
+        {
+          name: 'TIME',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xb54f16fB19478766A268F172C9480f8da1a7c9C3'
+    },
+    {
+      currencyCode: 'SPELL',
+      currencyName: 'Spell Token',
+      denominations: [
+        {
+          name: 'SPELL',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xCE1bFFBD5374Dac86a2893119683F4911a2F7814'
+    },
+    {
+      currencyCode: 'FXS',
+      currencyName: 'Frax Share',
+      denominations: [
+        {
+          name: 'FXS',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x214DB107654fF987AD859F34125307783fC8e387'
+    },
+    {
+      currencyCode: 'MIM',
+      currencyName: 'Magic Internet Money',
+      denominations: [
+        {
+          name: 'MIM',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x130966628846bfd36ff31a822705796e8cb8c18d'
+    },
+    {
+      currencyCode: 'BUSD.e',
+      currencyName: 'Binance USD',
+      denominations: [
+        {
+          name: 'BUSD.e',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98'
+    },
+    {
+      currencyCode: 'DAI.e',
+      currencyName: 'Dai Stablecoin',
+      denominations: [
+        {
+          name: 'DAI.e',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xd586E7F844cEa2F87f50152665BCbc2C279D8d70'
+    },
+    {
+      currencyCode: 'LINK.e',
+      currencyName: 'ChainLink Token',
+      denominations: [
+        {
+          name: 'LINK.e',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x5947BB275c521040051D82396192181b413227A3'
+    },
+    {
+      currencyCode: 'UNI.e',
+      currencyName: 'Uniswap',
+      denominations: [
+        {
+          name: 'UNI.e',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x8eBAf22B6F053dFFeaf46f4Dd9eFA95D89ba8580'
+    },
+    {
+      currencyCode: 'USDC.e',
+      currencyName: 'USD Coin',
+      denominations: [
+        {
+          name: 'USDC.e',
+          multiplier: '1000000'
+        }
+      ],
+      contractAddress: '0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664'
+    },
+    {
+      currencyCode: 'USDT.e',
+      currencyName: 'Tether USD',
+      denominations: [
+        {
+          name: 'USDT.e',
+          multiplier: '1000000'
+        }
+      ],
+      contractAddress: '0xc7198437980c041c805A1EDcbA50c1Ce5db95118'
+    },
+    {
+      currencyCode: 'WBTC.e',
+      currencyName: 'Wrapped BTC',
+      denominations: [
+        {
+          name: 'WBTC.e',
+          multiplier: '100000000'
+        }
+      ],
+      contractAddress: '0x50b7545627a5162F82A992c33b87aDc75187B218'
+    }
+  ]
 }
 
 export const makeAvalanchePlugin = (opts: EdgeCorePluginOptions) => {

--- a/src/ethereum/ethInfo.js
+++ b/src/ethereum/ethInfo.js
@@ -1279,6 +1279,50 @@ export const currencyInfo: EdgeCurrencyInfo = {
         }
       ],
       contractAddress: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'
+    },
+    {
+      currencyCode: 'MATIC',
+      currencyName: 'Polygon',
+      denominations: [
+        {
+          name: 'MATIC',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'
+    },
+    {
+      currencyCode: 'BNB',
+      currencyName: 'Binance',
+      denominations: [
+        {
+          name: 'BNB',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xB8c77482e45F1F44dE1745F52C74426C631bDD52'
+    },
+    {
+      currencyCode: 'FTM',
+      currencyName: 'Fantom',
+      denominations: [
+        {
+          name: 'FTM',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x4e15361fd6b4bb609fa63c81a2be19d873717870'
+    },
+    {
+      currencyCode: '1INCH',
+      currencyName: '1inch',
+      denominations: [
+        {
+          name: '1INCH',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x111111111117dc0aa78b770fa6a738034120c302'
     }
   ]
 }

--- a/src/ethereum/ftminfo.js
+++ b/src/ethereum/ftminfo.js
@@ -93,6 +93,39 @@ export const currencyInfo: EdgeCurrencyInfo = {
         }
       ],
       contractAddress: '0x049d68029688eabf473097a2fc38ef61633a3c7a'
+    },
+    {
+      currencyCode: 'FBTC',
+      currencyName: 'Frapped Bitcoin',
+      denominations: [
+        {
+          name: 'FBTC',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xe1146b9ac456fcbb60644c36fd3f868a9072fc6e'
+    },
+    {
+      currencyCode: 'USDC',
+      currencyName: 'USD Coin',
+      denominations: [
+        {
+          name: 'USDC',
+          multiplier: '1000000'
+        }
+      ],
+      contractAddress: '0x04068da6c83afcfa0e13ba15a6696662335d5b75'
+    },
+    {
+      currencyCode: 'FETH',
+      currencyName: 'Frapped Ethereum',
+      denominations: [
+        {
+          name: 'FETH',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x658b0c7613e890ee50b8c4bc6a3f41ef411208ad'
     }
   ]
 }

--- a/src/ethereum/maticInfo.js
+++ b/src/ethereum/maticInfo.js
@@ -94,7 +94,173 @@ export const currencyInfo: EdgeCurrencyInfo = {
       symbol: 'mMATIC'
     }
   ],
-  metaTokens: []
+  metaTokens: [
+    {
+      currencyCode: 'USDC',
+      currencyName: 'USD Coin',
+      denominations: [
+        {
+          name: 'USDC',
+          multiplier: '1000000'
+        }
+      ],
+      contractAddress: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174'
+    },
+    {
+      currencyCode: 'DAI',
+      currencyName: 'Dai Stablecoin',
+      denominations: [
+        {
+          name: 'DAI',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063'
+    },
+    {
+      currencyCode: 'USDT',
+      currencyName: 'Tether',
+      denominations: [
+        {
+          name: 'USDT',
+          multiplier: '1000000'
+        }
+      ],
+      contractAddress: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f'
+    },
+    {
+      currencyCode: 'AAVE',
+      currencyName: 'Aave',
+      denominations: [
+        {
+          name: 'AAVE',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xd6df932a45c0f255f85145f286ea0b292b21c90b'
+    },
+    {
+      currencyCode: 'WBTC',
+      currencyName: 'Wrapped Bitcoin',
+      denominations: [
+        {
+          name: 'WBTC',
+          multiplier: '100000000'
+        }
+      ],
+      contractAddress: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6'
+    },
+    {
+      currencyCode: 'YFI',
+      currencyName: 'Yearn Finance',
+      denominations: [
+        {
+          name: 'YFI',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xda537104d6a5edd53c6fbba9a898708e465260b6'
+    },
+    {
+      currencyCode: 'WETH',
+      currencyName: 'Wrapped ETH',
+      denominations: [
+        {
+          name: 'WETH',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619'
+    },
+    {
+      currencyCode: 'BUSD',
+      currencyName: 'Binance USD',
+      denominations: [
+        {
+          name: 'BUSD',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xdab529f40e671a1d4bf91361c21bf9f0c9712ab7'
+    },
+    {
+      currencyCode: 'UNI',
+      currencyName: 'Uniswap',
+      denominations: [
+        {
+          name: 'UNI',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xb33eaad8d922b1083446dc23f610c2567fb5180f'
+    },
+    {
+      currencyCode: 'FTM',
+      currencyName: 'Fantom',
+      denominations: [
+        {
+          name: 'FTM',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xc9c1c1c20b3658f8787cc2fd702267791f224ce1'
+    },
+    {
+      currencyCode: 'MKR',
+      currencyName: 'Maker',
+      denominations: [
+        {
+          name: 'MKR',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x6f7C932e7684666C9fd1d44527765433e01fF61d'
+    },
+    {
+      currencyCode: 'TUSD',
+      currencyName: 'TrueUSD',
+      denominations: [
+        {
+          name: 'TUSD',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x2e1ad108ff1d8c782fcbbb89aad783ac49586756'
+    },
+    {
+      currencyCode: 'BNB',
+      currencyName: 'Binance',
+      denominations: [
+        {
+          name: 'BNB',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x3BA4c387f786bFEE076A58914F5Bd38d668B42c3'
+    },
+    {
+      currencyCode: 'MANA',
+      currencyName: 'Decentraland',
+      denominations: [
+        {
+          name: 'MANA',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4'
+    },
+    {
+      currencyCode: 'LINK',
+      currencyName: 'Chainlink',
+      denominations: [
+        {
+          name: 'LINK',
+          multiplier: '1000000000000000000'
+        }
+      ],
+      contractAddress: '0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39'
+    }
+  ]
 }
 
 export const makePolygonPlugin = (opts: EdgeCorePluginOptions) => {


### PR DESCRIPTION
In addition to adding new default tokens to AVAX, FTM, and MATIC, this PR includes a fix to add a zero balance for newly enabled tokens. This keeps the balances in sync with the enabled tokens list. 

While it's logical to do that, the motivation to do that is it's the simpler solution for edge-react-gui not showing an exchange rate for newly enabled tokens since edge-core-js uses the balances object to build the exchange rates reqeust.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201724097897066