### PR TITLE
Add new RPC servers for FTM

### DIFF
--- a/src/ethereum/ftminfo.js
+++ b/src/ethereum/ftminfo.js
@@ -31,7 +31,14 @@ const defaultNetworkFees: EthereumFees = {
 }
 
 const otherSettings: EthereumSettings = {
-  rpcServers: ['https://rpcapi.fantom.network', 'https://rpc.ftm.tools'],
+  rpcServers: [
+    'https://ftmrpc.ultimatenodes.io',
+    'https://rpcapi.fantom.network',
+    'https://rpc.fantom.network',
+    'https://rpc2.fantom.network',
+    'https://rpc3.fantom.network',
+    'https://rpc.ftm.tools'
+  ],
   etherscanApiServers: ['https://api.ftmscan.com/'],
   blockcypherApiServers: [],
   blockbookServers: [],


### PR DESCRIPTION
https://app.asana.com/0/1190492602001461/1201868425294797/f

FTM RPC servers have been under increasingly heavy load, sometimes completely unresponsive. Add all known RPC servers:

    'https://ftmrpc.ultimatenodes.io/',
    'https://rpcapi.fantom.network/',
    'https://rpc.fantom.network/',
    'https://rpc2.fantom.network/',
    'https://rpc3.fantom.network/',
    'https://rpc.ftm.tools/'