### PR TITLE
Remove queries for internal transactions

### DIFF
--- a/src/ethereum/ethTypes.js
+++ b/src/ethereum/ethTypes.js
@@ -167,24 +167,6 @@ export const asEvmScanTransaction = asObject({
 
 export type EvmScanTransaction = $Call<typeof asEvmScanTransaction>
 
-export const asEvmScanInternalTransaction = asObject({
-  hash: asOptional(asString),
-  transactionHash: asOptional(asString),
-  blockNumber: asString,
-  timeStamp: asString,
-  gasUsed: asString,
-  value: asString,
-  from: asString,
-  to: asString,
-  gas: asString,
-  isError: asString,
-  contractAddress: asOptional(asString)
-})
-
-export type EvmScanInternalTransaction = $Call<
-  typeof asEvmScanInternalTransaction
->
-
 export const asEvmScanGasResponseResult = asObject({
   LastBlock: asString,
   SafeGasPrice: asString,


### PR DESCRIPTION
Internal transactions are by definition between contracts and don't affect the end balance of an EVM account. These queries were overwriting regular transactions with the same txid causing incorrect transaction amounts.