### PR TITLE
Build feeRateUsed for Ethereum receiving txns

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -43,7 +43,7 @@ import {
   validateObject
 } from '../common/utils'
 import { NETWORK_FEES_POLL_MILLISECONDS, WEI_MULTIPLIER } from './ethConsts.js'
-import { EthereumNetwork } from './ethNetwork'
+import { EthereumNetwork, getFeeRateUsed } from './ethNetwork'
 import { EthereumPlugin } from './ethPlugin'
 import { EIP712TypedDataSchema } from './ethSchema.js'
 import {
@@ -966,17 +966,6 @@ export class EthereumEngine extends CurrencyEngine {
     // **********************************
     // Create the unsigned EdgeTransaction
 
-    // This is used for display purposes in the GUI
-    const feeRateUsed = {
-      // Convert gasPrice from wei to gwei
-      gasPrice: bns.div(
-        gasPrice,
-        WEI_MULTIPLIER.toString(),
-        WEI_MULTIPLIER.toString().length - 1
-      ),
-      gasLimit
-    }
-
     const edgeTransaction: EdgeTransaction = {
       txid: '', // txid
       date: 0, // date
@@ -984,7 +973,7 @@ export class EthereumEngine extends CurrencyEngine {
       blockHeight: 0, // blockHeight
       nativeAmount, // nativeAmount
       networkFee: nativeNetworkFee, // networkFee
-      feeRateUsed,
+      feeRateUsed: getFeeRateUsed(gasPrice, gasLimit),
       ourReceiveAddresses: [], // ourReceiveAddresses
       signedTx: '', // signedTx
       otherParams // otherParams

--- a/src/ethereum/ethNetwork.js
+++ b/src/ethereum/ethNetwork.js
@@ -27,7 +27,6 @@ import { EthereumEngine } from './ethEngine'
 import { EtherscanGetAccountNonce, EtherscanGetBlockHeight } from './ethSchema'
 import {
   type AlethioTokenTransfer,
-  type AmberdataInternalTx,
   type AmberdataTx,
   type BlockbookAddress,
   type BlockbookTokenBalance,


### PR DESCRIPTION
Fetches gas related variables to build the `feeRateUsed` object for GUI
display purpose.

Note that the `gasUsed` has no corresponding key string in the GUI 
repo. We might need to open a task for creating localized strings for
`gasUsed`.

![Simulator Screen Shot - iPhone 13 - 2022-07-05 at 13 33 34](https://user-images.githubusercontent.com/23110002/177412973-33aec063-6b07-4156-a34a-4da3d08a83a0.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200984756686295