### PR TITLE
Fix return types for engine.js:makeSpend

### DIFF
--- a/src/common/engine.js
+++ b/src/common/engine.js
@@ -928,7 +928,13 @@ export class CurrencyEngine<T> {
     return dataDump
   }
 
-  makeSpend(edgeSpendInfo: EdgeSpendInfo): Object {
+  makeSpendCheck(edgeSpendInfo: EdgeSpendInfo): {
+    edgeSpendInfo: EdgeSpendInfo,
+    nativeBalance: string,
+    currencyCode: string,
+    denom: EdgeDenomination,
+    skipChecks: boolean
+  } {
     const { skipChecks = false } = edgeSpendInfo
     checkEdgeSpendInfo(edgeSpendInfo)
 

--- a/src/eos/eosEngine.js
+++ b/src/eos/eosEngine.js
@@ -914,7 +914,7 @@ export class EosEngine extends CurrencyEngine<EosPlugin> {
 
   async makeSpend(edgeSpendInfoIn: EdgeSpendInfo) {
     const { edgeSpendInfo, currencyCode, nativeBalance, denom } =
-      super.makeSpend(edgeSpendInfoIn)
+      this.makeSpendCheck(edgeSpendInfoIn)
     const { defaultSettings } = this.currencyInfo
     const tokenInfo = this.getTokenInfo(currencyCode)
     if (!tokenInfo) throw new Error('Unable to find token info')
@@ -931,7 +931,12 @@ export class EosEngine extends CurrencyEngine<EosPlugin> {
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
     }
-    const publicAddress = edgeSpendInfo.spendTargets[0].publicAddress
+    const { publicAddress } = edgeSpendInfo.spendTargets[0]
+    let { nativeAmount } = edgeSpendInfo.spendTargets[0]
+
+    if (publicAddress == null)
+      throw new Error('makeSpend Missing publicAddress')
+    if (nativeAmount == null) throw new NoAmountSpecifiedError()
 
     // Check if destination address is activated
     let mustCreateAccount = false
@@ -954,13 +959,6 @@ export class EosEngine extends CurrencyEngine<EosPlugin> {
     }
     if (mustCreateAccount) {
       throw new Error('ErrorAccountNotActivated')
-    }
-
-    let nativeAmount = '0'
-    if (typeof edgeSpendInfo.spendTargets[0].nativeAmount === 'string') {
-      nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
-    } else {
-      throw new NoAmountSpecifiedError()
     }
 
     if (bns.eq(nativeAmount, '0')) {

--- a/src/hedera/hederaEngine.js
+++ b/src/hedera/hederaEngine.js
@@ -393,20 +393,19 @@ export class HederaEngine extends CurrencyEngine<HederaPlugin> {
       throw Error('ErrorAccountNotActivated')
     }
 
-    const { edgeSpendInfo, currencyCode } = super.makeSpend(edgeSpendInfoIn)
+    const { edgeSpendInfo, currencyCode } = this.makeSpendCheck(edgeSpendInfoIn)
 
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
     }
+
     const { publicAddress, uniqueIdentifier = '' } =
       edgeSpendInfo.spendTargets[0]
+    let { nativeAmount } = edgeSpendInfo.spendTargets[0]
 
-    let nativeAmount = '0'
-    if (typeof edgeSpendInfo.spendTargets[0].nativeAmount === 'string') {
-      nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
-    } else {
-      throw new NoAmountSpecifiedError()
-    }
+    if (publicAddress == null)
+      throw new Error('makeSpend Missing publicAddress')
+    if (nativeAmount == null) throw new NoAmountSpecifiedError()
 
     if (bns.eq(nativeAmount, '0')) {
       throw new NoAmountSpecifiedError()

--- a/src/polkadot/polkadotEngine.js
+++ b/src/polkadot/polkadotEngine.js
@@ -6,7 +6,8 @@ import {
   type EdgeTransaction,
   type EdgeWalletInfo,
   type JsonObject,
-  InsufficientFundsError
+  InsufficientFundsError,
+  NoAmountSpecifiedError
 } from 'edge-core-js/types'
 
 import { CurrencyEngine } from '../common/engine.js'
@@ -303,13 +304,17 @@ export class PolkadotEngine extends CurrencyEngine<PolkadotPlugin> {
   }
 
   async makeSpend(edgeSpendInfoIn: EdgeSpendInfo): Promise<EdgeTransaction> {
-    const { edgeSpendInfo, currencyCode } = super.makeSpend(edgeSpendInfoIn)
+    const { edgeSpendInfo, currencyCode } = this.makeSpendCheck(edgeSpendInfoIn)
 
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
     }
-    const publicAddress = edgeSpendInfo.spendTargets[0].publicAddress
-    const nativeAmount: string = edgeSpendInfo.spendTargets[0].nativeAmount
+    const { nativeAmount, publicAddress } = edgeSpendInfo.spendTargets[0]
+
+    if (publicAddress == null)
+      throw new Error('makeSpend Missing publicAddress')
+    if (nativeAmount == null) throw new NoAmountSpecifiedError()
+
     const balance = this.getBalance({
       currencyCode: this.currencyInfo.currencyCode
     })

--- a/src/tezos/tezosEngine.js
+++ b/src/tezos/tezosEngine.js
@@ -361,17 +361,18 @@ export class TezosEngine extends CurrencyEngine<TezosPlugin> {
     edgeSpendInfoIn: EdgeSpendInfo
   ): Promise<EdgeTransaction> {
     const { edgeSpendInfo, currencyCode, nativeBalance, denom } =
-      super.makeSpend(edgeSpendInfoIn)
+      this.makeSpendCheck(edgeSpendInfoIn)
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
     }
-    const publicAddress = edgeSpendInfo.spendTargets[0].publicAddress
-    let nativeAmount = '0'
-    if (typeof edgeSpendInfo.spendTargets[0].nativeAmount === 'string') {
-      nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
-    } else {
-      throw new NoAmountSpecifiedError()
-    }
+
+    const { publicAddress } = edgeSpendInfo.spendTargets[0]
+    let { nativeAmount } = edgeSpendInfo.spendTargets[0]
+
+    if (publicAddress == null)
+      throw new Error('makeSpend Missing publicAddress')
+    if (nativeAmount == null) throw new NoAmountSpecifiedError()
+
     if (bns.eq(nativeAmount, '0')) {
       throw new NoAmountSpecifiedError()
     }

--- a/src/xrp/xrpEngine.js
+++ b/src/xrp/xrpEngine.js
@@ -283,21 +283,19 @@ export class XrpEngine extends CurrencyEngine<XrpPlugin> {
   }
 
   async makeSpend(edgeSpendInfoIn: EdgeSpendInfo) {
-    const { edgeSpendInfo, currencyCode, nativeBalance } = super.makeSpend(
-      edgeSpendInfoIn
-    )
+    const { edgeSpendInfo, currencyCode, nativeBalance } =
+      this.makeSpendCheck(edgeSpendInfoIn)
 
     if (edgeSpendInfo.spendTargets.length !== 1) {
       throw new Error('Error: only one output allowed')
     }
-    const publicAddress = edgeSpendInfo.spendTargets[0].publicAddress
 
-    let nativeAmount = '0'
-    if (typeof edgeSpendInfo.spendTargets[0].nativeAmount === 'string') {
-      nativeAmount = edgeSpendInfo.spendTargets[0].nativeAmount
-    } else {
-      throw new Error('Error: no amount specified')
-    }
+    const { publicAddress } = edgeSpendInfo.spendTargets[0]
+    let { nativeAmount } = edgeSpendInfo.spendTargets[0]
+
+    if (publicAddress == null)
+      throw new Error('makeSpend Missing publicAddress')
+    if (nativeAmount == null) throw new NoAmountSpecifiedError()
 
     if (bns.eq(nativeAmount, '0')) {
       throw new NoAmountSpecifiedError()


### PR DESCRIPTION
Rename engine.js:makeSpend to makeSpendCheck since it has a different return signature than the asset specific makeSpend.

This exposed Flow errors in every asset engine that then needed to be fixed.