### PR TITLE
Fix spend with empty memo

### DIFF
--- a/src/ethereum/ethEngine.js
+++ b/src/ethereum/ethEngine.js
@@ -715,9 +715,11 @@ export class EthereumEngine extends CurrencyEngine<EthereumPlugin> {
     }
 
     let data = spendTarget.memo ?? spendTarget.otherParams?.data
-    if (data != null && !isHex(data)) {
+    if (data != null && data.length > 0 && !isHex(data)) {
       throw new Error(`Memo/data field must be of type 'hex'`)
     }
+
+    if (data === '') data = undefined
 
     let otherParams: Object = {}
 


### PR DESCRIPTION
Allow empty string memo and set as undefined.

Fixes invalid hex value error since empty string is not valid hex

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202935772126439