### PR TITLE
Add dynamic fee to Stellar

### DIFF
--- a/src/stellar/stellarTypes.ts
+++ b/src/stellar/stellarTypes.ts
@@ -2,6 +2,8 @@
  * Created by paul on 8/26/17.
  */
 
+import { asObject, asString } from 'cleaners'
+
 export interface StellarSettings {
   stellarServers: string[]
 }
@@ -63,3 +65,22 @@ export interface StellarWalletOtherData {
   lastPagingToken: string
   accountSequence: number
 }
+
+export const asFeeStats = asObject({
+  fee_charged: asObject({
+    // max: asString,
+    // min: asString,
+    // mode: asString,
+    // p10: asString,
+    // p20: asString,
+    // p30: asString,
+    // p40: asString,
+    p50: asString,
+    // p60: asString,
+    p70: asString,
+    // p80: asString,
+    // p90: asString,
+    p95: asString
+    // p99: asString
+  })
+})


### PR DESCRIPTION
Transactions sent with the base fee can fail if the network fees surge. This change makes the engine periodically query the average fees from the 5 most recent ledgers. I chose 50th percentile for low to avoid the case where a transaction fails. Low fees on the stellar network don't mean slower confirmation and instead result in completely failed transactions instead if they don't confirm within a few ledgers.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203059815007345