### PR TITLE
Filter blockscout from broadcasting tx method

### DIFF
--- a/src/ethereum/ethNetwork.ts
+++ b/src/ethereum/ethNetwork.ts
@@ -761,12 +761,15 @@ export class EthereumNetwork {
         })
 
         evmScanApiServers.forEach(baseUrl => {
-          promises.push(
-            broadcastWrapper(
-              this.broadcastEtherscan(params[0], baseUrl),
-              'etherscan'
+          // blockscout doesn't support Geth/Parity Proxy (eth_sendRawTransaction/broadcasting tx) for both ethereum classic and rsk
+          if (!baseUrl.includes('blockscout')) {
+            promises.push(
+              broadcastWrapper(
+                this.broadcastEtherscan(params[0], baseUrl),
+                'etherscan'
+              )
             )
-          )
+          }
         })
 
         blockbookServers.forEach(baseUrl => {


### PR DESCRIPTION
Unlike etherscan, the blackscout does not provide proxy for sending/broadcasting a signed transaction. 

Currently, one of the four ways to broadcast a transaction is through `evmScanServer` using the url `https://blockscout.com/etc/mainnet/api?module=proxy&action=eth_sendRawTransaction...`.

Blockscout is being used for Ethereum Classic and RSK blockchains. However, the proxy endpoints are not supported by Blockscout.

- API docs for [RSK blockscout](https://blockscout.com/rsk/mainnet/api-docs) 
- API docs for [Ethereum Classic (ETC)](https://blockscout.com/etc/mainnet/api-docs)

This pull request will filter the `evmScanServers` for blockscout and will disable the send requests for broadcasting transaction using blockscout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203476994536515