### PR TITLE
Engine cleanup

### DIFF
--- a/src/binance/bnbEngine.ts
+++ b/src/binance/bnbEngine.ts
@@ -1,6 +1,8 @@
 import { BncClient } from '@binance-chain/javascript-sdk'
 import { add, gt, mul, sub } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
+  EdgeCurrencyEngineOptions,
   EdgeSpendInfo,
   EdgeTransaction,
   EdgeWalletInfo,
@@ -9,6 +11,7 @@ import {
 } from 'edge-core-js/types'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import { asErrorMessage } from '../common/types'
 import {
   asyncWaterfall,
@@ -515,4 +518,22 @@ export class BinanceEngine extends CurrencyEngine<BinanceTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: BinanceTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const { initOptions } = env
+
+  const engine = new BinanceEngine(tools, walletInfo, initOptions, opts)
+
+  // Do any async initialization necessary for the engine
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  engine.otherData = engine.walletLocalData.otherData
+
+  return engine
 }

--- a/src/binance/bnbEngine.ts
+++ b/src/binance/bnbEngine.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 7/7/17.
- */
-
 import { BncClient } from '@binance-chain/javascript-sdk'
 import { add, gt, mul, sub } from 'biggystring'
 import {

--- a/src/binance/bnbInfo.ts
+++ b/src/binance/bnbInfo.ts
@@ -1,5 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { BinanceTools } from './bnbPlugin'
 import { BinanceSettings } from './bnbTypes'
 
 const otherSettings: BinanceSettings = {
@@ -41,3 +43,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const binance = makeOuterPlugin<{}, BinanceTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./bnbPlugin')
+  }
+})

--- a/src/binance/bnbInfo.ts
+++ b/src/binance/bnbInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { BinanceSettings } from './bnbTypes'

--- a/src/binance/bnbPlugin.ts
+++ b/src/binance/bnbPlugin.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-
 import { crypto } from '@binance-chain/javascript-sdk'
 import { div } from 'biggystring'
 import { entropyToMnemonic } from 'bip39'

--- a/src/binance/bnbTypes.ts
+++ b/src/binance/bnbTypes.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import {
   asArray,
   asBoolean,

--- a/src/common/innerPlugin.ts
+++ b/src/common/innerPlugin.ts
@@ -1,0 +1,27 @@
+import { EdgeOtherMethods } from 'edge-core-js/types'
+
+/**
+ * Builds an object with async proxy methods.
+ * Calling any of these methods will load the currency tools,
+ * and then call the corresponding method on the currency tools object.
+ */
+export function makeOtherMethods<T>(
+  getTools: () => Promise<T>,
+  otherMethodNames: Array<string & keyof T>
+): EdgeOtherMethods {
+  // Shims for our other methods,
+  // to load the plugin on-demand the first time somebody calls a method:
+  const out: { [name: string]: any } = {}
+  for (const name of otherMethodNames) {
+    out[name] = async (...args: any[]) => {
+      const tools = await getTools()
+      const method = tools[name]
+      if (typeof method !== 'function') {
+        throw new Error(`Method ${name} is not implemented`)
+      }
+      return method.apply(tools, args)
+    }
+  }
+
+  return out
+}

--- a/src/common/innerPlugin.ts
+++ b/src/common/innerPlugin.ts
@@ -1,4 +1,112 @@
-import { EdgeOtherMethods } from 'edge-core-js/types'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyEngine,
+  EdgeCurrencyEngineOptions,
+  EdgeCurrencyInfo,
+  EdgeCurrencyPlugin,
+  EdgeCurrencyTools,
+  EdgeOtherMethods,
+  EdgeTokenMap,
+  EdgeWalletInfo
+} from 'edge-core-js/types'
+
+/**
+ * We pass a more complete plugin environment to the inner plugin,
+ * so we can share the same instance between sibling networks.
+ */
+export interface PluginEnvironment<NetworkInfo> extends EdgeCorePluginOptions {
+  currencyInfo: EdgeCurrencyInfo
+  networkInfo: NetworkInfo
+}
+
+/**
+ * These methods involve expensive crypto libraries
+ * that we don't want to load unless we actually have wallets in an account.
+ */
+export interface InnerPlugin<NetworkInfo, Tools extends EdgeCurrencyTools> {
+  makeCurrencyEngine: (
+    env: PluginEnvironment<NetworkInfo>,
+    tools: Tools,
+    walletInfo: EdgeWalletInfo,
+    opts: EdgeCurrencyEngineOptions
+  ) => Promise<EdgeCurrencyEngine>
+
+  makeCurrencyTools: (env: PluginEnvironment<NetworkInfo>) => Promise<Tools>
+}
+
+/**
+ * These methods involve cheap, static information,
+ * so we don't have to load any crypto libraries.
+ */
+export interface OuterPlugin<NetworkInfo, Tools extends EdgeCurrencyTools> {
+  currencyInfo: EdgeCurrencyInfo
+  networkInfo: NetworkInfo
+
+  getBuiltinTokens?: (
+    env: PluginEnvironment<NetworkInfo>
+  ) => Promise<EdgeTokenMap>
+
+  getInnerPlugin: () => Promise<InnerPlugin<NetworkInfo, Tools>>
+
+  otherMethodNames?: ReadonlyArray<string & keyof Tools>
+}
+
+type EdgeCorePluginFactory = (env: EdgeCorePluginOptions) => EdgeCurrencyPlugin
+
+export function makeOuterPlugin<NetworkInfo, Tools extends EdgeCurrencyTools>(
+  template: OuterPlugin<NetworkInfo, Tools>
+): EdgeCorePluginFactory {
+  return (env: EdgeCorePluginOptions): EdgeCurrencyPlugin => {
+    const { currencyInfo, networkInfo, otherMethodNames = [] } = template
+    const innerEnv = { ...env, currencyInfo, networkInfo }
+
+    // Logic to load the inner plugin:
+    let pluginPromise: Promise<InnerPlugin<NetworkInfo, Tools>> | undefined
+    let toolsPromise: Promise<Tools> | undefined
+    async function loadInnerPlugin(): Promise<{
+      plugin: InnerPlugin<NetworkInfo, Tools>
+      tools: Tools
+    }> {
+      if (pluginPromise == null) {
+        pluginPromise = template.getInnerPlugin()
+      }
+      const plugin = await pluginPromise
+      if (toolsPromise == null) {
+        toolsPromise = plugin.makeCurrencyTools(innerEnv)
+      }
+      const tools = await toolsPromise
+      return { plugin, tools }
+    }
+
+    async function getBuiltinTokens(): Promise<EdgeTokenMap> {
+      if (template.getBuiltinTokens == null) return {}
+      return await template.getBuiltinTokens(innerEnv)
+    }
+
+    async function makeCurrencyTools(): Promise<Tools> {
+      const { tools } = await loadInnerPlugin()
+      return tools
+    }
+
+    async function makeCurrencyEngine(
+      walletInfo: EdgeWalletInfo,
+      opts: EdgeCurrencyEngineOptions
+    ): Promise<EdgeCurrencyEngine> {
+      const { tools, plugin } = await loadInnerPlugin()
+      return await plugin.makeCurrencyEngine(innerEnv, tools, walletInfo, opts)
+    }
+
+    const otherMethods = makeOtherMethods(makeCurrencyTools, otherMethodNames)
+
+    return {
+      currencyInfo,
+      getBuiltinTokens,
+      makeCurrencyTools,
+      makeCurrencyEngine,
+      otherMethods
+    }
+  }
+}
 
 /**
  * Builds an object with async proxy methods.
@@ -7,7 +115,7 @@ import { EdgeOtherMethods } from 'edge-core-js/types'
  */
 export function makeOtherMethods<T>(
   getTools: () => Promise<T>,
-  otherMethodNames: Array<string & keyof T>
+  otherMethodNames: ReadonlyArray<string & keyof T>
 ): EdgeOtherMethods {
   // Shims for our other methods,
   // to load the plugin on-demand the first time somebody calls a method:

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import { asObject, asString } from 'cleaners'
 import { EdgeTransaction } from 'edge-core-js/types'
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import { add, mul } from 'biggystring'
 import { Buffer } from 'buffer'
 import { asArray, asObject, asOptional, asString } from 'cleaners'

--- a/src/eos/eosEngine.ts
+++ b/src/eos/eosEngine.ts
@@ -103,8 +103,7 @@ class CosignAuthorityProvider {
 }
 export class EosEngine extends CurrencyEngine<EosTools> {
   activatedAccountsCache: { [publicAddress: string]: boolean }
-  // @ts-expect-error
-  otherData: EosWalletOtherData
+  otherData!: EosWalletOtherData
   otherMethods: Object
   eosJsConfig: EosJsConfig
   fetchCors: EdgeFetchFunction
@@ -689,9 +688,7 @@ export class EosEngine extends CurrencyEngine<EosTools> {
               // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (!authorizersReply.ok) {
                 throw new Error(
-                  `${server} get_key_accounts failed with ${JSON.stringify(
-                    authorizersReply
-                  )}`
+                  `${server} get_key_accounts failed with ${authorizersReply.status}`
                 )
               }
               const authorizersData = await authorizersReply.json()
@@ -752,7 +749,7 @@ export class EosEngine extends CurrencyEngine<EosTools> {
               // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (!accountReply.ok) {
                 throw new Error(
-                  `${server} get_account failed with ${authorizersReply}`
+                  `${server} get_account failed with ${accountReply.status}`
                 )
               }
               return { server, result: await accountReply.json() }
@@ -771,7 +768,7 @@ export class EosEngine extends CurrencyEngine<EosTools> {
               // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (!response.ok) {
                 throw new Error(
-                  `${server} get_account failed with ${response.code}`
+                  `${server} get_account failed with ${response.status}`
                 )
               }
               const responseJson = asDfuseGetKeyAccountsResponse(
@@ -818,9 +815,9 @@ export class EosEngine extends CurrencyEngine<EosTools> {
           randomNodes.map(server => async () => {
             // @ts-expect-error
             const rpc = new JsonRpc(server, {
-              fetch: (...args) => {
+              fetch: async (...args) => {
                 // this.log(`LoggedFetch: ${JSON.stringify(args)}`)
-                return this.eosJsConfig.fetch(...args)
+                return await this.eosJsConfig.fetch(...args)
               }
             })
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/src/eos/eosInfo.ts
+++ b/src/eos/eosInfo.ts
@@ -1,7 +1,8 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosNetworkInfo } from './eosTypes'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { EosTools } from './eosPlugin'
+import { EosNetworkInfo, eosOtherMethodNames } from './eosTypes'
 
 // ----EOSIO MAIN NET----
 export const eosNetworkInfo: EosNetworkInfo = {
@@ -52,7 +53,12 @@ export const eosCurrencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeEosPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, eosCurrencyInfo, eosNetworkInfo)
-}
+export const eos = makeOuterPlugin<EosNetworkInfo, EosTools>({
+  currencyInfo: eosCurrencyInfo,
+  networkInfo: eosNetworkInfo,
+  otherMethodNames: eosOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./eosPlugin')
+  }
+})

--- a/src/eos/eosInfo.ts
+++ b/src/eos/eosInfo.ts
@@ -1,6 +1,3 @@
-/**
- * Created by on 2020-02-14
- */
 /* global fetch */
 
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'

--- a/src/eos/eosInfo.ts
+++ b/src/eos/eosInfo.ts
@@ -1,42 +1,12 @@
-/* global fetch */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosJsConfig, EosSettings } from './eosTypes'
-
-const GREYMASS_FUEL_ACTION = {
-  authorization: [
-    {
-      actor: 'greymassfuel',
-      permission: 'cosign'
-    }
-  ],
-  account: 'greymassnoop',
-  name: 'noop',
-  data: {}
-}
+import { EosNetworkInfo } from './eosTypes'
 
 // ----EOSIO MAIN NET----
-export const eosJsConfig: EosJsConfig = {
+export const eosNetworkInfo: EosNetworkInfo = {
   chainId: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906', // eosio main net
-  keyProvider: [],
-  httpEndpoint: '', // main net
-  fetch: fetch,
-  verbose: false // verbose logging such as API activity
-}
 
-const denominations = [
-  // An array of Objects of the possible denominations for this currency
-  {
-    name: 'EOS',
-    multiplier: '10000',
-    symbol: 'E'
-  }
-]
-
-const otherSettings: EosSettings = {
-  // @ts-expect-error
   eosActivationServers: ['https://eospay.edge.app'],
   eosHyperionNodes: ['https://api.eossweden.org'],
   eosNodes: [
@@ -52,24 +22,26 @@ const otherSettings: EosSettings = {
   ],
   eosFuelServers: ['https://eos.greymass.com'],
   eosDfuseServers: ['https://eos.dfuse.eosnation.io'],
-  uriProtocol: 'eos',
-  fuelActions: [GREYMASS_FUEL_ACTION]
+  uriProtocol: 'eos'
 }
 
-const defaultSettings: any = {
-  otherSettings
-}
+const denominations = [
+  // An array of Objects of the possible denominations for this currency
+  {
+    name: 'EOS',
+    multiplier: '10000',
+    symbol: 'E'
+  }
+]
 
 export const eosCurrencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'EOS',
   displayName: 'EOS',
   pluginId: 'eos',
-  // @ts-expect-error
-  pluginName: 'eos',
   walletType: 'wallet:eos',
 
-  defaultSettings,
+  defaultSettings: {},
 
   memoMaxLength: 256,
 
@@ -82,5 +54,5 @@ export const eosCurrencyInfo: EdgeCurrencyInfo = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const makeEosPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, eosCurrencyInfo, eosJsConfig)
+  return makeEosBasedPluginInner(opts, eosCurrencyInfo, eosNetworkInfo)
 }

--- a/src/eos/eosPlugin.ts
+++ b/src/eos/eosPlugin.ts
@@ -1,8 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-/* global */
-
 import { div, toFixed } from 'biggystring'
 import {
   EdgeCorePluginOptions,

--- a/src/eos/eosSchema.ts
+++ b/src/eos/eosSchema.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/27/17.
- */
-
 import {
   asArray,
   asBoolean,

--- a/src/eos/eosTypes.ts
+++ b/src/eos/eosTypes.ts
@@ -10,6 +10,12 @@ export interface EosNetworkInfo {
   uriProtocol: string
 }
 
+export const eosOtherMethodNames = [
+  'getActivationCost',
+  'getActivationSupportedCurrencies',
+  'validateAccount'
+] as const
+
 export interface EosTransactionSuperNode {
   act: {
     data: {

--- a/src/eos/eosTypes.ts
+++ b/src/eos/eosTypes.ts
@@ -1,3 +1,5 @@
+import { EdgeFetchFunction } from 'edge-core-js'
+
 export interface EosSettings {
   eosHyperionNodes: string[]
   eosNodes: string[]
@@ -20,10 +22,8 @@ export interface EosTransactionSuperNode {
 
 export interface EosTransaction {
   block_time: string
-  // @ts-expect-error
   block_num: number
   account_action_seq: number
-  // @ts-expect-error
   trx_id: string
   act: {
     authorization: any
@@ -38,11 +38,7 @@ export interface EosTransaction {
     name: string
   }
   '@timestamp': string
-  // @ts-expect-error
-  block_num: number
   producer: string
-  // @ts-expect-error
-  trx_id: string
   parent: number
   global_sequence: number
   notified: string[]
@@ -85,6 +81,6 @@ export interface EosJsConfig {
   chainId: string
   keyProvider: any[]
   httpEndpoint: string
-  fetch: Function
+  fetch: EdgeFetchFunction
   verbose: boolean // verbose logging such as API activity
 }

--- a/src/eos/eosTypes.ts
+++ b/src/eos/eosTypes.ts
@@ -1,8 +1,13 @@
-import { EdgeFetchFunction } from 'edge-core-js'
+export interface EosNetworkInfo {
+  chainId: string
 
-export interface EosSettings {
+  createAccountViaSingleApiEndpoints?: string[]
+  eosActivationServers: string[]
+  eosDfuseServers: string[]
+  eosFuelServers: string[]
   eosHyperionNodes: string[]
   eosNodes: string[]
+  uriProtocol: string
 }
 
 export interface EosTransactionSuperNode {
@@ -75,12 +80,4 @@ export interface EosWalletOtherData {
   lastQueryActionSeq: { [string]: number }
   // @ts-expect-error
   highestTxHeight: { [string]: number }
-}
-
-export interface EosJsConfig {
-  chainId: string
-  keyProvider: any[]
-  httpEndpoint: string
-  fetch: EdgeFetchFunction
-  verbose: boolean // verbose logging such as API activity
 }

--- a/src/eos/eosTypes.ts
+++ b/src/eos/eosTypes.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 export interface EosSettings {
   eosHyperionNodes: string[]
   eosNodes: string[]

--- a/src/eos/index.ts
+++ b/src/eos/index.ts
@@ -1,9 +1,9 @@
-import { makeEosPlugin } from './eosInfo'
-import { makeTelosPlugin } from './telosInfo'
-import { makeWaxPlugin } from './waxInfo'
+import { eos } from './eosInfo'
+import { telos } from './telosInfo'
+import { wax } from './waxInfo'
 
 export const eosPlugins = {
-  eos: makeEosPlugin,
-  telos: makeTelosPlugin,
-  wax: makeWaxPlugin
+  eos,
+  telos,
+  wax
 }

--- a/src/eos/telosInfo.ts
+++ b/src/eos/telosInfo.ts
@@ -1,7 +1,8 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosNetworkInfo } from './eosTypes'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { EosTools } from './eosPlugin'
+import { EosNetworkInfo, eosOtherMethodNames } from './eosTypes'
 
 // ----TELOS MAIN NET----
 export const telosNetworkInfo: EosNetworkInfo = {
@@ -44,7 +45,12 @@ export const telosCurrencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeTelosPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, telosCurrencyInfo, telosNetworkInfo)
-}
+export const telos = makeOuterPlugin<EosNetworkInfo, EosTools>({
+  currencyInfo: telosCurrencyInfo,
+  networkInfo: telosNetworkInfo,
+  otherMethodNames: eosOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./eosPlugin')
+  }
+})

--- a/src/eos/telosInfo.ts
+++ b/src/eos/telosInfo.ts
@@ -1,6 +1,3 @@
-/**
- * Created by on 2020-02-14
- */
 /* global fetch */
 
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'

--- a/src/eos/telosInfo.ts
+++ b/src/eos/telosInfo.ts
@@ -1,17 +1,21 @@
-/* global fetch */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosJsConfig, EosSettings } from './eosTypes'
+import { EosNetworkInfo } from './eosTypes'
 
 // ----TELOS MAIN NET----
-export const eosJsConfig: EosJsConfig = {
+export const telosNetworkInfo: EosNetworkInfo = {
   chainId: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11', // Telos main net
-  keyProvider: [],
-  httpEndpoint: '', // main net
-  fetch: fetch,
-  verbose: false // verbose logging such as API activity
+
+  eosActivationServers: [
+    'https://eospay.edge.app',
+    'https://account.teloscrew.com'
+  ],
+  eosHyperionNodes: ['https://telos.caleos.io'],
+  eosNodes: ['https://telos.caleos.io'],
+  eosFuelServers: [], // this will need to be fixed
+  eosDfuseServers: [],
+  uriProtocol: 'telos'
 }
 
 const denominations = [
@@ -22,50 +26,14 @@ const denominations = [
   }
 ]
 
-const otherSettings: EosSettings = {
-  // @ts-expect-error
-  eosActivationServers: [
-    'https://eospay.edge.app',
-    'https://account.teloscrew.com'
-  ],
-  // used for the following routines, is Hyperion v2:
-
-  // getIncomingTransactions
-  // `/v2/history/get_transfers?to=${acct}&symbol=${currencyCode}&skip=${skip}&limit=${limit}&sort=desc`
-
-  // getOutgoingTransactions
-  // `/v2/history/get_actions?transfer.from=${acct}&transfer.symbol=${currencyCode}&skip=${skip}&limit=${limit}&sort=desc`
-
-  // getKeyAccounts
-  // `${server}/v2/state/get_key_accounts?public_key=${params[0]}`
-
-  eosHyperionNodes: ['https://telos.caleos.io'],
-
-  // used for eosjs fetch routines
-  // getCurrencyBalance
-  // getInfo
-  // transaction
-  eosNodes: ['https://telos.caleos.io'],
-  eosFuelServers: [], // this will need to be fixed
-  eosDfuseServers: [],
-  uriProtocol: 'telos'
-}
-
-const defaultSettings: any = {
-  otherSettings
-}
-
 export const telosCurrencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'TLOS',
   displayName: 'Telos',
   pluginId: 'telos',
-  // @ts-expect-error
-  pluginName: 'telos',
-  // do we need plugin name?
   walletType: 'wallet:telos',
 
-  defaultSettings,
+  defaultSettings: {},
 
   memoMaxLength: 256,
 
@@ -78,5 +46,5 @@ export const telosCurrencyInfo: EdgeCurrencyInfo = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const makeTelosPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, telosCurrencyInfo, eosJsConfig)
+  return makeEosBasedPluginInner(opts, telosCurrencyInfo, telosNetworkInfo)
 }

--- a/src/eos/waxInfo.ts
+++ b/src/eos/waxInfo.ts
@@ -1,6 +1,3 @@
-/**
- * Created by on 2020-02-14
- */
 /* global fetch */
 
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'

--- a/src/eos/waxInfo.ts
+++ b/src/eos/waxInfo.ts
@@ -1,7 +1,8 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosNetworkInfo } from './eosTypes'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { EosTools } from './eosPlugin'
+import { EosNetworkInfo, eosOtherMethodNames } from './eosTypes'
 
 // ----WAX MAIN NET----
 export const waxNetworkInfo: EosNetworkInfo = {
@@ -45,7 +46,12 @@ export const waxCurrencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeWaxPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, waxCurrencyInfo, waxNetworkInfo)
-}
+export const wax = makeOuterPlugin<EosNetworkInfo, EosTools>({
+  currencyInfo: waxCurrencyInfo,
+  networkInfo: waxNetworkInfo,
+  otherMethodNames: eosOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./eosPlugin')
+  }
+})

--- a/src/eos/waxInfo.ts
+++ b/src/eos/waxInfo.ts
@@ -1,9 +1,22 @@
-/* global fetch */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEosBasedPluginInner } from './eosPlugin'
-import { EosJsConfig, EosSettings } from './eosTypes'
+import { EosNetworkInfo } from './eosTypes'
+
+// ----WAX MAIN NET----
+export const waxNetworkInfo: EosNetworkInfo = {
+  chainId: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4', // Wax main net
+
+  createAccountViaSingleApiEndpoints: [
+    'https://edge.maltablock.org/api/v1/activateAccount'
+  ],
+  eosActivationServers: [],
+  eosDfuseServers: [],
+  eosFuelServers: [], // this will need to be fixed
+  eosHyperionNodes: ['https://api.waxsweden.org'],
+  eosNodes: ['https://api.waxsweden.org'],
+  uriProtocol: 'wax'
+}
 
 const denominations = [
   // An array of Objects of the possible denominations for this currency
@@ -14,59 +27,14 @@ const denominations = [
   }
 ]
 
-// ----WAX MAIN NET----
-export const eosJsConfig: EosJsConfig = {
-  chainId: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4', // Wax main net
-  keyProvider: [],
-  httpEndpoint: '', // main net
-  fetch: fetch,
-  verbose: false // verbose logging such as API activity
-}
-
-const otherSettings: EosSettings = {
-  // @ts-expect-error
-  eosActivationServers: [],
-  // used for the following routines, is Hyperion v2:
-
-  // getIncomingTransactions
-  // `/v2/history/get_transfers?to=${acct}&symbol=${currencyCode}&skip=${skip}&limit=${limit}&sort=desc`
-
-  // getOutgoingTransactions
-  // `/v2/history/get_actions?transfer.from=${acct}&transfer.symbol=${currencyCode}&skip=${skip}&limit=${limit}&sort=desc`
-
-  // getKeyAccounts
-  // `${server}/v2/state/get_key_accounts?public_key=${params[0]}`
-
-  eosHyperionNodes: ['https://api.waxsweden.org'],
-
-  // used for eosjs fetch routines
-  // getCurrencyBalance
-  // getInfo
-  // transaction
-  eosNodes: ['https://api.waxsweden.org'],
-  eosFuelServers: [], // this will need to be fixed
-  eosDfuseServers: [],
-  uriProtocol: 'wax',
-  createAccountViaSingleApiEndpoints: [
-    'https://edge.maltablock.org/api/v1/activateAccount'
-  ]
-}
-
-const defaultSettings: any = {
-  otherSettings
-}
-
 export const waxCurrencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'WAX',
   displayName: 'Wax',
   pluginId: 'wax',
-  // @ts-expect-error
-  pluginName: 'wax',
-  // do we need plugin name?
   walletType: 'wallet:wax',
 
-  defaultSettings,
+  defaultSettings: {},
 
   memoMaxLength: 256,
 
@@ -79,5 +47,5 @@ export const waxCurrencyInfo: EdgeCurrencyInfo = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const makeWaxPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEosBasedPluginInner(opts, waxCurrencyInfo, eosJsConfig)
+  return makeEosBasedPluginInner(opts, waxCurrencyInfo, waxNetworkInfo)
 }

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 7/7/17.
- */
-
 import Common from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 import WalletConnect from '@walletconnect/client'

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -70,8 +70,7 @@ import {
 const walletConnectors: WalletConnectors = {}
 
 export class EthereumEngine extends CurrencyEngine<EthereumTools> {
-  // @ts-expect-error
-  otherData: EthereumWalletOtherData
+  otherData!: EthereumWalletOtherData
   initOptions: EthereumInitOptions
   ethNetwork: EthereumNetwork
   lastEstimatedGasLimit: LastEstimatedGasLimit

--- a/src/ethereum/ethInfos.ts
+++ b/src/ethereum/ethInfos.ts
@@ -1,31 +1,31 @@
-import { makeAvalanchePlugin } from './info/avaxInfo'
-import { makeBinanceSmartChainPlugin } from './info/bscInfo'
-import { makeCeloPlugin } from './info/celoInfo'
-import { makeEthereumClassicPlugin } from './info/etcInfo'
-import { makeEthDevPlugin } from './info/ethDevInfo'
-import { makeEthereumPlugin } from './info/ethInfo'
-import { makeEthereumPoWPlugin } from './info/ethwInfo'
-import { makeFantomPlugin } from './info/ftmInfo'
-import { makeGoerliPlugin } from './info/goerliInfo'
-import { makeKovanPlugin } from './info/kovanInfo'
-import { makePolygonPlugin } from './info/maticInfo'
-import { makeRinkebyPlugin } from './info/rinkebyInfo'
-import { makeRopstenPlugin } from './info/ropstenInfo'
-import { makeRskPlugin } from './info/rskInfo'
+import { avalanche } from './info/avaxInfo'
+import { binancesmartchain } from './info/bscInfo'
+import { celo } from './info/celoInfo'
+import { ethereumclassic } from './info/etcInfo'
+import { ethDev } from './info/ethDevInfo'
+import { ethereum } from './info/ethInfo'
+import { ethereumpow } from './info/ethwInfo'
+import { fantom } from './info/ftmInfo'
+import { goerli } from './info/goerliInfo'
+import { kovan } from './info/kovanInfo'
+import { polygon } from './info/maticInfo'
+import { rinkeby } from './info/rinkebyInfo'
+import { ropsten } from './info/ropstenInfo'
+import { rsk } from './info/rskInfo'
 
 export const ethPlugins = {
-  avalanche: makeAvalanchePlugin,
-  binancesmartchain: makeBinanceSmartChainPlugin,
-  celo: makeCeloPlugin,
-  ethDev: makeEthDevPlugin,
-  ethereum: makeEthereumPlugin,
-  ethereumclassic: makeEthereumClassicPlugin,
-  ethereumpow: makeEthereumPoWPlugin,
-  fantom: makeFantomPlugin,
-  goerli: makeGoerliPlugin,
-  kovan: makeKovanPlugin,
-  polygon: makePolygonPlugin,
-  rinkeby: makeRinkebyPlugin,
-  ropsten: makeRopstenPlugin,
-  rsk: makeRskPlugin
+  avalanche,
+  binancesmartchain,
+  celo,
+  ethDev,
+  ethereum,
+  ethereumclassic,
+  ethereumpow,
+  fantom,
+  goerli,
+  kovan,
+  polygon,
+  rinkeby,
+  ropsten,
+  rsk
 }

--- a/src/ethereum/ethInfos.ts
+++ b/src/ethereum/ethInfos.ts
@@ -14,18 +14,18 @@ import { makeRopstenPlugin } from './info/ropstenInfo'
 import { makeRskPlugin } from './info/rskInfo'
 
 export const ethPlugins = {
+  avalanche: makeAvalanchePlugin,
   binancesmartchain: makeBinanceSmartChainPlugin,
+  celo: makeCeloPlugin,
+  ethDev: makeEthDevPlugin,
   ethereum: makeEthereumPlugin,
   ethereumclassic: makeEthereumClassicPlugin,
   ethereumpow: makeEthereumPoWPlugin,
-  ethDev: makeEthDevPlugin,
   fantom: makeFantomPlugin,
   goerli: makeGoerliPlugin,
   kovan: makeKovanPlugin,
+  polygon: makePolygonPlugin,
   rinkeby: makeRinkebyPlugin,
   ropsten: makeRopstenPlugin,
-  rsk: makeRskPlugin,
-  polygon: makePolygonPlugin,
-  celo: makeCeloPlugin,
-  avalanche: makeAvalanchePlugin
+  rsk: makeRskPlugin
 }

--- a/src/ethereum/ethPlugin.ts
+++ b/src/ethereum/ethPlugin.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-
 import { getLocalStorage } from '@walletconnect/browser-utils'
 import { div } from 'biggystring'
 import { entropyToMnemonic, mnemonicToSeedSync, validateMnemonic } from 'bip39'

--- a/src/ethereum/ethPlugin.ts
+++ b/src/ethereum/ethPlugin.ts
@@ -3,11 +3,7 @@ import { div } from 'biggystring'
 import { entropyToMnemonic, mnemonicToSeedSync, validateMnemonic } from 'bip39'
 import { Buffer } from 'buffer'
 import {
-  EdgeCorePluginOptions,
-  EdgeCurrencyEngine,
-  EdgeCurrencyEngineOptions,
   EdgeCurrencyInfo,
-  EdgeCurrencyPlugin,
   EdgeCurrencyTools,
   EdgeEncodeUri,
   EdgeIo,
@@ -19,16 +15,17 @@ import {
 import EthereumUtil from 'ethereumjs-util'
 import hdKey from 'ethereumjs-wallet/hdkey'
 
+import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
-import { biggyScience, getDenomInfo, getFetchCors } from '../common/utils'
-import { EthereumEngine } from './ethEngine'
+import { biggyScience, getDenomInfo } from '../common/utils'
 import { ethPlugins } from './ethInfos'
 
 export class EthereumTools implements EdgeCurrencyTools {
   io: EdgeIo
   currencyInfo: EdgeCurrencyInfo
 
-  constructor(io: EdgeIo, currencyInfo: EdgeCurrencyInfo) {
+  constructor(env: PluginEnvironment<{}>) {
+    const { io, currencyInfo } = env
     this.io = io
     this.currencyInfo = currencyInfo
   }
@@ -363,71 +360,18 @@ export class EthereumTools implements EdgeCurrencyTools {
   }
 }
 
-export function makeEthereumBasedPluginInner(
-  opts: EdgeCorePluginOptions,
-  currencyInfo: EdgeCurrencyInfo
-): EdgeCurrencyPlugin {
-  const { io, initOptions } = opts
-  const fetchCors = getFetchCors(opts)
+export async function makeCurrencyTools(
+  env: PluginEnvironment<{}>
+): Promise<EthereumTools> {
+  const out = new EthereumTools(env)
 
-  let toolsPromise: Promise<EthereumTools>
-  async function makeCurrencyTools(): Promise<EthereumTools> {
-    if (toolsPromise != null) return await toolsPromise
-    toolsPromise = Promise.resolve(new EthereumTools(io, currencyInfo))
+  // FIXME: This clears locally stored walletconnect sessions that would otherwise prevent
+  // a user from reconnecting to an "active" but invisible connection. Future enhancement
+  // will restore these active sessions to the GUI
+  const wcStorage = getLocalStorage()
+  if (wcStorage != null) wcStorage.clear()
 
-    // FIXME: This clears locally stored walletconnect sessions that would otherwise prevent
-    // a user from reconnecting to an "active" but invisible connection. Future enhancement
-    // will restore these active sessions to the GUI
-    const wcStorage = getLocalStorage()
-    if (wcStorage != null) wcStorage.clear()
-
-    return await toolsPromise
-  }
-
-  async function makeCurrencyEngine(
-    walletInfo: EdgeWalletInfo,
-    opts: EdgeCurrencyEngineOptions
-  ): Promise<EdgeCurrencyEngine> {
-    const tools = await makeCurrencyTools()
-    const currencyEngine = new EthereumEngine(
-      tools,
-      walletInfo,
-      initOptions,
-      opts,
-      currencyInfo,
-      fetchCors
-    )
-
-    // Do any async initialization necessary for the engine
-    await currencyEngine.loadEngine(tools, walletInfo, opts)
-
-    // This is just to make sure otherData is Flow checked
-    // @ts-expect-error
-    currencyEngine.otherData = currencyEngine.walletLocalData.otherData
-
-    // Initialize otherData defaults if they weren't on disk
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!currencyEngine.otherData.nextNonce) {
-      currencyEngine.otherData.nextNonce = '0'
-    }
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!currencyEngine.otherData.unconfirmedNextNonce) {
-      currencyEngine.otherData.unconfirmedNextNonce = '0'
-    }
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!currencyEngine.otherData.networkFees) {
-      currencyEngine.otherData.networkFees = {
-        ...currencyInfo.defaultSettings.otherSettings.defaultNetworkFees
-      }
-    }
-
-    const out: EdgeCurrencyEngine = currencyEngine
-    return out
-  }
-
-  return {
-    currencyInfo,
-    makeCurrencyEngine,
-    makeCurrencyTools
-  }
+  return out
 }
+
+export { makeCurrencyEngine } from './ethEngine'

--- a/src/ethereum/ethSchema.ts
+++ b/src/ethereum/ethSchema.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/27/17.
- */
-
 export const EtherscanGetBlockHeight = {
   type: 'object',
   properties: {

--- a/src/ethereum/ethTypes.ts
+++ b/src/ethereum/ethTypes.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import WalletConnect from '@walletconnect/client'
 import {
   asArray,

--- a/src/ethereum/fees/ethMiningFees.ts
+++ b/src/ethereum/fees/ethMiningFees.ts
@@ -1,8 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- * @flow
- */
-
 import { add, div, gte, lt, lte, mul, sub } from 'biggystring'
 import { EdgeCurrencyInfo, EdgeSpendInfo } from 'edge-core-js/types'
 

--- a/src/ethereum/info/avaxInfo.ts
+++ b/src/ethereum/info/avaxInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/avaxInfo.ts
+++ b/src/ethereum/info/avaxInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 // Fees are in Wei
@@ -264,7 +265,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeAvalanchePlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const avalanche = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/bscInfo.ts
+++ b/src/ethereum/info/bscInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -86,7 +87,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeBinanceSmartChainPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const binancesmartchain = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -1,10 +1,7 @@
-import {
-  EdgeCorePluginOptions,
-  EdgeCurrencyInfo,
-  EdgeCurrencyPlugin
-} from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 // Fees are in Wei
@@ -116,8 +113,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-export const makeCeloPlugin = (
-  opts: EdgeCorePluginOptions
-): EdgeCurrencyPlugin => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const celo = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import {
   EdgeCorePluginOptions,
   EdgeCurrencyInfo,

--- a/src/ethereum/info/etcInfo.ts
+++ b/src/ethereum/info/etcInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/etcInfo.ts
+++ b/src/ethereum/info/etcInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -115,7 +116,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeEthereumClassicPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const ethereumclassic = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/ethDevInfo.ts
+++ b/src/ethereum/info/ethDevInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/ethDevInfo.ts
+++ b/src/ethereum/info/ethDevInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -164,7 +165,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeEthDevPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const ethDev = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/ethInfo.ts
+++ b/src/ethereum/info/ethInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/ethInfo.ts
+++ b/src/ethereum/info/ethInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -748,7 +749,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeEthereumPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const ethereum = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/ethwInfo.ts
+++ b/src/ethereum/info/ethwInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import {
   EdgeCorePluginOptions,
   EdgeCurrencyInfo,

--- a/src/ethereum/info/ethwInfo.ts
+++ b/src/ethereum/info/ethwInfo.ts
@@ -1,10 +1,7 @@
-import {
-  EdgeCorePluginOptions,
-  EdgeCurrencyInfo,
-  EdgeCurrencyPlugin
-} from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -100,8 +97,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-export const makeEthereumPoWPlugin = (
-  opts: EdgeCorePluginOptions
-): EdgeCurrencyPlugin => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const ethereumpow = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/ftmInfo.ts
+++ b/src/ethereum/info/ftmInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/ftmInfo.ts
+++ b/src/ethereum/info/ftmInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -357,7 +358,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeFantomPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const fantom = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/goerliInfo.ts
+++ b/src/ethereum/info/goerliInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/goerliInfo.ts
+++ b/src/ethereum/info/goerliInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -133,7 +134,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeGoerliPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const goerli = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/kovanInfo.ts
+++ b/src/ethereum/info/kovanInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/kovanInfo.ts
+++ b/src/ethereum/info/kovanInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -334,7 +335,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeKovanPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const kovan = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/maticInfo.ts
+++ b/src/ethereum/info/maticInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 // Fees are in Wei
@@ -259,7 +260,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makePolygonPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const polygon = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/maticInfo.ts
+++ b/src/ethereum/info/maticInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/rinkebyInfo.ts
+++ b/src/ethereum/info/rinkebyInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/rinkebyInfo.ts
+++ b/src/ethereum/info/rinkebyInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -133,7 +134,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeRinkebyPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const rinkeby = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/ropstenInfo.ts
+++ b/src/ethereum/info/ropstenInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/ropstenInfo.ts
+++ b/src/ethereum/info/ropstenInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -136,7 +137,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeRopstenPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+export const ropsten = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeEthereumBasedPluginInner } from '../ethPlugin'

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeEthereumBasedPluginInner } from '../ethPlugin'
+import { makeOuterPlugin } from '../../common/innerPlugin'
+import type { EthereumTools } from '../ethPlugin'
 import { EthereumFees, EthereumSettings } from '../ethTypes'
 
 const defaultNetworkFees: EthereumFees = {
@@ -92,7 +93,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
     }
   ]
 }
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeRskPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeEthereumBasedPluginInner(opts, currencyInfo)
-}
+
+export const rsk = makeOuterPlugin<{}, EthereumTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('../ethPlugin')
+  }
+})

--- a/src/fio/fioEngine.ts
+++ b/src/fio/fioEngine.ts
@@ -87,8 +87,7 @@ export class FioEngine extends CurrencyEngine<FioTools> {
   recentFioFee: RecentFioFee
   fioSdk!: FIOSDK
   fioSdkPreparedTrx!: FIOSDK
-  // @ts-expect-error
-  otherData: {
+  otherData!: {
     highestTxHeight: number
     fioAddresses: FioAddress[]
     fioDomains: FioDomain[]

--- a/src/fio/fioInfo.ts
+++ b/src/fio/fioInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { FIO_REQUESTS_TYPES } from './fioConst'

--- a/src/fio/fioInfo.ts
+++ b/src/fio/fioInfo.ts
@@ -1,6 +1,9 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
 import { FIO_REQUESTS_TYPES } from './fioConst'
+import type { FioTools } from './fioPlugin'
+import { fioOtherMethodNames } from './fioTypes'
 
 const defaultSettings: any = {
   apiUrls: [
@@ -72,3 +75,13 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const fio = makeOuterPlugin<{}, FioTools>({
+  currencyInfo,
+  networkInfo: {},
+  otherMethodNames: fioOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./fioPlugin')
+  }
+})

--- a/src/fio/fioPlugin.ts
+++ b/src/fio/fioPlugin.ts
@@ -1,5 +1,3 @@
-/* eslint camelcase: 0 */
-
 import { FIOSDK } from '@fioprotocol/fiosdk'
 import { Transactions } from '@fioprotocol/fiosdk/lib/transactions/Transactions'
 import { div } from 'biggystring'
@@ -12,16 +10,19 @@ import {
   EdgeCurrencyPlugin,
   EdgeCurrencyTools,
   EdgeEncodeUri,
+  EdgeFetchFunction,
   EdgeIo,
   EdgeParsedUri,
   EdgeWalletInfo
 } from 'edge-core-js/types'
 import ecc from 'eosjs-ecc'
 
+import { makeOtherMethods } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import {
   asyncWaterfall,
   getDenomInfo,
+  getFetchCors,
   pickRandom,
   safeErrorMessage,
   shuffleArray
@@ -53,10 +54,29 @@ export function checkAddress(address: string): boolean {
 export class FioTools implements EdgeCurrencyTools {
   io: EdgeIo
   currencyInfo: EdgeCurrencyInfo
+  connection: FIOSDK
+  fetchCors: EdgeFetchFunction
+  fioRegApiToken: string
 
-  constructor(io: EdgeIo) {
+  constructor(opts: EdgeCorePluginOptions) {
+    const { initOptions, io } = opts
+    const { tpid = 'finance@edge', fioRegApiToken = FIO_REG_SITE_API_KEY } =
+      initOptions
+
     this.io = io
     this.currencyInfo = currencyInfo
+    this.fetchCors = getFetchCors(opts)
+    this.fioRegApiToken = fioRegApiToken
+
+    const [baseUrl] = pickRandom(currencyInfo.defaultSettings.apiUrls, 1)
+    this.connection = new FIOSDK(
+      '',
+      '',
+      baseUrl,
+      this.fetchCors,
+      undefined,
+      tpid
+    )
   }
 
   async importPrivateKey(userInput: string): Promise<Object> {
@@ -151,24 +171,333 @@ export class FioTools implements EdgeCurrencyTools {
     const encodedUri = encodeUriCommon(obj, FIO_TYPE, amount)
     return encodedUri
   }
-}
 
-export function makeFioPlugin(opts: EdgeCorePluginOptions): EdgeCurrencyPlugin {
-  const { initOptions, io } = opts
-  const { fetchCors = io.fetch } = io
-  const { tpid = 'finance@edge', fioRegApiToken = FIO_REG_SITE_API_KEY } =
-    initOptions
-  const baseUrl = pickRandom(currencyInfo.defaultSettings.apiUrls, 1)[0]
-  const connection = new FIOSDK('', '', baseUrl, fetchCors, undefined, tpid)
+  //
+  // otherMethods
+  //
 
-  let toolsPromise: Promise<FioTools>
-  async function makeCurrencyTools(): Promise<FioTools> {
-    if (toolsPromise != null) return await toolsPromise
-    toolsPromise = Promise.resolve(new FioTools(io))
-    return await toolsPromise
+  async getConnectedPublicAddress(
+    fioAddress: string,
+    chainCode: string,
+    tokenCode: string
+  ): Promise<any> {
+    try {
+      FIOSDK.isFioAddressValid(fioAddress)
+    } catch (e: any) {
+      throw new FioError(
+        '',
+        400,
+        currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
+      )
+    }
+    try {
+      const isAvailableRes = await this.multicastServers('isAvailable', {
+        fioName: fioAddress
+      })
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (!isAvailableRes.is_registered) {
+        throw new FioError(
+          '',
+          404,
+          currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_EXIST
+        )
+      }
+    } catch (e: any) {
+      if (
+        e.name === 'FioError' &&
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        e.json &&
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        e.json.fields &&
+        e.errorCode === 400
+      ) {
+        e.labelCode =
+          currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
+      }
+
+      throw e
+    }
+    try {
+      const result = await this.multicastServers('getPublicAddress', {
+        fioAddress,
+        chainCode,
+        tokenCode
+      })
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (!result.public_address || result.public_address === '0') {
+        throw new FioError(
+          '',
+          404,
+          currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_LINKED
+        )
+      }
+      return result
+    } catch (e: any) {
+      if (
+        (e.name === 'FioError' &&
+          e.labelCode ===
+            currencyInfo.defaultSettings.errorCodes
+              .FIO_ADDRESS_IS_NOT_LINKED) ||
+        e.errorCode === 404
+      ) {
+        throw new FioError(
+          '',
+          404,
+          currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_LINKED
+        )
+      }
+      throw e
+    }
   }
 
-  async function multicastServers(
+  async isFioAddressValid(fioAddress: string): Promise<boolean> {
+    try {
+      return FIOSDK.isFioAddressValid(fioAddress)
+    } catch (e: any) {
+      return false
+    }
+  }
+
+  async validateAccount(
+    fioName: string,
+    isDomain: boolean = false
+  ): Promise<boolean> {
+    try {
+      if (isDomain) {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (!FIOSDK.isFioDomainValid(fioName)) return false
+      } else {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (!FIOSDK.isFioAddressValid(fioName)) return false
+      }
+    } catch (e: any) {
+      throw new FioError(
+        '',
+        400,
+        currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
+      )
+    }
+    try {
+      const isAvailableRes = await this.multicastServers('isAvailable', {
+        fioName
+      })
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      return !isAvailableRes.is_registered
+    } catch (e: any) {
+      if (
+        e.name === 'FioError' &&
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        e.json &&
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        e.json.fields &&
+        e.errorCode === 400
+      ) {
+        e.labelCode =
+          currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
+      }
+
+      throw e
+    }
+  }
+
+  async isDomainPublic(domain: string): Promise<boolean> {
+    const isAvailableRes = await this.multicastServers('isAvailable', {
+      fioName: domain
+    })
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (!isAvailableRes.is_registered)
+      throw new FioError(
+        '',
+        400,
+        currencyInfo.defaultSettings.errorCodes.FIO_DOMAIN_IS_NOT_EXIST
+      )
+    const result = await this.fetchCors(
+      `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.isDomainPublic}/${domain}`,
+      {
+        method: 'GET'
+      }
+    )
+    if (!result.ok) {
+      const data = await result.json()
+      throw new FioError(
+        '',
+        result.status,
+        currencyInfo.defaultSettings.errorCodes.IS_DOMAIN_PUBLIC_ERROR,
+        data
+      )
+    }
+    const { isPublic } = await result.json()
+    return isPublic
+  }
+
+  async doesAccountExist(fioName: string): Promise<boolean> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (!FIOSDK.isFioAddressValid(fioName)) return false
+    } catch (e: any) {
+      return false
+    }
+    try {
+      const isAvailableRes = await this.multicastServers('isAvailable', {
+        fioName
+      })
+
+      return isAvailableRes.is_registered
+    } catch (e: any) {
+      // @ts-expect-error
+      this.error('doesAccountExist error: ', e)
+      return false
+    }
+  }
+
+  async buyAddressRequest(
+    options: {
+      address: string
+      referralCode: string
+      publicKey: string
+      apiToken?: string
+    },
+    isFree: boolean = false
+  ): Promise<any> {
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+    if (isFree) {
+      options.apiToken = this.fioRegApiToken
+    }
+    try {
+      const result = await this.fetchCors(
+        `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.buyAddress}`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(options)
+        }
+      )
+      if (!result.ok) {
+        const data = await result.json()
+
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (fioRegApiErrorCodes[data.errorCode]) {
+          throw new FioError(
+            data.error,
+            result.status,
+            // @ts-expect-error
+            fioRegApiErrorCodes[data.errorCode],
+            data
+          )
+        }
+
+        if (data.error === 'Already registered') {
+          throw new FioError(
+            data.error,
+            result.status,
+            // @ts-expect-error
+            fioRegApiErrorCodes.ALREADY_REGISTERED,
+            data
+          )
+        }
+
+        throw new Error(data.error)
+      }
+      return await result.json()
+    } catch (e: any) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (e.labelCode) throw e
+      throw new FioError(
+        safeErrorMessage(e),
+        500,
+        currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
+      )
+    }
+  }
+
+  async getDomains(ref: string = ''): Promise<DomainItem[] | { error: any }> {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (!ref) ref = currencyInfo.defaultSettings.defaultRef
+    try {
+      const result = await this.fetchCors(
+        `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.getDomains}/${ref}`,
+        {
+          method: 'GET'
+        }
+      )
+      const json = await result.json()
+      if (!result.ok) {
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (fioRegApiErrorCodes[json.errorCode]) {
+          throw new FioError(
+            json.error,
+            result.status,
+            // @ts-expect-error
+            fioRegApiErrorCodes[json.errorCode],
+            json
+          )
+        }
+
+        throw new Error(json.error)
+      }
+      return json.domains
+    } catch (e: any) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (e.labelCode) throw e
+      throw new FioError(
+        safeErrorMessage(e),
+        500,
+        currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
+      )
+    }
+  }
+
+  async getStakeEstReturn(): Promise<number | { error: any }> {
+    try {
+      const result = await this.fetchCors(
+        `${currencyInfo.defaultSettings.fioStakingApyUrl}`,
+        {
+          method: 'GET'
+        }
+      )
+      const json: {
+        staked_token_pool: number
+        outstanding_srps: number
+        rewards_token_pool: number
+        combined_token_pool: number
+        staking_rewards_reserves_minted: number
+        roe: number
+        activated: boolean
+        historical_apr: {
+          '1day': number | null
+          '7day': number | null
+          '30day': number | null
+        }
+      } = await result.json()
+      if (!result.ok) {
+        throw new Error(currencyInfo.defaultSettings.errorCodes.SERVER_ERROR)
+      }
+      const apr = json.historical_apr['7day']
+      return (apr != null && apr > DEFAULT_APR) || apr == null
+        ? DEFAULT_APR
+        : apr
+    } catch (e: any) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (e.labelCode) throw e
+      throw new FioError(
+        e.message,
+        500,
+        currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
+      )
+    }
+  }
+
+  //
+  // Helpers
+  //
+
+  private async multicastServers(
     actionName: string,
     params?: any
   ): Promise<any> {
@@ -181,7 +510,7 @@ export function makeFioPlugin(opts: EdgeCorePluginOptions): EdgeCurrencyPlugin {
           Transactions.baseUrl = apiUrl
 
           try {
-            out = await connection.genericAction(actionName, params)
+            out = await this.connection.genericAction(actionName, params)
           } catch (e: any) {
             // handle FIO API error
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -216,6 +545,19 @@ export function makeFioPlugin(opts: EdgeCorePluginOptions): EdgeCurrencyPlugin {
     }
 
     return res
+  }
+}
+
+export function makeFioPlugin(opts: EdgeCorePluginOptions): EdgeCurrencyPlugin {
+  const { initOptions, io } = opts
+  const { fetchCors = io.fetch } = io
+  const { tpid = 'finance@edge' } = initOptions
+
+  let toolsPromise: Promise<FioTools>
+  async function makeCurrencyTools(): Promise<FioTools> {
+    if (toolsPromise != null) return await toolsPromise
+    toolsPromise = Promise.resolve(new FioTools(opts))
+    return await toolsPromise
   }
 
   async function makeCurrencyEngine(
@@ -271,318 +613,16 @@ export function makeFioPlugin(opts: EdgeCorePluginOptions): EdgeCurrencyPlugin {
     return out
   }
 
-  const otherMethods = {
-    async getConnectedPublicAddress(
-      fioAddress: string,
-      chainCode: string,
-      tokenCode: string
-    ) {
-      try {
-        FIOSDK.isFioAddressValid(fioAddress)
-      } catch (e: any) {
-        throw new FioError(
-          '',
-          400,
-          currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
-        )
-      }
-      try {
-        const isAvailableRes = await multicastServers('isAvailable', {
-          fioName: fioAddress
-        })
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!isAvailableRes.is_registered) {
-          throw new FioError(
-            '',
-            404,
-            currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_EXIST
-          )
-        }
-      } catch (e: any) {
-        if (
-          e.name === 'FioError' &&
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          e.json &&
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          e.json.fields &&
-          e.errorCode === 400
-        ) {
-          e.labelCode =
-            currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
-        }
-
-        throw e
-      }
-      try {
-        const result = await multicastServers('getPublicAddress', {
-          fioAddress,
-          chainCode,
-          tokenCode
-        })
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!result.public_address || result.public_address === '0') {
-          throw new FioError(
-            '',
-            404,
-            currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_LINKED
-          )
-        }
-        return result
-      } catch (e: any) {
-        if (
-          (e.name === 'FioError' &&
-            e.labelCode ===
-              currencyInfo.defaultSettings.errorCodes
-                .FIO_ADDRESS_IS_NOT_LINKED) ||
-          e.errorCode === 404
-        ) {
-          throw new FioError(
-            '',
-            404,
-            currencyInfo.defaultSettings.errorCodes.FIO_ADDRESS_IS_NOT_LINKED
-          )
-        }
-        throw e
-      }
-    },
-    async isFioAddressValid(fioAddress: string): Promise<boolean> {
-      try {
-        return FIOSDK.isFioAddressValid(fioAddress)
-      } catch (e: any) {
-        return false
-      }
-    },
-    async validateAccount(
-      fioName: string,
-      isDomain: boolean = false
-    ): Promise<boolean> {
-      try {
-        if (isDomain) {
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          if (!FIOSDK.isFioDomainValid(fioName)) return false
-        } else {
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          if (!FIOSDK.isFioAddressValid(fioName)) return false
-        }
-      } catch (e: any) {
-        throw new FioError(
-          '',
-          400,
-          currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
-        )
-      }
-      try {
-        const isAvailableRes = await multicastServers('isAvailable', {
-          fioName
-        })
-
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        return !isAvailableRes.is_registered
-      } catch (e: any) {
-        if (
-          e.name === 'FioError' &&
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          e.json &&
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          e.json.fields &&
-          e.errorCode === 400
-        ) {
-          e.labelCode =
-            currencyInfo.defaultSettings.errorCodes.INVALID_FIO_ADDRESS
-        }
-
-        throw e
-      }
-    },
-    // @ts-expect-error
-    async isDomainPublic(domain): Promise<boolean> {
-      const isAvailableRes = await multicastServers('isAvailable', {
-        fioName: domain
-      })
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      if (!isAvailableRes.is_registered)
-        throw new FioError(
-          '',
-          400,
-          currencyInfo.defaultSettings.errorCodes.FIO_DOMAIN_IS_NOT_EXIST
-        )
-      const result = await fetchCors(
-        `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.isDomainPublic}/${domain}`,
-        {
-          method: 'GET'
-        }
-      )
-      if (!result.ok) {
-        const data = await result.json()
-        throw new FioError(
-          '',
-          result.status,
-          currencyInfo.defaultSettings.errorCodes.IS_DOMAIN_PUBLIC_ERROR,
-          data
-        )
-      }
-      const { isPublic } = await result.json()
-      return isPublic
-    },
-    async doesAccountExist(fioName: string): Promise<boolean> {
-      try {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!FIOSDK.isFioAddressValid(fioName)) return false
-      } catch (e: any) {
-        return false
-      }
-      try {
-        const isAvailableRes = await multicastServers('isAvailable', {
-          fioName
-        })
-
-        return isAvailableRes.is_registered
-      } catch (e: any) {
-        // @ts-expect-error
-        this.error('doesAccountExist error: ', e)
-        return false
-      }
-    },
-    async buyAddressRequest(
-      options: {
-        address: string
-        referralCode: string
-        publicKey: string
-        apiToken?: string
-      },
-      isFree: boolean = false
-    ): Promise<any> {
-      const headers = {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      }
-      if (isFree) {
-        options.apiToken = fioRegApiToken
-      }
-      try {
-        const result = await fetchCors(
-          `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.buyAddress}`,
-          {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(options)
-          }
-        )
-        if (!result.ok) {
-          const data = await result.json()
-
-          // @ts-expect-error
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          if (fioRegApiErrorCodes[data.errorCode]) {
-            throw new FioError(
-              data.error,
-              result.status,
-              // @ts-expect-error
-              fioRegApiErrorCodes[data.errorCode],
-              data
-            )
-          }
-
-          if (data.error === 'Already registered') {
-            throw new FioError(
-              data.error,
-              result.status,
-              // @ts-expect-error
-              fioRegApiErrorCodes.ALREADY_REGISTERED,
-              data
-            )
-          }
-
-          throw new Error(data.error)
-        }
-        return await result.json()
-      } catch (e: any) {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (e.labelCode) throw e
-        throw new FioError(
-          safeErrorMessage(e),
-          500,
-          currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
-        )
-      }
-    },
-    async getDomains(ref: string = ''): Promise<DomainItem[] | { error: any }> {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      if (!ref) ref = currencyInfo.defaultSettings.defaultRef
-      try {
-        const result = await fetchCors(
-          `${currencyInfo.defaultSettings.fioRegApiUrl}${FIO_REG_API_ENDPOINTS.getDomains}/${ref}`,
-          {
-            method: 'GET'
-          }
-        )
-        const json = await result.json()
-        if (!result.ok) {
-          // @ts-expect-error
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          if (fioRegApiErrorCodes[json.errorCode]) {
-            throw new FioError(
-              json.error,
-              result.status,
-              // @ts-expect-error
-              fioRegApiErrorCodes[json.errorCode],
-              json
-            )
-          }
-
-          throw new Error(json.error)
-        }
-        return json.domains
-      } catch (e: any) {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (e.labelCode) throw e
-        throw new FioError(
-          safeErrorMessage(e),
-          500,
-          currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
-        )
-      }
-    },
-    async getStakeEstReturn(): Promise<number | { error: any }> {
-      try {
-        const result = await fetchCors(
-          `${currencyInfo.defaultSettings.fioStakingApyUrl}`,
-          {
-            method: 'GET'
-          }
-        )
-        const json: {
-          staked_token_pool: number
-          outstanding_srps: number
-          rewards_token_pool: number
-          combined_token_pool: number
-          staking_rewards_reserves_minted: number
-          roe: number
-          activated: boolean
-          historical_apr: {
-            '1day': number | null
-            '7day': number | null
-            '30day': number | null
-          }
-        } = await result.json()
-        if (!result.ok) {
-          throw new Error(currencyInfo.defaultSettings.errorCodes.SERVER_ERROR)
-        }
-        const apr = json.historical_apr['7day']
-        return (apr != null && apr > DEFAULT_APR) || apr == null
-          ? DEFAULT_APR
-          : apr
-      } catch (e: any) {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (e.labelCode) throw e
-        throw new FioError(
-          e.message,
-          500,
-          currencyInfo.defaultSettings.errorCodes.SERVER_ERROR
-        )
-      }
-    }
-  }
+  const otherMethods = makeOtherMethods(makeCurrencyTools, [
+    'getConnectedPublicAddress',
+    'isFioAddressValid',
+    'validateAccount',
+    'isDomainPublic',
+    'doesAccountExist',
+    'buyAddressRequest',
+    'getDomains',
+    'getStakeEstReturn'
+  ])
 
   return {
     currencyInfo,

--- a/src/fio/fioTypes.ts
+++ b/src/fio/fioTypes.ts
@@ -1,0 +1,10 @@
+export const fioOtherMethodNames = [
+  'getConnectedPublicAddress',
+  'isFioAddressValid',
+  'validateAccount',
+  'isDomainPublic',
+  'doesAccountExist',
+  'buyAddressRequest',
+  'getDomains',
+  'getStakeEstReturn'
+] as const

--- a/src/hedera/hederaEngine.ts
+++ b/src/hedera/hederaEngine.ts
@@ -1,6 +1,7 @@
 import * as hedera from '@hashgraph/sdk'
 import { add, eq, gt, toFixed } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeCurrencyInfo,
   EdgeFreshAddress,
@@ -15,6 +16,7 @@ import {
 import { base64 } from 'rfc4648'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import { bufToHex, hexToBuf, removeHexPrefix } from '../common/utils'
 import { HederaTools } from './hederaPlugin'
 import {
@@ -547,4 +549,18 @@ export class HederaEngine extends CurrencyEngine<HederaTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: HederaTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const { io, currencyInfo } = env
+  const engine = new HederaEngine(tools, walletInfo, opts, io, currencyInfo)
+
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  return engine
 }

--- a/src/hedera/hederaInfo.ts
+++ b/src/hedera/hederaInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeHederaPluginInner } from './hederaPlugin'

--- a/src/hedera/hederaInfo.ts
+++ b/src/hedera/hederaInfo.ts
@@ -1,7 +1,8 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeHederaPluginInner } from './hederaPlugin'
-import { HederaSettings } from './hederaTypes'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { HederaTools } from './hederaPlugin'
+import { hederaOtherMethodNames, HederaSettings } from './hederaTypes'
 
 const otherSettings: HederaSettings = {
   creatorApiServers: ['https://creator.myhbarwallet.com'],
@@ -46,7 +47,12 @@ const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeHederaPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeHederaPluginInner(opts, currencyInfo)
-}
+export const hedera = makeOuterPlugin<{}, HederaTools>({
+  currencyInfo,
+  networkInfo: {},
+  otherMethodNames: hederaOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./hederaPlugin')
+  }
+})

--- a/src/hedera/hederaTestnetInfo.ts
+++ b/src/hedera/hederaTestnetInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeHederaPluginInner } from './hederaPlugin'

--- a/src/hedera/hederaTestnetInfo.ts
+++ b/src/hedera/hederaTestnetInfo.ts
@@ -1,7 +1,8 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeHederaPluginInner } from './hederaPlugin'
-import { HederaSettings } from './hederaTypes'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { HederaTools } from './hederaPlugin'
+import { hederaOtherMethodNames, HederaSettings } from './hederaTypes'
 
 const otherSettings: HederaSettings = {
   creatorApiServers: ['https://creator.testnet.myhbarwallet.com'],
@@ -44,7 +45,12 @@ const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeHederaTestnetPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeHederaPluginInner(opts, currencyInfo)
-}
+export const hederatestnet = makeOuterPlugin<{}, HederaTools>({
+  currencyInfo,
+  networkInfo: {},
+  otherMethodNames: hederaOtherMethodNames,
+
+  async getInnerPlugin() {
+    return await import('./hederaPlugin')
+  }
+})

--- a/src/hedera/hederaTypes.ts
+++ b/src/hedera/hederaTypes.ts
@@ -8,6 +8,12 @@ export interface HederaSettings {
   maxFee: number
 }
 
+export const hederaOtherMethodNames = [
+  'getActivationSupportedCurrencies',
+  'getActivationCost',
+  'validateAccount'
+] as const
+
 export const asGetActivationCost = asObject({
   hbar: asString
 })

--- a/src/hedera/hederaUtils.ts
+++ b/src/hedera/hederaUtils.ts
@@ -1,37 +1,3 @@
-import {
-  EdgeCorePluginOptions,
-  EdgeCurrencyInfo,
-  EdgeIo
-} from 'edge-core-js/types'
-
-import { asGetActivationCost } from './hederaTypes'
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const getOtherMethods = (
-  opts: EdgeCorePluginOptions,
-  currencyInfo: EdgeCurrencyInfo,
-  io: EdgeIo = opts.io
-) => ({
-  getActivationSupportedCurrencies: () => ({ result: { ETH: true } }),
-  getActivationCost: async () => {
-    const creatorApiServer =
-      currencyInfo.defaultSettings.otherSettings.creatorApiServers[0]
-
-    try {
-      const response = await io.fetch(`${creatorApiServer}/account/cost`)
-      return asGetActivationCost(await response.json()).hbar
-    } catch (e: any) {
-      opts.log.warn(
-        'getActivationCost error unable to get account activation cost',
-        e
-      )
-      throw new Error('ErrorUnableToGetCost')
-    }
-  },
-  validateAccount: async () =>
-    await Promise.resolve({ result: 'AccountAvailable' })
-})
-
 export const validAddress = (address: string = ''): boolean => {
   // HIP-15
   return /^(0|(?:[1-9]\d*))\.(0|(?:[1-9]\d*))\.(0|(?:[1-9]\d*))(?:-([a-z]{5}))?$/.test(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,39 +1,38 @@
 import 'regenerator-runtime/runtime'
 
-import { makeBinancePlugin } from './binance/bnbPlugin'
+import { binance } from './binance/bnbInfo'
 import { eosPlugins } from './eos/index'
 import { ethPlugins } from './ethereum/ethInfos'
-import { makeFioPlugin } from './fio/fioPlugin'
-import { makeHederaPlugin } from './hedera/hederaInfo'
-import { makePolkadotPlugin } from './polkadot/polkadotInfo'
-import { makeSolanaPlugin } from './solana/solanaInfo'
-import { makeStellarPlugin } from './stellar/stellarPlugin'
-import { makeTezosPlugin } from './tezos/tezosPlugin'
-import { makeTronPlugin } from './tron/tronInfo'
-import { makeRipplePlugin } from './xrp/xrpPlugin'
-import { makeZcashPlugin } from './zcash/zecPlugin'
+import { fio } from './fio/fioInfo'
+import { hedera } from './hedera/hederaInfo'
+import { polkadot } from './polkadot/polkadotInfo'
+import { solana } from './solana/solanaInfo'
+import { stellar } from './stellar/stellarInfo'
+import { tezos } from './tezos/tezosInfo'
+import { tron } from './tron/tronInfo'
+import { ripple } from './xrp/xrpInfo'
+import { zcash } from './zcash/zecInfo'
 
 const plugins = {
   ...eosPlugins,
   ...ethPlugins,
-  binance: makeBinancePlugin,
-  fio: makeFioPlugin,
-  hedera: makeHederaPlugin,
-  polkadot: makePolkadotPlugin,
+  binance,
+  fio,
+  hedera,
+  polkadot,
   // "ripple" is network name. XRP is just an asset:
-  ripple: makeRipplePlugin,
-  solana: makeSolanaPlugin,
-  stellar: makeStellarPlugin,
-  tezos: makeTezosPlugin,
-  tron: makeTronPlugin,
-  zcash: makeZcashPlugin
+  ripple,
+  solana,
+  stellar,
+  tezos,
+  tron,
+  zcash
 }
 
 if (
   typeof window !== 'undefined' &&
   typeof window.addEdgeCorePlugins === 'function'
 ) {
-  // @ts-expect-error
   window.addEdgeCorePlugins(plugins)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-
 import 'regenerator-runtime/runtime'
 
 import { makeBinancePlugin } from './binance/bnbPlugin'

--- a/src/polkadot/polkadotEngine.ts
+++ b/src/polkadot/polkadotEngine.ts
@@ -1,5 +1,7 @@
 import { abs, add, div, gt, lte, mul, sub } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
+  EdgeCurrencyEngineOptions,
   EdgeSpendInfo,
   EdgeTransaction,
   EdgeWalletInfo,
@@ -9,6 +11,7 @@ import {
 } from 'edge-core-js/types'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import {
   cleanTxLogs,
   decimalToHex,
@@ -474,4 +477,21 @@ export class PolkadotEngine extends CurrencyEngine<PolkadotTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: PolkadotTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const engine = new PolkadotEngine(tools, walletInfo, opts)
+
+  // Do any async initialization necessary for the engine
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData
+
+  return engine
 }

--- a/src/polkadot/polkadotInfo.ts
+++ b/src/polkadot/polkadotInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makePolkadotPluginInner } from './polkadotPlugin'

--- a/src/polkadot/polkadotInfo.ts
+++ b/src/polkadot/polkadotInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makePolkadotPluginInner } from './polkadotPlugin'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { PolkadotTools } from './polkadotPlugin'
 import { PolkadotSettings } from './polkadotTypes'
 
 const otherSettings: PolkadotSettings = {
@@ -40,7 +41,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makePolkadotPlugin = (opts: EdgeCorePluginOptions) => {
-  return makePolkadotPluginInner(opts, currencyInfo)
-}
+export const polkadot = makeOuterPlugin<{}, PolkadotTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./polkadotPlugin')
+  }
+})

--- a/src/solana/solanaEngine.ts
+++ b/src/solana/solanaEngine.ts
@@ -2,6 +2,8 @@ import * as solanaWeb3 from '@solana/web3.js'
 import { add, gt, mul } from 'biggystring'
 import { asNumber } from 'cleaners'
 import {
+  EdgeCurrencyEngine,
+  EdgeCurrencyEngineOptions,
   EdgeFetchFunction,
   EdgeSpendInfo,
   EdgeTransaction,
@@ -12,7 +14,13 @@ import {
 } from 'edge-core-js/types'
 
 import { CurrencyEngine } from '../common/engine'
-import { asyncWaterfall, cleanTxLogs, getOtherParams } from '../common/utils'
+import { PluginEnvironment } from '../common/innerPlugin'
+import {
+  asyncWaterfall,
+  cleanTxLogs,
+  getFetchCors,
+  getOtherParams
+} from '../common/utils'
 import { SolanaTools } from './solanaPlugin'
 import {
   asRecentBlockHash,
@@ -439,4 +447,21 @@ export class SolanaEngine extends CurrencyEngine<SolanaTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: SolanaTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const engine = new SolanaEngine(tools, walletInfo, opts, getFetchCors(env))
+
+  // Do any async initialization necessary for the engine
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData as any
+
+  return engine
 }

--- a/src/solana/solanaEngine.ts
+++ b/src/solana/solanaEngine.ts
@@ -41,8 +41,7 @@ export class SolanaEngine extends CurrencyEngine<SolanaTools> {
   feePerSignature: string
   recentBlockhash: string
   chainCode: string
-  // @ts-expect-error
-  otherData: SolanaOtherData
+  otherData!: SolanaOtherData
   fetchCors: EdgeFetchFunction
   settings: SolanaSettings
   progressRatio: number

--- a/src/solana/solanaInfo.ts
+++ b/src/solana/solanaInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { makeSolanaPluginInner } from './solanaPlugin'

--- a/src/solana/solanaInfo.ts
+++ b/src/solana/solanaInfo.ts
@@ -1,6 +1,7 @@
-import { EdgeCorePluginOptions, EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeSolanaPluginInner } from './solanaPlugin'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { SolanaTools } from './solanaPlugin'
 import { SolanaSettings } from './solanaTypes'
 
 const otherSettings: SolanaSettings = {
@@ -42,7 +43,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   metaTokens: []
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const makeSolanaPlugin = (opts: EdgeCorePluginOptions) => {
-  return makeSolanaPluginInner(opts, currencyInfo)
-}
+export const solana = makeOuterPlugin<{}, SolanaTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./solanaPlugin')
+  }
+})

--- a/src/stellar/stellarEngine.ts
+++ b/src/stellar/stellarEngine.ts
@@ -1,6 +1,6 @@
 import { add, div, eq, gt, mul, sub } from 'biggystring'
-// import { currencyInfo } from './stellarInfo'
 import {
+  EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeSpendInfo,
   EdgeTransaction,
@@ -8,8 +8,10 @@ import {
   InsufficientFundsError,
   NoAmountSpecifiedError
 } from 'edge-core-js/types'
+import stellarApi from 'stellar-sdk'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import {
   asyncWaterfall,
   cleanTxLogs,
@@ -625,4 +627,29 @@ export class StellarEngine extends CurrencyEngine<StellarTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: StellarTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const engine = new StellarEngine(tools, walletInfo, opts)
+
+  engine.stellarApi = stellarApi
+
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData as any
+
+  if (engine.otherData.accountSequence == null) {
+    engine.otherData.accountSequence = 0
+  }
+  if (engine.otherData.lastPagingToken == null) {
+    engine.otherData.lastPagingToken = '0'
+  }
+
+  return engine
 }

--- a/src/stellar/stellarEngine.ts
+++ b/src/stellar/stellarEngine.ts
@@ -46,8 +46,7 @@ export class StellarEngine extends CurrencyEngine<StellarTools> {
   pendingTransactionsIndex: number
   pendingTransactionsMap: { [index: number]: Object }
   fees: { low: number; standard: number; high: number }
-  // @ts-expect-error
-  otherData: StellarWalletOtherData
+  otherData!: StellarWalletOtherData
 
   constructor(
     tools: StellarTools,

--- a/src/stellar/stellarEngine.ts
+++ b/src/stellar/stellarEngine.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 7/7/17.
- */
-
 import { add, div, eq, gt, mul, sub } from 'biggystring'
 // import { currencyInfo } from './stellarInfo'
 import {

--- a/src/stellar/stellarInfo.ts
+++ b/src/stellar/stellarInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { StellarSettings } from './stellarTypes'

--- a/src/stellar/stellarInfo.ts
+++ b/src/stellar/stellarInfo.ts
@@ -1,5 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { StellarTools } from './stellarPlugin'
 import { StellarSettings } from './stellarTypes'
 
 const otherSettings: StellarSettings = {
@@ -34,3 +36,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const stellar = makeOuterPlugin<{}, StellarTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./stellarPlugin')
+  }
+})

--- a/src/stellar/stellarPlugin.ts
+++ b/src/stellar/stellarPlugin.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-
 import { add, div } from 'biggystring'
 import {
   EdgeCorePluginOptions,

--- a/src/stellar/stellarTypes.ts
+++ b/src/stellar/stellarTypes.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import { asObject, asString } from 'cleaners'
 
 export interface StellarSettings {

--- a/src/tezos/tezosEngine.ts
+++ b/src/tezos/tezosEngine.ts
@@ -1,5 +1,6 @@
 import { add, div, eq, gt } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeFetchFunction,
   EdgeSpendInfo,
@@ -11,9 +12,11 @@ import {
 import { eztz } from 'eztz.js'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import {
   asyncWaterfall,
   cleanTxLogs,
+  getFetchCors,
   getOtherParams,
   makeMutex,
   promiseAny
@@ -508,4 +511,24 @@ export class TezosEngine extends CurrencyEngine<TezosTools> {
     }
     return ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: TezosTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const engine = new TezosEngine(tools, walletInfo, opts, getFetchCors(env))
+
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData
+
+  if (engine.otherData.numberTransactions == null) {
+    engine.otherData.numberTransaction = 0
+  }
+
+  return engine
 }

--- a/src/tezos/tezosInfo.ts
+++ b/src/tezos/tezosInfo.ts
@@ -1,5 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { TezosTools } from './tezosPlugin'
 import { TezosSettings } from './tezosTypes'
 
 const otherSettings: TezosSettings = {
@@ -58,3 +60,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const tezos = makeOuterPlugin<{}, TezosTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./tezosPlugin')
+  }
+})

--- a/src/tron/tronInfo.ts
+++ b/src/tron/tronInfo.ts
@@ -1,10 +1,7 @@
-import {
-  EdgeCorePluginOptions,
-  EdgeCurrencyInfo,
-  EdgeCurrencyPlugin
-} from 'edge-core-js/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { makeTronPluginInner } from './tronPlugin'
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { TronTools } from './tronPlugin'
 import { TronNetworkInfo } from './tronTypes'
 
 export const networkInfo: TronNetworkInfo = {
@@ -129,8 +126,11 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ]
 }
 
-export const makeTronPlugin = (
-  opts: EdgeCorePluginOptions
-): EdgeCurrencyPlugin => {
-  return makeTronPluginInner(opts, currencyInfo, networkInfo)
-}
+export const tron = makeOuterPlugin<TronNetworkInfo, TronTools>({
+  currencyInfo,
+  networkInfo,
+
+  async getInnerPlugin() {
+    return await import('./tronPlugin')
+  }
+})

--- a/src/xrp/xrpEngine.ts
+++ b/src/xrp/xrpEngine.ts
@@ -51,8 +51,7 @@ type XrpFunction =
   | 'submit'
 
 export class XrpEngine extends CurrencyEngine<RippleTools> {
-  // @ts-expect-error
-  otherData: XrpWalletOtherData
+  otherData!: XrpWalletOtherData
   xrpSettings: XrpSettings
 
   constructor(

--- a/src/xrp/xrpEngine.ts
+++ b/src/xrp/xrpEngine.ts
@@ -1,5 +1,6 @@
 import { add, eq, gt, lte, mul, sub } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeSpendInfo,
   EdgeTransaction,
@@ -10,6 +11,7 @@ import {
 import { rippleTimeToUnixTime, Wallet } from 'xrpl'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import { cleanTxLogs, getOtherParams, safeErrorMessage } from '../common/utils'
 import { PluginError, pluginErrorCodes, pluginErrorName } from '../pluginError'
 import { RippleTools } from './xrpPlugin'
@@ -439,4 +441,24 @@ export class XrpEngine extends CurrencyEngine<RippleTools> {
   getDisplayPublicSeed() {
     return this.walletInfo.keys?.publicKey ?? ''
   }
+}
+
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: RippleTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const engine = new XrpEngine(tools, walletInfo, opts)
+
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData as any
+
+  if (engine.otherData.recommendedFee == null) {
+    engine.otherData.recommendedFee = '0'
+  }
+
+  return engine
 }

--- a/src/xrp/xrpEngine.ts
+++ b/src/xrp/xrpEngine.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 7/7/17.
- */
-
 import { add, eq, gt, lte, mul, sub } from 'biggystring'
 import {
   EdgeCurrencyEngineOptions,

--- a/src/xrp/xrpInfo.ts
+++ b/src/xrp/xrpInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { XrpSettings } from './xrpTypes'

--- a/src/xrp/xrpInfo.ts
+++ b/src/xrp/xrpInfo.ts
@@ -1,5 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { RippleTools } from './xrpPlugin'
 import { XrpSettings } from './xrpTypes'
 
 const otherSettings: XrpSettings = {
@@ -42,3 +44,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const ripple = makeOuterPlugin<{}, RippleTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./xrpPlugin')
+  }
+})

--- a/src/xrp/xrpPlugin.ts
+++ b/src/xrp/xrpPlugin.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/8/17.
- */
-
 import { div } from 'biggystring'
 import {
   EdgeCorePluginOptions,

--- a/src/xrp/xrpTypes.ts
+++ b/src/xrp/xrpTypes.ts
@@ -1,7 +1,3 @@
-/**
- * Created by paul on 8/26/17.
- */
-
 import { asArray, asNumber, asObject, asString } from 'cleaners'
 
 export interface XrpSettings {

--- a/src/zcash/zecEngine.ts
+++ b/src/zcash/zecEngine.ts
@@ -1,5 +1,6 @@
 import { abs, add, eq, gt, lte, sub } from 'biggystring'
 import {
+  EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeCurrencyTools,
   EdgeSpendInfo,
@@ -10,6 +11,7 @@ import {
 } from 'edge-core-js/types'
 
 import { CurrencyEngine } from '../common/engine'
+import { PluginEnvironment } from '../common/innerPlugin'
 import { cleanTxLogs } from './../common/utils'
 import { ZcashTools } from './zecPlugin'
 import {
@@ -446,4 +448,22 @@ export class ZcashEngine extends CurrencyEngine<ZcashTools> {
       ...rpcNode
     }
   }
+}
+export async function makeCurrencyEngine(
+  env: PluginEnvironment<{}>,
+  tools: ZcashTools,
+  walletInfo: EdgeWalletInfo,
+  opts: EdgeCurrencyEngineOptions
+): Promise<EdgeCurrencyEngine> {
+  const { makeSynchronizer } = env.nativeIo['edge-currency-accountbased']
+
+  const engine = new ZcashEngine(tools, walletInfo, opts, makeSynchronizer)
+
+  // Do any async initialization necessary for the engine
+  await engine.loadEngine(tools, walletInfo, opts)
+
+  // This is just to make sure otherData is Flow checked
+  engine.otherData = engine.walletLocalData.otherData as any
+
+  return engine
 }

--- a/src/zcash/zecEngine.ts
+++ b/src/zcash/zecEngine.ts
@@ -24,22 +24,14 @@ import {
 
 export class ZcashEngine extends CurrencyEngine<ZcashTools> {
   pluginId: string
-  // @ts-expect-error
-  otherData: ZcashOtherData
-  // @ts-expect-error
-  synchronizer: ZcashSynchronizer
-  // @ts-expect-error
-  synchronizerStatus: ZcashSynchronizerStatus
-  // @ts-expect-error
-  availableZatoshi: string
-  // @ts-expect-error
-  initialNumBlocksToDownload: number
-  // @ts-expect-error
-  initializer: ZcashInitializerConfig
-  // @ts-expect-error
-  alias: string
-  // @ts-expect-error
-  progressRatio: number
+  otherData!: ZcashOtherData
+  synchronizer!: ZcashSynchronizer
+  synchronizerStatus!: ZcashSynchronizerStatus
+  availableZatoshi!: string
+  initialNumBlocksToDownload!: number
+  initializer!: ZcashInitializerConfig
+  alias!: string
+  progressRatio!: number
   makeSynchronizer: (
     config: ZcashInitializerConfig
   ) => Promise<ZcashSynchronizer>

--- a/src/zcash/zecInfo.ts
+++ b/src/zcash/zecInfo.ts
@@ -1,5 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
+import { makeOuterPlugin } from '../common/innerPlugin'
+import type { ZcashTools } from './zecPlugin'
 import { ZcashSettings } from './zecTypes'
 
 const otherSettings: ZcashSettings = {
@@ -43,3 +45,12 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
   metaTokens: []
 }
+
+export const zcash = makeOuterPlugin<{}, ZcashTools>({
+  currencyInfo,
+  networkInfo: {},
+
+  async getInnerPlugin() {
+    return await import('./zecPlugin')
+  }
+})

--- a/src/zcash/zecInfo.ts
+++ b/src/zcash/zecInfo.ts
@@ -1,5 +1,3 @@
-/* global */
-
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { ZcashSettings } from './zecTypes'


### PR DESCRIPTION
This improves the relationship between the currency plugins, currency infos, and currency engines, so we can split the heavy crypto libraries out of the main bundle.

It does not yet adjust the build settings to make this splitting happen.