### PR TITLE
Rebrand RSK to Rootstock - display name

### DIFF
--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -52,7 +52,7 @@ const networkInfo: EthereumNetworkInfo = {
   ercTokenStandard: 'RRC20',
   chainParams: {
     chainId: 30,
-    name: 'RSK Mainnet'
+    name: 'Rootstock Mainnet'
   },
   checkUnconfirmedTransactions: false,
   iosAllowedTokens: { RIF: true },
@@ -71,7 +71,7 @@ const defaultSettings: any = {
 export const currencyInfo: EdgeCurrencyInfo = {
   // Basic currency information:
   currencyCode: 'RBTC',
-  displayName: 'RSK',
+  displayName: 'Rootstock',
   pluginId: 'rsk',
   walletType: 'wallet:rsk',
   memoType: 'hex',


### PR DESCRIPTION
This pull request is to change the display name for RSK to Rootstock. 