### PR TITLE
Hedera: replace client balance query with mirror node

### DIFF
--- a/src/hedera/hederaTypes.ts
+++ b/src/hedera/hederaTypes.ts
@@ -24,6 +24,16 @@ export const asGetHederaAccount = asObject({
   )
 })
 
+export const asMirrorNodeQueryBalance = asObject({
+  balances: asArray(
+    asObject({
+      account: asString,
+      balance: asNumber
+      // tokens: []
+    })
+  )
+})
+
 export const asMirrorNodeTransactionResponse = asObject({
   transactions: asArray(
     asObject({


### PR DESCRIPTION
The account balance query isn't working and there isn't any context provided on the error. The error thrown is simply "Error". I couldn't find any relevant information about an outage so this seemed like a logical solution.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203696901426654