### PR TITLE
Move token validation into getTokenId

### DIFF
--- a/src/common/engine.ts
+++ b/src/common/engine.ts
@@ -815,6 +815,7 @@ export class CurrencyEngine<
     checkCustomToken(obj)
 
     const tokenObj: CustomToken = obj
+
     // If token is already in currencyInfo, error as it cannot be changed
     for (const tk of this.currencyInfo.metaTokens) {
       if (
@@ -823,23 +824,6 @@ export class CurrencyEngine<
       ) {
         throw new Error('ErrorCannotModifyToken')
       }
-    }
-
-    // Validate the token object
-    if (tokenObj.currencyCode.toUpperCase() !== tokenObj.currencyCode) {
-      throw new Error('ErrorInvalidCurrencyCode')
-    }
-    if (tokenObj.currencyCode.length < 2 || tokenObj.currencyCode.length > 7) {
-      throw new Error('ErrorInvalidCurrencyCodeLength')
-    }
-    if (tokenObj.currencyName.length < 3 || tokenObj.currencyName.length > 20) {
-      throw new Error('ErrorInvalidCurrencyNameLength')
-    }
-    if (
-      lt(tokenObj.multiplier, '1') ||
-      gt(tokenObj.multiplier, '100000000000000000000000000000000')
-    ) {
-      throw new Error('ErrorInvalidMultiplier')
     }
 
     for (const tk of this.customTokens) {

--- a/src/common/tokenHelpers.ts
+++ b/src/common/tokenHelpers.ts
@@ -1,5 +1,6 @@
+import { gt, lt } from 'biggystring'
 import { asMaybe, asObject, asString } from 'cleaners'
-import { EdgeMetaToken, EdgeTokenMap } from 'edge-core-js'
+import { EdgeMetaToken, EdgeToken, EdgeTokenMap } from 'edge-core-js'
 
 /**
  * The `networkLocation` field is untyped,
@@ -39,4 +40,39 @@ export const getTokenIdFromCurrencyCode = (
   for (const tokenId of Object.keys(allTokensMap)) {
     if (allTokensMap[tokenId].currencyCode === currencyCode) return tokenId
   }
+}
+
+/**
+ * Validates common things about a token, such as its currency code.
+ * Throws an exception if the token is wrong.
+ */
+export const validateToken = (token: EdgeToken): void => {
+  if (!isCurrencyCode(token.currencyCode)) {
+    throw new Error(`Invalid currency code "${token.currencyCode}"`)
+  }
+
+  // We cannot validate the display name, since it's for humans.
+  // Names like "AAVE Interest Bearing BAT" and "0x" would break
+  // the old length heuristic we had.
+
+  for (const denomination of token.denominations) {
+    if (!isCurrencyCode(denomination.name)) {
+      throw new Error(`Invalid denomination name "${denomination.name}"`)
+    }
+
+    if (
+      lt(denomination.multiplier, '1') ||
+      gt(denomination.multiplier, '100000000000000000000000000000000')
+    ) {
+      throw new Error('ErrorInvalidMultiplier')
+    }
+  }
+}
+
+/**
+ * Validates a currency code.
+ * Some weird but valid examples include: T, BUSD.e, xBOO, 1INCH, BADGER
+ */
+const isCurrencyCode = (code: string): boolean => {
+  return /^[.a-zA-Z0-9]+$/.test(code)
 }

--- a/src/eos/eosPlugin.ts
+++ b/src/eos/eosPlugin.ts
@@ -13,7 +13,7 @@ import EosApi from 'eosjs-api'
 import ecc from 'eosjs-ecc'
 
 import { PluginEnvironment } from '../common/innerPlugin'
-import { asMaybeContractLocation } from '../common/tokenHelpers'
+import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { asyncWaterfall, getDenomInfo, getFetchCors } from '../common/utils'
 import {
@@ -144,6 +144,7 @@ export class EosTools implements EdgeCurrencyTools {
   }
 
   async getTokenId(token: EdgeToken): Promise<string> {
+    validateToken(token)
     const cleanLocation = asMaybeContractLocation(token.networkLocation)
     if (cleanLocation == null || !checkAddress(cleanLocation.contractAddress)) {
       throw new Error('ErrorInvalidContractAddress')

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -1375,8 +1375,7 @@ export class EthereumEngine
     super.saveTx(edgeTransaction)
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  async addCustomToken(obj: CustomToken) {
+  async addCustomToken(obj: CustomToken): Promise<void> {
     const { contractAddress } = obj
     if (
       !isHex(contractAddress) ||
@@ -1384,8 +1383,7 @@ export class EthereumEngine
     ) {
       throw new Error('ErrorInvalidContractAddress')
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    super.addCustomToken(obj, contractAddress.toLowerCase())
+    await super.addCustomToken(obj, contractAddress.toLowerCase())
   }
 }
 

--- a/src/ethereum/ethPlugin.ts
+++ b/src/ethereum/ethPlugin.ts
@@ -16,7 +16,7 @@ import EthereumUtil from 'ethereumjs-util'
 import hdKey from 'ethereumjs-wallet/hdkey'
 
 import { PluginEnvironment } from '../common/innerPlugin'
-import { asMaybeContractLocation } from '../common/tokenHelpers'
+import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { biggyScience, getDenomInfo } from '../common/utils'
 import { ethPlugins } from './ethInfos'
@@ -346,6 +346,7 @@ export class EthereumTools implements EdgeCurrencyTools {
   }
 
   async getTokenId(token: EdgeToken): Promise<string> {
+    validateToken(token)
     const cleanLocation = asMaybeContractLocation(token.networkLocation)
     if (
       cleanLocation == null ||

--- a/src/tron/tronPlugin.ts
+++ b/src/tron/tronPlugin.ts
@@ -16,7 +16,7 @@ import EthereumUtil from 'ethereumjs-util'
 import hdKey from 'ethereumjs-wallet/hdkey'
 
 import { PluginEnvironment } from '../common/innerPlugin'
-import { asMaybeContractLocation } from '../common/tokenHelpers'
+import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
 import { asTronKeys, TronKeys, TronNetworkInfo } from './tronTypes'
@@ -142,6 +142,7 @@ export class TronTools implements EdgeCurrencyTools {
   }
 
   async getTokenId(token: EdgeToken): Promise<string> {
+    validateToken(token)
     const cleanLocation = asMaybeContractLocation(token.networkLocation)
     if (
       cleanLocation == null ||

--- a/src/xrp/xrpPlugin.ts
+++ b/src/xrp/xrpPlugin.ts
@@ -19,6 +19,7 @@ import {
 import ECDSA from 'xrpl/dist/npm/ECDSA'
 
 import { PluginEnvironment } from '../common/innerPlugin'
+import { validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { asyncWaterfall, getDenomInfo, safeErrorMessage } from '../common/utils'
 import { asXrpNetworkLocation, XrpNetworkInfo } from './xrpTypes'
@@ -163,6 +164,7 @@ export class RippleTools implements EdgeCurrencyTools {
   // issuer addresses can issue more than one token so we need
   // the currency code to make the token id unique
   async getTokenId(token: EdgeToken): Promise<string> {
+    validateToken(token)
     const location = token?.networkLocation
     if (location == null) {
       throw new Error('ErrorInvalidNetworkLocation')


### PR DESCRIPTION
The core requires `getTokenId` to validate its input, as opposed to `addCustomToken`.

We also need to loosen up the rules, since even our own builtin tokens would violate them.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203482303205169