### PR TITLE
Disallow top-level edge-core-js imports

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "name": "edge-core-js",
+        "message": "Use edge-core-js/types"
+      }
+    ]
+  }
+}

--- a/src/common/network.ts
+++ b/src/common/network.ts
@@ -3,7 +3,7 @@ import {
   EdgeFetchFunction,
   EdgeFetchOptions,
   EdgeFetchResponse
-} from 'edge-core-js'
+} from 'edge-core-js/types'
 
 import { asyncWaterfall, shuffleArray } from './utils'
 const INFO_SERVERS = ['https://info1.edge.app', 'https://info2.edge.app']

--- a/src/common/smartPay.ts
+++ b/src/common/smartPay.ts
@@ -1,6 +1,6 @@
 import { mul } from 'biggystring'
 import { asEither, asNumber, asObject, asString, asValue } from 'cleaners'
-import { EdgeIo, EdgeParsedUri, EdgeTokenMap } from 'edge-core-js'
+import { EdgeIo, EdgeParsedUri, EdgeTokenMap } from 'edge-core-js/types'
 
 import { cleanMultiFetch, makeQueryParams, QueryParams } from './network'
 import { computeCRC, formatPixKey } from './pixkey'

--- a/src/common/tokenHelpers.ts
+++ b/src/common/tokenHelpers.ts
@@ -1,6 +1,6 @@
 import { gt, lt } from 'biggystring'
 import { asMaybe, asObject, asString } from 'cleaners'
-import { EdgeMetaToken, EdgeToken, EdgeTokenMap } from 'edge-core-js'
+import { EdgeMetaToken, EdgeToken, EdgeTokenMap } from 'edge-core-js/types'
 
 /**
  * The `networkLocation` field is untyped,

--- a/src/ethereum/ethNetwork.ts
+++ b/src/ethereum/ethNetwork.ts
@@ -1,5 +1,5 @@
 import { add, div, mul, sub } from 'biggystring'
-import { EdgeTransaction, JsonObject } from 'edge-core-js'
+import { EdgeTransaction, JsonObject } from 'edge-core-js/types'
 import { FetchResponse } from 'serverlet'
 import parse from 'url-parse'
 

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -5,7 +5,7 @@ import {
   EdgeFetchFunction,
   EdgeLog,
   JsonObject
-} from 'edge-core-js'
+} from 'edge-core-js/types'
 
 import { fetchInfo } from '../../common/network'
 import { hexToDecimal, pickRandom } from '../../common/utils'

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -1,4 +1,4 @@
-import { EdgeOtherMethods } from 'edge-core-js'
+import { EdgeOtherMethods } from 'edge-core-js/types'
 import { NativeModules } from 'react-native'
 import {
   AddressTool as PiratechainAddressTool,

--- a/src/tron/tronTypes.ts
+++ b/src/tron/tronTypes.ts
@@ -11,7 +11,7 @@ import {
   asValue,
   Cleaner
 } from 'cleaners'
-import { JsonObject } from 'edge-core-js'
+import { JsonObject } from 'edge-core-js/types'
 
 export interface TronKeys {
   tronMnemonic?: string


### PR DESCRIPTION
We need to import edge-core-js/types to avoid pulling in extra stuff we don't need.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
