### PR TITLE
Add wallet connect v1 to Algorand

### DIFF
--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -211,8 +211,7 @@ export class AlgorandEngine extends CurrencyEngine<
         this.tools.walletConnectors[uri].walletId = walletId
       },
       wcDisconnect: (uri: string) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.tools.walletConnectors[uri].connector.killSession()
+        this.tools.walletConnectors[uri].connector.killSession().catch(() => {})
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete this.tools.walletConnectors[uri]
       },

--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -575,6 +575,19 @@ export class AlgorandEngine extends CurrencyEngine<
     return edgeTransaction
   }
 
+  async signMessage(message: string, privateKeys: JsonObject): Promise<string> {
+    const algorandPrivateKeys = asAlgorandPrivateKeys(
+      this.currencyInfo.pluginId
+    )(privateKeys)
+
+    const rawTx = decodeUnsignedTransaction(base64.parse(message))
+    const secretKey = algosdk.mnemonicToSecretKey(algorandPrivateKeys.mnemonic)
+    const signedTxBytes = rawTx.signTxn(secretKey.sk)
+    const signedTx = base64.stringify(signedTxBytes)
+
+    return signedTx
+  }
+
   async signTx(
     edgeTransaction: EdgeTransaction,
     privateKeys: JsonObject

--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -1,3 +1,4 @@
+import WalletConnect from '@walletconnect/client'
 import algosdk, {
   decodeUnsignedTransaction,
   encodeUnsignedTransaction,
@@ -22,26 +23,35 @@ import {
   JsonObject,
   NoAmountSpecifiedError
 } from 'edge-core-js/types'
-import { base16 } from 'rfc4648'
+import { base16, base64 } from 'rfc4648'
 
 import { CurrencyEngine } from '../common/engine'
 import { PluginEnvironment } from '../common/innerPlugin'
+import {
+  asWcSessionRequestParams,
+  WcDappDetails,
+  WcProps
+} from '../common/types'
 import {
   asyncWaterfall,
   cleanTxLogs,
   getOtherParams,
   makeMutex,
   matchJson,
-  Mutex
+  Mutex,
+  timeout
 } from '../common/utils'
 import { AlgorandTools } from './AlgorandTools'
 import {
   AccountInformation,
   AlgorandNetworkInfo,
+  AlgorandOtherMethods,
   AlgorandWalletOtherData,
+  AlgoWcRpcPayload,
   asAccountInformation,
   asAlgorandPrivateKeys,
   asAlgorandUnsignedTx,
+  asAlgorandWalletConnectPayload,
   asAlgorandWalletOtherData,
   asAxferTransaction,
   asBaseTxOpts,
@@ -74,6 +84,7 @@ export class AlgorandEngine extends CurrencyEngine<
   suggestedTransactionParams: SuggestedTransactionParams
   minimumAddressBalance: string
   totalReserve: string
+  otherMethods: AlgorandOtherMethods
 
   constructor(
     env: PluginEnvironment<AlgorandNetworkInfo>,
@@ -95,6 +106,152 @@ export class AlgorandEngine extends CurrencyEngine<
     }
     this.minimumAddressBalance = this.networkInfo.minimumAddressBalance
     this.totalReserve = this.minimumAddressBalance
+
+    this.otherMethods = {
+      // Wallet Connect utils
+      wcInit: async (
+        wcProps: WcProps,
+        walletName: string = 'Edge'
+      ): Promise<WcDappDetails> => {
+        return await timeout(
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          new Promise((resolve, reject) => {
+            const connector = new WalletConnect({
+              uri: wcProps.uri,
+              storageId: wcProps.uri,
+              clientMeta: {
+                description: 'Edge Wallet',
+                url: 'https://www.edge.app',
+                icons: ['https://content.edge.app/Edge_logo_Icon.png'],
+                name: walletName
+              }
+            })
+
+            connector.on(
+              'session_request',
+              (error: Error | null, payload: AlgoWcRpcPayload) => {
+                if (error != null) {
+                  this.error(`Wallet connect session_request`, error)
+                  throw error
+                }
+
+                const params = asWcSessionRequestParams(payload).params[0]
+                const dApp = { ...params, timeConnected: Date.now() / 1000 }
+
+                // Set connector in memory
+                this.tools.walletConnectors[wcProps.uri] = {
+                  connector,
+                  wcProps,
+                  dApp
+                }
+                resolve(dApp)
+              }
+            )
+
+            // Subscribe to call requests
+            connector.on(
+              'call_request',
+              (error: Error | null, payload: AlgoWcRpcPayload) => {
+                try {
+                  if (error != null) throw error
+                  const cleanPayload = asAlgorandWalletConnectPayload(payload)
+                  const params = cleanPayload.params[0][0]
+                  const algoTx = decodeUnsignedTransaction(
+                    base64.parse(params.txn)
+                  )
+
+                  const nativeAmount =
+                    algoTx.amount != null ? algoTx.amount.toString() : '0'
+                  const networkFee = algoTx.fee.toFixed()
+                  let tokenId: string | undefined
+
+                  if (algoTx.type === 'axfer') {
+                    const assetIndex = algoTx.assetIndex.toString()
+                    const metaToken: EdgeToken | undefined =
+                      this.allTokensMap[assetIndex]
+                    if (metaToken == null) throw new Error('Unrecognized token')
+                    tokenId = assetIndex
+                  }
+
+                  const out = {
+                    uri: wcProps.uri,
+                    dApp: this.tools.walletConnectors[wcProps.uri].dApp,
+                    payload: cleanPayload,
+                    walletId: this.tools.walletConnectors[wcProps.uri].walletId,
+                    nativeAmount,
+                    networkFee,
+                    tokenId // optional
+                  }
+
+                  this.currencyEngineCallbacks.onWcNewContractCall(out)
+                } catch (e: any) {
+                  this.warn(`Wallet connect call_request `, e)
+                  throw e
+                }
+              }
+            )
+
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            connector.on('disconnect', (error, payload) => {
+              if (error != null) {
+                throw error
+              }
+              // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+              delete this.tools.walletConnectors[wcProps.uri]
+            })
+          }),
+          5000
+        )
+      },
+      wcConnect: (uri: string, publicKey: string, walletId: string) => {
+        this.tools.walletConnectors[uri].connector.approveSession({
+          accounts: [publicKey],
+          chainId: 416001 // Not actually required in runtime. Using the placeholder value found in another implementation.
+        })
+        this.tools.walletConnectors[uri].walletId = walletId
+      },
+      wcDisconnect: (uri: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.tools.walletConnectors[uri].connector.killSession()
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete this.tools.walletConnectors[uri]
+      },
+      wcApproveRequest: async (
+        uri: string,
+        payload: AlgoWcRpcPayload,
+        result: string
+      ): Promise<void> => {
+        this.tools.walletConnectors[uri].connector.approveRequest({
+          id: parseInt(payload.id.toString()),
+          jsonrpc: '2.0',
+          result: [result]
+        })
+      },
+      wcRejectRequest: async (
+        uri: string,
+        payload: AlgoWcRpcPayload
+      ): Promise<void> => {
+        this.tools.walletConnectors[uri].connector.rejectRequest({
+          id: parseInt(payload.id.toString()),
+          jsonrpc: '2.0',
+          error: {
+            message: 'rejected'
+          }
+        })
+      },
+      wcGetConnections: () =>
+        Object.keys(this.tools.walletConnectors)
+          .filter(
+            uri =>
+              this.tools.walletConnectors[uri].walletId === this.walletInfo.id
+          )
+          .map(
+            uri => ({
+              ...this.tools.walletConnectors[uri].dApp,
+              ...this.tools.walletConnectors[uri].wcProps
+            }) // NOTE: keys are all the uris from the walletConnectors. This returns all the wsProps
+          )
+    }
   }
 
   setOtherData(raw: any): void {

--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -221,7 +221,7 @@ export class AlgorandEngine extends CurrencyEngine<
         result: string
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.approveRequest({
-          id: parseInt(payload.id.toString()),
+          id: Number(payload.id),
           jsonrpc: '2.0',
           result: [result]
         })
@@ -231,7 +231,7 @@ export class AlgorandEngine extends CurrencyEngine<
         payload: AlgoWcRpcPayload
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.rejectRequest({
-          id: parseInt(payload.id.toString()),
+          id: Number(payload.id),
           jsonrpc: '2.0',
           error: {
             message: 'rejected'

--- a/src/algorand/AlgorandTools.ts
+++ b/src/algorand/AlgorandTools.ts
@@ -15,6 +15,7 @@ import {
 
 import { PluginEnvironment } from '../common/innerPlugin'
 import { validateToken } from '../common/tokenHelpers'
+import { WalletConnectors } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
 import {
@@ -30,11 +31,15 @@ export class AlgorandTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
   currencyInfo: EdgeCurrencyInfo
 
+  walletConnectors: WalletConnectors
+
   constructor(env: PluginEnvironment<AlgorandNetworkInfo>) {
     const { builtinTokens, currencyInfo, io } = env
     this.io = io
     this.currencyInfo = currencyInfo
     this.builtinTokens = builtinTokens
+
+    this.walletConnectors = {}
   }
 
   async importPrivateKey(input: string): Promise<JsonObject> {
@@ -75,7 +80,7 @@ export class AlgorandTools implements EdgeCurrencyTools {
     customTokens?: EdgeMetaToken[]
   ): Promise<EdgeParsedUri> {
     const { pluginId } = this.currencyInfo
-    const networks = { [pluginId]: true }
+    const networks = { [pluginId]: true, wc: true }
 
     const { parsedUri, edgeParsedUri } = parseUriCommon(
       this.currencyInfo,
@@ -84,6 +89,20 @@ export class AlgorandTools implements EdgeCurrencyTools {
       currencyCode ?? this.currencyInfo.currencyCode,
       customTokens
     )
+
+    if (parsedUri.protocol === 'wc') {
+      if (parsedUri.query.bridge != null && parsedUri.query.key != null) {
+        edgeParsedUri.walletConnect = {
+          uri,
+          topic: parsedUri.pathname.split('@')[0],
+          version: parsedUri.pathname.split('@')[1],
+          bridge: parsedUri.query.bridge,
+          key: parsedUri.query.key
+        }
+        return edgeParsedUri
+      } else throw new Error('MissingWcBridgeKey')
+    }
+
     let address = ''
 
     if (edgeParsedUri.publicAddress != null) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -107,7 +107,7 @@ export type WcDappDetails = {
   timeConnected: number
 } & ReturnType<typeof asWcDappDetails>
 
-export type Dapp = { timeConnected: number } & WcProps & WcDappDetails
+export type Dapp = WcProps & WcDappDetails
 
 export interface WalletConnectors {
   [uri: string]: {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,4 @@
+import WalletConnect from '@walletconnect/client'
 import {
   asArray,
   asEither,
@@ -82,3 +83,41 @@ export function asIntegerString(raw: unknown): string {
   }
   return clean
 }
+
+export const asWcProps = asObject({
+  uri: asString,
+  language: asMaybe(asString),
+  token: asMaybe(asString)
+})
+
+export type WcProps = ReturnType<typeof asWcProps>
+
+const asWcDappDetails = asObject({
+  peerId: asString,
+  peerMeta: asObject({
+    description: asString,
+    url: asString,
+    icons: asArray(asString),
+    name: asString
+  }),
+  chainId: asOptional(asNumber, 1)
+})
+
+export type WcDappDetails = {
+  timeConnected: number
+} & ReturnType<typeof asWcDappDetails>
+
+export type Dapp = { timeConnected: number } & WcProps & WcDappDetails
+
+export interface WalletConnectors {
+  [uri: string]: {
+    connector: WalletConnect
+    wcProps: WcProps
+    dApp: WcDappDetails
+    walletId?: string
+  }
+}
+
+export const asWcSessionRequestParams = asObject({
+  params: asArray(asWcDappDetails)
+})

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -447,7 +447,7 @@ export class EthereumEngine extends CurrencyEngine<
         result: string
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.approveRequest({
-          id: parseInt(payload.id.toString()),
+          id: Number(payload.id),
           jsonrpc: '2.0',
           result: result
         })
@@ -457,7 +457,7 @@ export class EthereumEngine extends CurrencyEngine<
         payload: EvmWcRpcPayload
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.rejectRequest({
-          id: parseInt(payload.id.toString()),
+          id: Number(payload.id),
           jsonrpc: '2.0',
           error: {
             message: 'rejected'

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -437,8 +437,7 @@ export class EthereumEngine extends CurrencyEngine<
         this.tools.walletConnectors[uri].walletId = walletId
       },
       wcDisconnect: (uri: string) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.tools.walletConnectors[uri].connector.killSession()
+        this.tools.walletConnectors[uri].connector.killSession().catch(() => {})
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete this.tools.walletConnectors[uri]
       },

--- a/src/ethereum/ethEngine.ts
+++ b/src/ethereum/ethEngine.ts
@@ -26,7 +26,12 @@ import ethWallet from 'ethereumjs-wallet'
 
 import { CurrencyEngine } from '../common/engine'
 import { PluginEnvironment } from '../common/innerPlugin'
-import { CustomToken } from '../common/types'
+import {
+  asWcSessionRequestParams,
+  CustomToken,
+  WcDappDetails,
+  WcProps
+} from '../common/types'
 import {
   biggyRoundToNearestInt,
   bufToHex,
@@ -59,7 +64,6 @@ import {
   asRollupGasPrices,
   asRpcResultString,
   asSafeEthWalletInfo,
-  asWcSessionRequestParams,
   CalcL1RollupFeeParams,
   EIP712TypedDataParam,
   EthereumBaseMultiplier,
@@ -72,14 +76,12 @@ import {
   EthereumTxOtherParams,
   EthereumUtils,
   EthereumWalletOtherData,
+  EvmWcRpcPayload,
   KeysOfEthereumBaseMultiplier,
   L1RollupParams,
   LastEstimatedGasLimit,
   SafeEthWalletInfo,
-  TxRpcParams,
-  WcDappDetails,
-  WcProps,
-  WcRpcPayload
+  TxRpcParams
 } from './ethTypes'
 import { calcL1RollupFees, calcMiningFee } from './fees/ethMiningFees'
 import {
@@ -327,7 +329,7 @@ export class EthereumEngine extends CurrencyEngine<
             connector.on(
               'session_request',
               // @ts-expect-error
-              (error: Error, payload: WcRpcPayload) => {
+              (error: Error, payload: EvmWcRpcPayload) => {
                 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 if (error) {
                   this.error(`Wallet connect session_request`, error)
@@ -349,7 +351,7 @@ export class EthereumEngine extends CurrencyEngine<
             connector.on(
               'call_request',
               // @ts-expect-error
-              (error: Error, payload: WcRpcPayload) => {
+              (error: Error, payload: EvmWcRpcPayload) => {
                 try {
                   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                   if (error) throw error
@@ -415,7 +417,7 @@ export class EthereumEngine extends CurrencyEngine<
       },
       wcApproveRequest: async (
         uri: string,
-        payload: WcRpcPayload,
+        payload: EvmWcRpcPayload,
         result: string
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.approveRequest({
@@ -426,7 +428,7 @@ export class EthereumEngine extends CurrencyEngine<
       },
       wcRejectRequest: async (
         uri: string,
-        payload: WcRpcPayload
+        payload: EvmWcRpcPayload
       ): Promise<void> => {
         this.tools.walletConnectors[uri].connector.rejectRequest({
           id: parseInt(payload.id.toString()),

--- a/src/ethereum/ethPlugin.ts
+++ b/src/ethereum/ethPlugin.ts
@@ -18,10 +18,11 @@ import hdKey from 'ethereumjs-wallet/hdkey'
 
 import { PluginEnvironment } from '../common/innerPlugin'
 import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
+import { WalletConnectors } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { biggyScience, getDenomInfo } from '../common/utils'
 import { ethPlugins } from './ethInfos'
-import { EthereumNetworkInfo, WalletConnectors } from './ethTypes'
+import { EthereumNetworkInfo } from './ethTypes'
 
 export class EthereumTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap

--- a/src/ethereum/ethTypes.ts
+++ b/src/ethereum/ethTypes.ts
@@ -1,4 +1,3 @@
-import WalletConnect from '@walletconnect/client'
 import {
   asArray,
   asBoolean,
@@ -16,7 +15,12 @@ import {
 } from 'cleaners'
 import { EdgeSpendInfo } from 'edge-core-js/types'
 
-import { asSafeCommonWalletInfo } from '../common/types'
+import {
+  asSafeCommonWalletInfo,
+  Dapp,
+  WcDappDetails,
+  WcProps
+} from '../common/types'
 
 export interface EthereumInitOptions {
   blockcypherApiKey?: string
@@ -416,15 +420,7 @@ export interface EthereumUtils {
   txRpcParamsToSpendInfo: (params: TxRpcParams) => EdgeSpendInfo
 }
 
-export const asWcProps = asObject({
-  uri: asString,
-  language: asMaybe(asString),
-  token: asMaybe(asString)
-})
-
-export type WcProps = ReturnType<typeof asWcProps>
-
-export const asWcRpcPayload = asObject({
+export const asEvmWcRpcPayload = asObject({
   id: asEither(asString, asNumber),
   method: asValue(
     'personal_sign',
@@ -438,37 +434,7 @@ export const asWcRpcPayload = asObject({
   params: asArray(asUnknown)
 })
 
-export type WcRpcPayload = ReturnType<typeof asWcRpcPayload>
-
-const asWcDappDetails = asObject({
-  peerId: asString,
-  peerMeta: asObject({
-    description: asString,
-    url: asString,
-    icons: asArray(asString),
-    name: asString
-  }),
-  chainId: asOptional(asNumber, 1)
-})
-
-export type WcDappDetails = {
-  timeConnected: number
-} & ReturnType<typeof asWcDappDetails>
-
-export type Dapp = { timeConnected: number } & WcProps & WcDappDetails
-
-export interface WalletConnectors {
-  [uri: string]: {
-    connector: WalletConnect
-    wcProps: WcProps
-    dApp: WcDappDetails
-    walletId?: string
-  }
-}
-
-export const asWcSessionRequestParams = asObject({
-  params: asArray(asWcDappDetails)
-})
+export type EvmWcRpcPayload = ReturnType<typeof asEvmWcRpcPayload>
 
 //
 // Other Params and Other Methods:
@@ -481,10 +447,10 @@ export interface EthereumOtherMethods {
   wcDisconnect: (uri: string) => void
   wcApproveRequest: (
     uri: string,
-    payload: WcRpcPayload,
+    payload: EvmWcRpcPayload,
     result: string
   ) => Promise<void>
-  wcRejectRequest: (uri: string, payload: WcRpcPayload) => Promise<void>
+  wcRejectRequest: (uri: string, payload: EvmWcRpcPayload) => Promise<void>
   wcGetConnections: () => Dapp[]
 }
 


### PR DESCRIPTION
Wallet connect v1 functionality is directly managed by the engines. This PR updates the existing EVM integration to return more generic params (native amount, network fee, and tokenId) first and then adds wallet connect to Algorand. It's largely a copy/paste of the EVM handling with tweaks to handle the unique ALGO call_request response. 

Futher cleanups and optimizations were not attempted because wallet connect v1 is due to sunset at the end of June 2023.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204452616785593