### PR TITLE
Sam/zksync-min-fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Precision bug in min gas price checks for EVM currencies
+- Change: Lower zkSync minGasPrice to 0.01 gwei
 
 ## 1.2.2 (2023-05-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-currency-accountbased
 
+## Unreleased
+
+- Fix: Precision bug in min gas price checks for EVM currencies
+
 ## 1.2.2 (2023-05-01)
 
 - FIO: Update node list

--- a/src/ethereum/fees/ethMiningFees.ts
+++ b/src/ethereum/fees/ethMiningFees.ts
@@ -58,10 +58,10 @@ export function calcMiningFee(
           networkFees.default?.gasPrice?.minGasPrice ??
           networkInfo.defaultNetworkFees.default.gasPrice?.minGasPrice
         if (minGasPrice != null) {
-          const minGasPriceGwei = div(minGasPrice, WEI_MULTIPLIER)
-          if (lt(gasPrice, minGasPriceGwei) || /^\s*$/.test(gasPrice)) {
+          const gasPriceInWei = mul(gasPrice, WEI_MULTIPLIER)
+          if (lt(gasPriceInWei, minGasPrice) || /^\s*$/.test(gasPrice)) {
             const e = new Error(
-              `Gas Limit: ${gasLimit} Gas Price (Gwei): ${gasPrice}`
+              `Gas price ${gasPriceInWei} wei below minimum ${minGasPrice} wei`
             )
             e.name = 'ErrorBelowMinimumFee'
             throw e
@@ -80,7 +80,7 @@ export function calcMiningFee(
           /^\s*$/.test(gasLimit)
         ) {
           const e = new Error(
-            `Gas Limit: ${gasLimit} Gas Price (Gwei): ${gasPrice}`
+            `Gas limit ${gasLimit} below minimum ${minGasLimit}`
           )
           e.name = 'ErrorBelowMinimumFee'
           throw e

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -37,7 +37,7 @@ const defaultNetworkFees: EthereumFees = {
       standardFeeLowAmount: '100000000000000000',
       standardFeeHighAmount: '10000000000000000000',
       highFee: '40000000001',
-      minGasPrice: '1000000000'
+      minGasPrice: '10000000'
     },
     minPriorityFee: '2000000000'
   }


### PR DESCRIPTION
### CHANGELOG

- Fix: Precision bug in min gas price checks for EVM currencies
- Change: Lower zkSync minGasPrice to 0.01 gwei

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204532331054942