### PR TITLE
Include `data` from `memo` or `otherParams` for native currency spends

### DIFF
--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -815,6 +815,7 @@ export class EthereumEngine extends CurrencyEngine<
     if (currencyCode === currencyInfo.currencyCode) {
       value = nativeAmount == null ? undefined : decimalToHex(nativeAmount)
       return {
+        data,
         value
       }
     } else {


### PR DESCRIPTION
### CHANGELOG

Fixed: Critical bug that is missing data field for native EVM transactions including a memo

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204940534353339