### PR TITLE
Fix asMaybe object fallback values in shared otherData cleaner

### DIFF
--- a/src/fio/fioConst.ts
+++ b/src/fio/fioConst.ts
@@ -180,16 +180,16 @@ export const asFioWalletOtherData = asObject({
       PENDING: asArray(asFioRequest),
       SENT: asArray(asFioRequest)
     }),
-    {
+    () => ({
       SENT: [],
       PENDING: []
-    }
+    })
   ),
   srps: asMaybe(asNumber, 0),
   stakingRoe: asMaybe(asString, ''),
-  stakingStatus: asMaybe(asEdgeStakingStatus, {
+  stakingStatus: asMaybe(asEdgeStakingStatus, () => ({
     stakedAmounts: []
-  })
+  }))
 })
 
 export type FioWalletOtherData = ReturnType<typeof asFioWalletOtherData>

--- a/src/tron/tronTypes.ts
+++ b/src/tron/tronTypes.ts
@@ -65,7 +65,7 @@ export const asTronWalletOtherData = asObject({
       mainnet: asTxQueryCache,
       trc20: asTxQueryCache
     }),
-    {
+    () => ({
       mainnet: {
         txid: '',
         timestamp: 0
@@ -74,7 +74,7 @@ export const asTronWalletOtherData = asObject({
         txid: '',
         timestamp: 0
       }
-    }
+    })
   )
 })
 

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -99,10 +99,10 @@ export type ZcashBlockRange = ReturnType<typeof asZcashBlockRange>
 
 export const asZcashWalletOtherData = asObject({
   alias: asMaybe(asString),
-  blockRange: asMaybe(asZcashBlockRange, {
+  blockRange: asMaybe(asZcashBlockRange, () => ({
     first: 0,
     last: 0
-  })
+  }))
 })
 
 export type ZcashWalletOtherData = ReturnType<typeof asZcashWalletOtherData>


### PR DESCRIPTION
This cleaner is shared across engines and therefore the fallback object will be shared

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205131987503159