### PR TITLE
Update display-key methods

### DIFF
--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -708,17 +708,6 @@ export class AlgorandEngine extends CurrencyEngine<
     return edgeTransaction
   }
 
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const algorandPrivateKeys = asAlgorandPrivateKeys(
-      this.currencyInfo.pluginId
-    )(privateKeys)
-    return algorandPrivateKeys.mnemonic
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.publicKey ?? ''
-  }
-
   engineGetActivationAssets = async (
     options: EdgeEngineGetActivationAssetsOptions
   ): Promise<EdgeGetActivationAssetsResults> => {

--- a/src/algorand/AlgorandTools.ts
+++ b/src/algorand/AlgorandTools.ts
@@ -20,7 +20,8 @@ import { getDenomInfo } from '../common/utils'
 import {
   AlgorandNetworkInfo,
   asAlgorandPrivateKeys,
-  asMaybeContractAddressLocation
+  asMaybeContractAddressLocation,
+  asSafeAlgorandWalletInfo
 } from './algorandTypes'
 
 const { isValidAddress, mnemonicFromSeed } = algosdk
@@ -35,6 +36,19 @@ export class AlgorandTools implements EdgeCurrencyTools {
     this.io = io
     this.currencyInfo = currencyInfo
     this.builtinTokens = builtinTokens
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asAlgorandPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.mnemonic
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeAlgorandWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(input: string): Promise<JsonObject> {

--- a/src/binance/BinanceEngine.ts
+++ b/src/binance/BinanceEngine.ts
@@ -514,16 +514,6 @@ export class BinanceEngine extends CurrencyEngine<
       throw new Error(`Broadcast failed: ${e.message}`)
     }
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const bnbPrivateKey = asBnbPrivateKey(privateKeys)
-    return bnbPrivateKey.binanceMnemonic
-  }
-
-  getDisplayPublicSeed(): string {
-    const { keys } = this.walletInfo
-    return keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/binance/BinanceTools.ts
+++ b/src/binance/BinanceTools.ts
@@ -16,7 +16,11 @@ import {
 import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
-import { BinanceNetworkInfo } from './binanceTypes'
+import {
+  asBnbPrivateKey,
+  asSafeBnbWalletInfo,
+  BinanceNetworkInfo
+} from './binanceTypes'
 
 const {
   checkAddress,
@@ -37,6 +41,18 @@ export class BinanceTools implements EdgeCurrencyTools {
     this.currencyInfo = currencyInfo
     this.io = io
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asBnbPrivateKey(privateWalletInfo.keys)
+    return keys.binanceMnemonic
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeBnbWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   // will actually use MNEMONIC version of private key

--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -1076,14 +1076,6 @@ export class CurrencyEngine<
   // Virtual functions to be override by extension:
   //
 
-  getDisplayPrivateSeed(privateKeys: JsonObject): string | null {
-    throw new Error('not implemented')
-  }
-
-  getDisplayPublicSeed(): string | null {
-    throw new Error('not implemented')
-  }
-
   async resyncBlockchain(): Promise<void> {
     throw new Error('not implemented')
   }

--- a/src/eos/EosEngine.ts
+++ b/src/eos/EosEngine.ts
@@ -1150,31 +1150,6 @@ export class EosEngine extends CurrencyEngine<EosTools, SafeEosWalletInfo> {
       throw err
     }
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const eosPrivateKeys = asEosPrivateKeys(privateKeys)
-    let out = ''
-    // usage of eosOwnerKey must be protected by conditional
-    // checking for its existence
-    out += 'owner key\n' + String(eosPrivateKeys.eosOwnerKey) + '\n\n'
-    out += 'active key\n' + String(eosPrivateKeys.eosKey) + '\n\n'
-    return out
-  }
-
-  getDisplayPublicSeed(): string {
-    let out = ''
-    if (this.walletInfo.keys?.ownerPublicKey != null) {
-      out +=
-        'owner publicKey\n' +
-        String(this.walletInfo.keys.ownerPublicKey) +
-        '\n\n'
-    }
-    if (this.walletInfo.keys?.publicKey != null) {
-      out +=
-        'active publicKey\n' + String(this.walletInfo.keys.publicKey) + '\n\n'
-    }
-    return out
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/eos/EosTools.ts
+++ b/src/eos/EosTools.ts
@@ -30,7 +30,11 @@ import {
   asGetActivationCost,
   asGetActivationSupportedCurrencies
 } from './eosSchema'
-import { EosNetworkInfo } from './eosTypes'
+import {
+  asEosPrivateKeys,
+  asSafeEosWalletInfo,
+  EosNetworkInfo
+} from './eosTypes'
 
 export function checkAddress(address: string): boolean {
   return Name.pattern.test(address)
@@ -61,6 +65,31 @@ export class EosTools implements EdgeCurrencyTools {
     this.io = io
     this.log = log
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asEosPrivateKeys(privateWalletInfo.keys)
+    let out = ''
+    // usage of eosOwnerKey must be protected by conditional
+    // checking for its existence
+    out += 'owner key\n' + String(keys.eosOwnerKey) + '\n\n'
+    out += 'active key\n' + String(keys.eosKey) + '\n\n'
+    return out
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeEosWalletInfo(publicWalletInfo)
+
+    let out = ''
+    if (keys?.ownerPublicKey != null) {
+      out += 'owner publicKey\n' + String(keys.ownerPublicKey) + '\n\n'
+    }
+    if (keys?.publicKey != null) {
+      out += 'active publicKey\n' + String(keys.publicKey) + '\n\n'
+    }
+    return out
   }
 
   async importPrivateKey(privateKey: string): Promise<Object> {

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -1325,17 +1325,6 @@ export class EthereumEngine extends CurrencyEngine<
     }
   }
 
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const ethereumPrivateKeys = asEthereumPrivateKeys(
-      this.currencyInfo.pluginId
-    )(privateKeys)
-    return ethereumPrivateKeys.privateKey
-  }
-
-  getDisplayPublicSeed(): string | null {
-    return this.walletInfo.keys.publicKey
-  }
-
   // Overload saveTx to mutate replaced transactions by RBF
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async saveTx(edgeTransaction: EdgeTransaction) {

--- a/src/ethereum/EthereumTools.ts
+++ b/src/ethereum/EthereumTools.ts
@@ -20,7 +20,11 @@ import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { biggyScience, getDenomInfo } from '../common/utils'
 import { ethereumPlugins } from './ethereumInfos'
-import { EthereumNetworkInfo } from './ethereumTypes'
+import {
+  asEthereumPrivateKeys,
+  asSafeEthWalletInfo,
+  EthereumNetworkInfo
+} from './ethereumTypes'
 
 export class EthereumTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
@@ -34,6 +38,19 @@ export class EthereumTools implements EdgeCurrencyTools {
     this.currencyInfo = currencyInfo
     this.io = io
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asEthereumPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.privateKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeEthWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(userInput: string): Promise<Object> {

--- a/src/fio/FioEngine.ts
+++ b/src/fio/FioEngine.ts
@@ -1991,15 +1991,6 @@ export class FioEngine extends CurrencyEngine<FioTools, SafeFioWalletInfo> {
   async getFreshAddress(options: any): Promise<EdgeFreshAddress> {
     return { publicAddress: this.walletInfo.keys.publicKey }
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const fioPrivateKeys = asFioPrivateKeys(privateKeys)
-    return fioPrivateKeys.fioKey
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/fio/FioTools.ts
+++ b/src/fio/FioTools.ts
@@ -26,7 +26,11 @@ import {
 import { DEFAULT_APR, FIO_REG_API_ENDPOINTS } from './fioConst'
 import { fioApiErrorCodes, FioError } from './fioError'
 import { currencyInfo } from './fioInfo'
-import { FioNetworkInfo } from './fioTypes'
+import {
+  asFioPrivateKeys,
+  asSafeFioWalletInfo,
+  FioNetworkInfo
+} from './fioTypes'
 
 const FIO_CURRENCY_CODE = 'FIO'
 const FIO_TYPE = 'fio'
@@ -72,6 +76,18 @@ export class FioTools implements EdgeCurrencyTools {
       // eslint-disable-next-line
       new FIOSDK('', '', baseUrl, this.fetchCors, undefined, tpid)
     }
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asFioPrivateKeys(privateWalletInfo.keys)
+    return keys.fioKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeFioWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(userInput: string): Promise<Object> {

--- a/src/hedera/HederaEngine.ts
+++ b/src/hedera/HederaEngine.ts
@@ -544,25 +544,6 @@ export class HederaEngine extends CurrencyEngine<
   getBlockHeight(): number {
     return Math.floor(Date.now() / 1000)
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const hederaPrivateKeys = asHederaPrivateKeys(this.currencyInfo.pluginId)(
-      privateKeys
-    )
-    return hederaPrivateKeys.mnemonic ?? hederaPrivateKeys.privateKey
-  }
-
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  getDisplayPublicSeed() {
-    if (
-      // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-      this.walletInfo.keys != null &&
-      this.walletInfo.keys.publicKey != null
-    ) {
-      return this.walletInfo.keys.publicKey
-    }
-    return ''
-  }
 }
 
 function hashToTxid(hash: Uint8Array): string {

--- a/src/hedera/HederaTools.ts
+++ b/src/hedera/HederaTools.ts
@@ -16,7 +16,12 @@ import {
 import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo, getFetchCors } from '../common/utils'
-import { asGetActivationCost, HederaNetworkInfo } from './hederaTypes'
+import {
+  asGetActivationCost,
+  asHederaPrivateKeys,
+  asSafeHederaWalletInfo,
+  HederaNetworkInfo
+} from './hederaTypes'
 import { createChecksum, validAddress } from './hederaUtils'
 
 // if users want to import their mnemonic phrase in e.g. MyHbarWallet.com
@@ -40,6 +45,19 @@ export class HederaTools implements EdgeCurrencyTools {
     this.io = io
     this.log = log
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asHederaPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.mnemonic ?? keys.privateKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeHederaWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async createPrivateKey(walletType: string): Promise<Object> {

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -476,17 +476,6 @@ export class PolkadotEngine extends CurrencyEngine<
 
     return edgeTransaction
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const polkadotPrivateKeys = asPolkapolkadotPrivateKeys(
-      this.currencyInfo.pluginId
-    )(privateKeys)
-    return polkadotPrivateKeys.mnemonic ?? polkadotPrivateKeys.privateKey
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.publicKey ?? ''
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/polkadot/PolkadotTools.ts
+++ b/src/polkadot/PolkadotTools.ts
@@ -18,7 +18,11 @@ import {
 import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo, isHex } from '../common/utils'
-import { PolkadotNetworkInfo } from './polkadotTypes'
+import {
+  asPolkapolkadotPrivateKeys,
+  asSafePolkadotWalletInfo,
+  PolkadotNetworkInfo
+} from './polkadotTypes'
 
 const { ed25519PairFromSeed, isAddress, mnemonicToMiniSecret } = utilCrypto
 
@@ -40,6 +44,19 @@ export class PolkadotTools implements EdgeCurrencyTools {
     this.networkInfo = networkInfo
 
     this.polkadotApiSubscribers = new Set()
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asPolkapolkadotPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.mnemonic ?? keys.privateKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafePolkadotWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(userInput: string): Promise<JsonObject> {

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -893,15 +893,6 @@ export class XrpEngine extends CurrencyEngine<
     return edgeTransaction
   }
 
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const ripplePrivateKeys = asRipplePrivateKeys(privateKeys)
-    return ripplePrivateKeys.rippleKey
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys?.publicKey ?? ''
-  }
-
   engineGetActivationAssets = async (
     options: EdgeEngineGetActivationAssetsOptions
   ): Promise<EdgeGetActivationAssetsResults> => {

--- a/src/ripple/RippleTools.ts
+++ b/src/ripple/RippleTools.ts
@@ -23,7 +23,12 @@ import { PluginEnvironment } from '../common/innerPlugin'
 import { validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { asyncWaterfall, getDenomInfo, safeErrorMessage } from '../common/utils'
-import { asXrpNetworkLocation, XrpNetworkInfo } from './rippleTypes'
+import {
+  asRipplePrivateKeys,
+  asSafeRippleWalletInfo,
+  asXrpNetworkLocation,
+  XrpNetworkInfo
+} from './rippleTypes'
 import { makeTokenId } from './rippleUtils'
 
 export class RippleTools implements EdgeCurrencyTools {
@@ -43,6 +48,18 @@ export class RippleTools implements EdgeCurrencyTools {
     this.networkInfo = networkInfo
 
     this.rippleApiSubscribers = {}
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asRipplePrivateKeys(privateWalletInfo.keys)
+    return keys.rippleKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeRippleWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async connectApi(walletId: string): Promise<void> {

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -434,17 +434,6 @@ export class SolanaEngine extends CurrencyEngine<
 
     return edgeTransaction
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string | null {
-    const solanaPrivateKeys = asSolanaPrivateKeys(this.currencyInfo.pluginId)(
-      privateKeys
-    )
-    return solanaPrivateKeys.mnemonic
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/solana/SolanaTools.ts
+++ b/src/solana/SolanaTools.ts
@@ -18,7 +18,11 @@ import {
 import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
-import { SolanaNetworkInfo } from './solanaTypes'
+import {
+  asSafeSolanaWalletInfo,
+  asSolanaPrivateKeys,
+  SolanaNetworkInfo
+} from './solanaTypes'
 
 const { Keypair, PublicKey } = solanaWeb3
 
@@ -45,6 +49,19 @@ export class SolanaTools implements EdgeCurrencyTools {
     this.currencyInfo = currencyInfo
     this.io = io
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asSolanaPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.mnemonic
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeSolanaWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(mnemonic: string): Promise<JsonObject> {

--- a/src/stellar/StellarEngine.ts
+++ b/src/stellar/StellarEngine.ts
@@ -667,15 +667,6 @@ export class StellarEngine extends CurrencyEngine<
     }
     return edgeTransaction
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string | null {
-    const stellarPrivateKeys = asStellarPrivateKeys(privateKeys)
-    return stellarPrivateKeys.stellarKey
-  }
-
-  getDisplayPublicSeed(): string | null {
-    return this.walletInfo.keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/stellar/StellarTools.ts
+++ b/src/stellar/StellarTools.ts
@@ -15,7 +15,11 @@ import parse from 'url-parse'
 import { PluginEnvironment } from '../common/innerPlugin'
 import { parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
-import { StellarNetworkInfo } from './stellarTypes'
+import {
+  asSafeStellarWalletInfo,
+  asStellarPrivateKeys,
+  StellarNetworkInfo
+} from './stellarTypes'
 
 const URI_PREFIX = 'web+stellar'
 
@@ -42,6 +46,18 @@ export class StellarTools implements EdgeCurrencyTools {
       stellarServer.serverName = server
       this.stellarApiServers.push(stellarServer)
     }
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asStellarPrivateKeys(privateWalletInfo.keys)
+    return keys.stellarKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeStellarWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   checkAddress(address: string): boolean {

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -519,15 +519,6 @@ export class TezosEngine extends CurrencyEngine<
     this.warn(`SUCCESS broadcastTx\n${cleanTxLogs(edgeTransaction)}`)
     return edgeTransaction
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string | null {
-    const tezosPrivateKeys = asTezosPrivateKeys(privateKeys)
-    return tezosPrivateKeys.mnemonic
-  }
-
-  getDisplayPublicSeed(): string | null {
-    return this.walletInfo.keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/tezos/TezosTools.ts
+++ b/src/tezos/TezosTools.ts
@@ -11,7 +11,12 @@ import { eztz } from 'eztz.js'
 import { decodeMainnet, encodeMainnet } from 'tezos-uri'
 
 import { PluginEnvironment } from '../common/innerPlugin'
-import type { TezosNetworkInfo, UriTransaction } from './tezosTypes'
+import {
+  asSafeTezosWalletInfo,
+  asTezosPrivateKeys,
+  TezosNetworkInfo,
+  UriTransaction
+} from './tezosTypes'
 
 export class TezosTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
@@ -31,6 +36,18 @@ export class TezosTools implements EdgeCurrencyTools {
 
     this.tezosRpcNodes = [...this.networkInfo.tezosRpcNodes]
     this.tezosApiServers = [...this.networkInfo.tezosApiServers]
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asTezosPrivateKeys(privateWalletInfo.keys)
+    return keys.mnemonic
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeTezosWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   checkAddress(address: string): boolean {

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -1497,15 +1497,6 @@ export class TronEngine extends CurrencyEngine<TronTools, SafeTronWalletInfo> {
     edgeTransaction.date = Date.now() / 1000
     return edgeTransaction
   }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const tronPrivateKeys = asTronPrivateKeys(privateKeys)
-    return tronPrivateKeys.tronMnemonic ?? tronPrivateKeys.tronKey
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.publicKey
-  }
 }
 
 export async function makeCurrencyEngine(

--- a/src/tron/TronTools.ts
+++ b/src/tron/TronTools.ts
@@ -22,6 +22,7 @@ import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
 import {
+  asSafeTronWalletInfo,
   asTronInitOptions,
   asTronPrivateKeys,
   TronInitOptions,
@@ -52,6 +53,18 @@ export class TronTools implements EdgeCurrencyTools {
     this.io = io
     this.log = log
     this.networkInfo = networkInfo
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const keys = asTronPrivateKeys(privateWalletInfo.keys)
+    return keys.tronMnemonic ?? keys.tronKey
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeTronWalletInfo(publicWalletInfo)
+    return keys.publicKey
   }
 
   async importPrivateKey(

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -8,7 +8,6 @@ import {
   EdgeTransaction,
   EdgeWalletInfo,
   InsufficientFundsError,
-  JsonObject,
   NoAmountSpecifiedError
 } from 'edge-core-js/types'
 
@@ -398,15 +397,6 @@ export class ZcashEngine extends CurrencyEngine<
       throw e
     }
     return edgeTransaction
-  }
-
-  getDisplayPrivateSeed(privateKeys: JsonObject): string {
-    const zcashPrivateKeys = asZcashPrivateKeys(this.pluginId)(privateKeys)
-    return zcashPrivateKeys.mnemonic
-  }
-
-  getDisplayPublicSeed(): string {
-    return this.walletInfo.keys.unifiedViewingKeys?.extfvk ?? ''
   }
 
   async loadEngine(

--- a/src/zcash/ZcashTools.ts
+++ b/src/zcash/ZcashTools.ts
@@ -22,6 +22,7 @@ import { asIntegerString } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getDenomInfo } from '../common/utils'
 import {
+  asSafeZcashWalletInfo,
   asZcashPrivateKeys,
   asZecPublicKey,
   UnifiedViewingKey,
@@ -52,6 +53,19 @@ export class ZcashTools implements EdgeCurrencyTools {
 
     this.KeyTool = KeyTool
     this.AddressTool = AddressTool
+  }
+
+  async getDisplayPrivateKey(
+    privateWalletInfo: EdgeWalletInfo
+  ): Promise<string> {
+    const { pluginId } = this.currencyInfo
+    const keys = asZcashPrivateKeys(pluginId)(privateWalletInfo.keys)
+    return keys.mnemonic
+  }
+
+  async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
+    const { keys } = asSafeZcashWalletInfo(publicWalletInfo)
+    return keys.unifiedViewingKeys?.extfvk
   }
 
   async getNewWalletBirthdayBlockheight(): Promise<number> {


### PR DESCRIPTION
### CHANGELOG

- changed: Move deprecated display-key methods from the engines to the tools. This requires edge-core-js v0.21.2 or later.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

Maybe use the "files changed" view, since that will make the review easier. We could even go so far as to squash the two commits together.

However, the second commit is a breaking change, since it means we will no longer be compatible with older core versions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205139579993261