### PR TITLE
Only use `io.fetchCors`, never `io.fetch`

### DIFF
--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -84,7 +84,6 @@ export class CurrencyEngine<
   currentSettings: any
   timers: any
   walletId: string
-  io: EdgeIo
   log: EdgeLog
   warn: (message: string, e?: Error) => void
   error: (message: string, e?: Error) => void
@@ -97,12 +96,11 @@ export class CurrencyEngine<
     walletInfo: SafeWalletInfo,
     opts: EdgeCurrencyEngineOptions
   ) {
-    const { io, currencyInfo } = tools
+    const { currencyInfo } = tools
     const { currencyCode } = currencyInfo
     const { walletLocalDisklet, callbacks, customTokens } = opts
 
     this.tools = tools
-    this.io = io
     this.log = opts.log
     this.warn = (message, e?) => this.log.warn(message + safeErrorMessage(e))
     this.error = (message, e?) => this.log.error(message + safeErrorMessage(e))

--- a/src/common/smartPay.ts
+++ b/src/common/smartPay.ts
@@ -4,6 +4,7 @@ import { EdgeIo, EdgeParsedUri, EdgeTokenMap } from 'edge-core-js/types'
 
 import { cleanMultiFetch, makeQueryParams, QueryParams } from './network'
 import { computeCRC, formatPixKey } from './pixkey'
+import { getFetchCors } from './utils'
 
 const MAX_TIMEOUT_S = 60 * 60 * 24 * 7
 
@@ -65,6 +66,7 @@ export const parsePixKey = async (
       return
     }
     try {
+      const fetchCors = getFetchCors(io)
       const qrcode = encodeURIComponent(code)
       const decode = await cleanMultiFetch(
         asSmartPayQrDecode,
@@ -72,7 +74,7 @@ export const parsePixKey = async (
         `api/pix/qrdecode?qrcode=${qrcode}`,
         undefined,
         undefined,
-        io.fetch
+        fetchCors
       )
       if (decode.status !== 'ok') {
         throw new Error(decode.msg)
@@ -104,7 +106,7 @@ export const parsePixKey = async (
           `api/swapix/swapquote?${params}`,
           undefined,
           undefined,
-          io.fetch
+          fetchCors
         )
 
         const { data: quoteData } = quote

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -2,10 +2,10 @@ import { add, mul } from 'biggystring'
 import { Buffer } from 'buffer'
 import { asArray, asObject, asOptional, asString } from 'cleaners'
 import {
-  EdgeCorePluginOptions,
   EdgeCurrencyInfo,
   EdgeDenomination,
   EdgeFetchFunction,
+  EdgeIo,
   EdgeMetaToken,
   EdgeTokenMap,
   EdgeTransaction,
@@ -364,8 +364,8 @@ export function biggyScience(num: string): string {
 /**
  * Emulates the browser Fetch API more accurately than fetch JSON.
  */
-export function getFetchCors(opts: EdgeCorePluginOptions): EdgeFetchFunction {
-  return opts.io.fetchCors ?? opts.io.fetch
+export function getFetchCors(io: EdgeIo): EdgeFetchFunction {
+  return io.fetchCors ?? io.fetch
 }
 
 export function safeErrorMessage(e?: Error): string {

--- a/src/eos/EosEngine.ts
+++ b/src/eos/EosEngine.ts
@@ -106,10 +106,9 @@ export class EosEngine extends CurrencyEngine<EosTools, SafeEosWalletInfo> {
     walletInfo: SafeEosWalletInfo,
     opts: EdgeCurrencyEngineOptions
   ) {
-    const fetchCors = getFetchCors(env)
     super(env, tools, walletInfo, opts)
     const { networkInfo } = env
-    this.fetchCors = fetchCors
+    this.fetchCors = getFetchCors(env.io)
     this.networkInfo = networkInfo
     this.activatedAccountsCache = {}
     const { currencyCode, denominations } = this.currencyInfo
@@ -176,7 +175,7 @@ export class EosEngine extends CurrencyEngine<EosTools, SafeEosWalletInfo> {
           const out = await asyncWaterfall(
             this.networkInfo.eosActivationServers.map(server => async () => {
               const uri = `${server}/api/v1/activateAccount`
-              const response = await fetchCors(uri, options)
+              const response = await this.fetchCors(uri, options)
               return await response.json()
             }),
             15000

--- a/src/eos/EosTools.ts
+++ b/src/eos/EosTools.ts
@@ -57,10 +57,10 @@ export class EosTools implements EdgeCurrencyTools {
     const { builtinTokens, currencyInfo, io, log, networkInfo } = env
     this.builtinTokens = builtinTokens
     this.currencyInfo = currencyInfo
+    this.fetchCors = getFetchCors(env.io)
     this.io = io
     this.log = log
     this.networkInfo = networkInfo
-    this.fetchCors = getFetchCors(env)
   }
 
   async importPrivateKey(privateKey: string): Promise<Object> {

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -122,11 +122,11 @@ export class EthereumEngine extends CurrencyEngine<
       this.l1RollupParams = this.networkInfo.l1RollupParams
     }
     this.networkFees = this.networkInfo.defaultNetworkFees
-    this.fetchCors = getFetchCors(env)
+    this.fetchCors = getFetchCors(env.io)
 
     // Update network fees from other providers
     const { infoFeeProvider, externalFeeProviders } = FeeProviders(
-      this.io.fetch,
+      this.fetchCors,
       this.currencyInfo,
       this.initOptions,
       this.log,

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -476,17 +476,7 @@ export class EthereumNetwork {
 
     const url = `${server}/api${cmd}`
 
-    const fetcher = useFetchCors
-      ? this.ethEngine.io.fetchCors
-      : this.ethEngine.io.fetch
-
-    // Assert that fetch is defined (only possible if fetchCors is undefined)
-    if (fetcher == null)
-      throw new Error(
-        `Failed to fetch from ${server} undefined fetchCors in EdgeIo`
-      )
-
-    const response = await fetcher(`${url}${apiKeyParam}`)
+    const response = await this.ethEngine.fetchCors(`${url}${apiKeyParam}`)
     if (!response.ok) this.throwError(response, 'fetchGetEtherscan', url)
     return await response.json()
   }
@@ -495,7 +485,7 @@ export class EthereumNetwork {
   async fetchGetBlockbook(server: string, param: string) {
     const url = server + param
     const resultRaw = !server.includes('trezor')
-      ? await this.ethEngine.io.fetch(url)
+      ? await this.ethEngine.fetchCors(url)
       : await this.ethEngine.fetchCors(url, {
           headers: { 'User-Agent': 'http.agent' }
         })
@@ -541,7 +531,7 @@ export class EthereumNetwork {
     }
     url += addOnUrl
 
-    const response = await this.ethEngine.io.fetch(url, {
+    const response = await this.ethEngine.fetchCors(url, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json'
@@ -567,7 +557,7 @@ export class EthereumNetwork {
     }
 
     const url = `${baseUrl}/${cmd}${apiKey}`
-    const response = await this.ethEngine.io.fetch(url, {
+    const response = await this.ethEngine.fetchCors(url, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json'
@@ -591,7 +581,7 @@ export class EthereumNetwork {
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       includeKey && blockchairApiKey ? `&key=${blockchairApiKey}` : ''
     const url = `${blockchairApiServers[0]}${path}`
-    const response = await this.ethEngine.io.fetch(`${url}${keyParam}`)
+    const response = await this.ethEngine.fetchCors(`${url}${keyParam}`)
     if (!response.ok) this.throwError(response, 'fetchGetBlockchair', url)
     return await response.json()
   }
@@ -666,7 +656,7 @@ export class EthereumNetwork {
     const { alethioApiServers } = this.ethEngine.networkInfo
     const url = isPath ? `${alethioApiServers[0]}${pathOrLink}` : pathOrLink
 
-    const response = await this.ethEngine.io.fetch(
+    const response = await this.ethEngine.fetchCors(
       url,
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       alethioApiKey

--- a/src/fio/FioEngine.ts
+++ b/src/fio/FioEngine.ts
@@ -142,8 +142,7 @@ export class FioEngine extends CurrencyEngine<FioTools, SafeFioWalletInfo> {
     tpid: string
   ) {
     super(env, tools, walletInfo, opts)
-    const fetchCors = getFetchCors(env)
-    this.fetchCors = fetchCors
+    this.fetchCors = getFetchCors(env.io)
     this.tpid = tpid
     this.networkInfo = env.networkInfo
     this.refBlock = {

--- a/src/fio/FioTools.ts
+++ b/src/fio/FioTools.ts
@@ -63,7 +63,7 @@ export class FioTools implements EdgeCurrencyTools {
     const { tpid = 'finance@edge', fioRegApiToken = FIO_REG_SITE_API_KEY } =
       initOptions
 
-    this.fetchCors = getFetchCors(env)
+    this.fetchCors = getFetchCors(env.io)
     this.fioRegApiToken = fioRegApiToken
     this.tpid = tpid
 

--- a/src/hedera/HederaTools.ts
+++ b/src/hedera/HederaTools.ts
@@ -5,6 +5,7 @@ import {
   EdgeCurrencyInfo,
   EdgeCurrencyTools,
   EdgeEncodeUri,
+  EdgeFetchFunction,
   EdgeIo,
   EdgeLog,
   EdgeParsedUri,
@@ -14,7 +15,7 @@ import {
 
 import { PluginEnvironment } from '../common/innerPlugin'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
-import { getDenomInfo } from '../common/utils'
+import { getDenomInfo, getFetchCors } from '../common/utils'
 import { asGetActivationCost, HederaNetworkInfo } from './hederaTypes'
 import { createChecksum, validAddress } from './hederaUtils'
 
@@ -26,6 +27,7 @@ const Ed25519PrivateKeyPrefix = '302e020100300506032b657004220420'
 export class HederaTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
   currencyInfo: EdgeCurrencyInfo
+  fetchCors: EdgeFetchFunction
   io: EdgeIo
   log: EdgeLog
   networkInfo: HederaNetworkInfo
@@ -34,6 +36,7 @@ export class HederaTools implements EdgeCurrencyTools {
     const { builtinTokens, currencyInfo, io, log, networkInfo } = env
     this.builtinTokens = builtinTokens
     this.currencyInfo = currencyInfo
+    this.fetchCors = getFetchCors(io)
     this.io = io
     this.log = log
     this.networkInfo = networkInfo
@@ -170,7 +173,7 @@ export class HederaTools implements EdgeCurrencyTools {
     const creatorApiServer = this.networkInfo.creatorApiServers[0]
 
     try {
-      const response = await this.io.fetch(`${creatorApiServer}/account/cost`)
+      const response = await this.fetchCors(`${creatorApiServer}/account/cost`)
       return asGetActivationCost(await response.json()).hbar
     } catch (e: any) {
       this.log.warn(

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -5,6 +5,7 @@ import { abs, add, div, gt, lte, mul, sub } from 'biggystring'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
+  EdgeFetchFunction,
   EdgeSpendInfo,
   EdgeTransaction,
   EdgeWalletInfo,
@@ -20,6 +21,7 @@ import {
   cleanTxLogs,
   decimalToHex,
   getDenomInfo,
+  getFetchCors,
   getOtherParams,
   makeMutex
 } from '../common/utils'
@@ -48,6 +50,7 @@ export class PolkadotEngine extends CurrencyEngine<
   PolkadotTools,
   SafePolkadotWalletInfo
 > {
+  fetchCors: EdgeFetchFunction
   networkInfo: PolkadotNetworkInfo
   otherData!: PolkadotWalletOtherData
   api!: ApiPromise
@@ -61,6 +64,7 @@ export class PolkadotEngine extends CurrencyEngine<
     opts: EdgeCurrencyEngineOptions
   ) {
     super(env, tools, walletInfo, opts)
+    this.fetchCors = getFetchCors(env.io)
     this.networkInfo = env.networkInfo
     this.nonce = 0
     this.minimumAddressBalance = this.networkInfo.existentialDeposit
@@ -92,7 +96,7 @@ export class PolkadotEngine extends CurrencyEngine<
       },
       body: JSON.stringify(body)
     }
-    const response = await this.io.fetch(
+    const response = await this.fetchCors(
       this.networkInfo.subscanBaseUrl + endpoint,
       options
     )

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -70,9 +70,8 @@ export class SolanaEngine extends CurrencyEngine<
   ) {
     super(env, tools, walletInfo, opts)
     this.networkInfo = env.networkInfo
-    const fetchCors = getFetchCors(env)
     this.chainCode = tools.currencyInfo.currencyCode
-    this.fetchCors = fetchCors
+    this.fetchCors = getFetchCors(env.io)
     this.feePerSignature = '5000'
     this.recentBlockhash = '' // must be < ~2min old to send tx
     this.base58PublicKey = walletInfo.keys.publicKey

--- a/src/stellar/StellarEngine.ts
+++ b/src/stellar/StellarEngine.ts
@@ -2,6 +2,7 @@ import { abs, add, div, eq, gt, mul, sub } from 'biggystring'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
+  EdgeFetchFunction,
   EdgeSpendInfo,
   EdgeTransaction,
   EdgeWalletInfo,
@@ -17,6 +18,7 @@ import {
   asyncWaterfall,
   cleanTxLogs,
   getDenomInfo,
+  getFetchCors,
   getOtherParams,
   promiseAny
 } from '../common/utils'
@@ -53,6 +55,7 @@ export class StellarEngine extends CurrencyEngine<
   SafeStellarWalletInfo
 > {
   networkInfo: StellarNetworkInfo
+  fetchCors: EdgeFetchFunction
   stellarApi: Object
   activatedAccountsCache: { [publicAddress: string]: boolean }
   pendingTransactionsIndex: number
@@ -68,6 +71,7 @@ export class StellarEngine extends CurrencyEngine<
   ) {
     super(env, tools, walletInfo, opts)
     this.networkInfo = env.networkInfo
+    this.fetchCors = getFetchCors(env.io)
     this.stellarApi = {}
     this.activatedAccountsCache = {}
     this.pendingTransactionsIndex = 0
@@ -119,7 +123,7 @@ export class StellarEngine extends CurrencyEngine<
       case 'feeStats':
         funcs = this.networkInfo.stellarServers.map(
           (serverUrl: string) => async () => {
-            const response = await this.io.fetch(`${serverUrl}/fee_stats`)
+            const response = await this.fetchCors(`${serverUrl}/fee_stats`)
             const result = asFeeStats(await response.json())
 
             return { server: serverUrl, result }

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -72,8 +72,7 @@ export class TezosEngine extends CurrencyEngine<
     super(env, tools, walletInfo, opts)
     this.walletInfo = asSafeTezosWalletInfo(walletInfo)
     this.networkInfo = env.networkInfo
-    const fetchCors = getFetchCors(env)
-    this.fetchCors = fetchCors
+    this.fetchCors = getFetchCors(env.io)
   }
 
   setOtherData(raw: any): void {
@@ -90,9 +89,9 @@ export class TezosEngine extends CurrencyEngine<
         // need to re-enable once that nodes issue is fixed
         const nonCachedNodes = this.tools.tezosRpcNodes
         funcs = nonCachedNodes.map(server => async () => {
-          const result = await this.io
-            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands, @typescript-eslint/no-base-to-string
-            .fetch(server + '/chains/main/blocks/head/header')
+          const result = await this.fetchCors(
+            server + '/chains/main/blocks/head/header'
+          )
             .then(async function (response) {
               return await response.json()
             })

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -4,7 +4,6 @@ import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
   EdgeFetchFunction,
-  EdgeLog,
   EdgeSpendInfo,
   EdgeStakingStatus,
   EdgeTransaction,
@@ -100,7 +99,6 @@ type TronFunction =
 
 export class TronEngine extends CurrencyEngine<TronTools, SafeTronWalletInfo> {
   fetchCors: EdgeFetchFunction
-  log: EdgeLog
   readonly recentBlock: ReferenceBlock
   accountResources: TronAccountResources
   networkFees: TronNetworkFees
@@ -117,10 +115,8 @@ export class TronEngine extends CurrencyEngine<TronTools, SafeTronWalletInfo> {
     opts: EdgeCurrencyEngineOptions
   ) {
     super(env, currencyPlugin, walletInfo, opts)
-    const fetchCors = getFetchCors(env)
     const { networkInfo } = env
-    this.fetchCors = fetchCors
-    this.log = opts.log
+    this.fetchCors = getFetchCors(env.io)
     this.networkInfo = networkInfo
     this.recentBlock = {
       hash: '0',


### PR DESCRIPTION
With the exception of when `io.fetchCors` doesn't exist. Then we have no choice.

### CHANGELOG

- changed: Use `EdgeIo.fetchCors` for all requests.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205163504777914