### PR TITLE
Remove Blockscout EVM scan API server from Ethereum Classic

### DIFF
--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -67,7 +67,7 @@ const defaultNetworkFees: EthereumFees = {
 
 const networkInfo: EthereumNetworkInfo = {
   rpcServers: ['https://www.ethercluster.com/etc'],
-  evmScanApiServers: ['https://blockscout.com/etc/mainnet'],
+  evmScanApiServers: [], // ['https://blockscout.com/etc/mainnet'],
   blockcypherApiServers: [],
   blockbookServers: ['https://etcbook.guarda.co', 'https://etc1.trezor.io'],
   uriNetworks: ['ethereumclassic', 'etherclass'],


### PR DESCRIPTION
### CHANGELOG

- changed: Removed blockscout API server from ETC info (disabling transaction list retrieval)

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205339631453865