### PR TITLE
Fix Filecoin block explorer

### DIFF
--- a/src/filecoin/filecoinInfo.ts
+++ b/src/filecoin/filecoinInfo.ts
@@ -24,9 +24,8 @@ export const currencyInfo: EdgeCurrencyInfo = {
 
   defaultSettings: {},
 
-  addressExplorer: 'https://blockchair.com/filecoin/address/%s?from=edgeapp',
-  transactionExplorer:
-    'https://blockchair.com/filecoin/transaction/%s?from=edgeapp',
+  addressExplorer: 'https://filscan.io/en/address/%s',
+  transactionExplorer: 'https://filscan.io/en/message/%s',
 
   denominations: [
     // An array of Objects of the possible denominations for this currency


### PR DESCRIPTION
### CHANGELOG

- fixed: Use Filscan as the block explorer for Filecoin

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205389198015854