### PR TITLE
Fix filecoin spend saving

### DIFF
--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -189,15 +189,15 @@ export class FilecoinEngine extends CurrencyEngine<
     }
 
     const networkFee = mul(txJson.GasLimit.toString(), txJson.GasPremium) // TODO: Include base fee and burn fee somehow?
-    const totalTxAmount = add(nativeAmount, networkFee)
+    const txNativeAmount = mul(add(nativeAmount, networkFee), '-1')
 
     const edgeTransaction: EdgeTransaction = {
       txid: '',
       date: 0,
       currencyCode,
       blockHeight: 0,
-      nativeAmount: `-${totalTxAmount}`,
-      isSend: nativeAmount.startsWith('-'),
+      nativeAmount: txNativeAmount,
+      isSend: true,
       networkFee,
       ourReceiveAddresses: [],
       otherParams,

--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -230,6 +230,8 @@ export class FilecoinEngine extends CurrencyEngine<
       sigJson: signature.toJSON()
     }
 
+    edgeTransaction.date = Date.now() / 1000
+
     return edgeTransaction
   }
 

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -1,4 +1,4 @@
-import { abs, add, eq, gt, lte, sub } from 'biggystring'
+import { abs, add, eq, gt, lte, mul, sub } from 'biggystring'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
@@ -338,13 +338,15 @@ export class ZcashEngine extends CurrencyEngine<
       publicAddress
     }))
 
+    const txNativeAmount = mul(totalTxAmount, '-1')
+
     const edgeTransaction: EdgeTransaction = {
       txid: '', // txid
       date: 0, // date
       currencyCode, // currencyCode
       blockHeight: 0, // blockHeight
-      nativeAmount: `-${totalTxAmount}`, // nativeAmount
-      isSend: nativeAmount.startsWith('-'),
+      nativeAmount: txNativeAmount, // nativeAmount
+      isSend: true,
       networkFee: this.networkInfo.defaultNetworkFee, // networkFee
       ourReceiveAddresses: [], // ourReceiveAddresses
       signedTx: '', // signedTx

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -341,15 +341,15 @@ export class ZcashEngine extends CurrencyEngine<
     const txNativeAmount = mul(totalTxAmount, '-1')
 
     const edgeTransaction: EdgeTransaction = {
-      txid: '', // txid
-      date: 0, // date
-      currencyCode, // currencyCode
-      blockHeight: 0, // blockHeight
-      nativeAmount: txNativeAmount, // nativeAmount
+      txid: '',
+      date: 0,
+      currencyCode,
+      blockHeight: 0,
+      nativeAmount: txNativeAmount,
       isSend: true,
-      networkFee: this.networkInfo.defaultNetworkFee, // networkFee
-      ourReceiveAddresses: [], // ourReceiveAddresses
-      signedTx: '', // signedTx
+      networkFee: this.networkInfo.defaultNetworkFee,
+      ourReceiveAddresses: [],
+      signedTx: '',
       spendTargets,
       walletId: this.walletId
     }


### PR DESCRIPTION
The date field was missing from the signed transactions so it wasn't being saved (I suppose that's a requirement by the CurrencyEngine implementation). Also, `isSend` had a bug that was copied from `ZcashEngine`; now it's fixed in both places.

### CHANGELOG

- fixed: Bug prevent Filecoin spend trasactions from being saved in the wallet (by `saveTx`)

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205428345589472