### PR TITLE
Filecoin network query fixes

### DIFF
--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -87,9 +87,7 @@ export class FilecoinEngine extends CurrencyEngine<
   }
 
   initData(): void {
-    // Initialize walletLocalData:
-    // ...
-
+    this.tokenCheckTransactionsStatus[this.currencyInfo.currencyCode] = 0
     // Engine variables
     this.availableAttoFil = '0'
   }

--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -343,7 +343,7 @@ export class FilecoinEngine extends CurrencyEngine<
       }
 
       const scanners = [
-        this.scanTransactionsFromFilscan(addressString, handleScan),
+        // this.scanTransactionsFromFilscan(addressString, handleScan),
         this.scanTransactionsFromFilfox(addressString, handleScan)
       ]
 

--- a/src/filecoin/Filfox.ts
+++ b/src/filecoin/Filfox.ts
@@ -40,7 +40,7 @@ export const asFilfoxMessage = asObject({
   height: asNumber,
   method: asString,
   nonce: asNumber,
-  reciept: asObject({
+  receipt: asObject({
     exitCode: asNumber
   }),
   timestamp: asNumber,


### PR DESCRIPTION
Heads up. This disables Filscan because I haven't found a convenient way to calculate fees from Filscan's API. I haven't quit wrapped my head around [how Filecoin fees are calculated](https://spec.filecoin.io/systems/filecoin_vm/gas_fee/), so rather than calculating the fee from the message fields, I use a hack to peer into the "transfer" data returned by Filfox.

### CHANGELOG

- fixed: Filecoin network fee query issue
- changed: Use Filfox exclusively for Filecoin transaction querying

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205419647873868