### PR TITLE
Remove the Tron memo length

### DIFF
--- a/src/tron/tronInfo.ts
+++ b/src/tron/tronInfo.ts
@@ -128,7 +128,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
 
   // https://developers.tron.network/v3.7/docs/how-to-build-a-transaction-locally
-  memoOptions: [{ type: 'text', memoName: 'data', maxLength: 10 }],
+  memoOptions: [{ type: 'text', memoName: 'data' }],
 
   // Deprecated:
   defaultSettings: {},


### PR DESCRIPTION
There is no specific memo size on this network - as long as the transaction pays its fees, a byte is a byte.

### CHANGELOG

- changed: Remove the maximum memo length on Tron.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205531946960596