### PR TITLE
Rename Tron memos to "note"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Rename Tron memos to "note".
+
 ## 2.5.0 (2023-09-20)
 
 - changed: Remove the maximum memo length on Tron

--- a/src/tron/tronInfo.ts
+++ b/src/tron/tronInfo.ts
@@ -128,7 +128,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
 
   // https://developers.tron.network/v3.7/docs/how-to-build-a-transaction-locally
-  memoOptions: [{ type: 'text', memoName: 'data' }],
+  memoOptions: [{ type: 'text', memoName: 'note' }],
 
   // Deprecated:
   defaultSettings: {},


### PR DESCRIPTION
### CHANGELOG

- fixed: Rename Tron memos to "note".

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205534353251276