### PR TITLE
Add autoshield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - added: EdgeTxAction tagging to TRX freeze/unfreeze contract call transactions
 - added: Support for importing XLM wallets via 12/24-word mnemonic seed phrase
+- added: Add Zcash autoshield support
+- changed: Use Zcash types directly from react-native-zcash
 
 ## 2.6.0 (2023-10-09)
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prettier": "^2.2.0",
     "process": "^0.11.10",
     "react-native-piratechain": "0.4.0",
-    "react-native-zcash": "0.6.0",
+    "react-native-zcash": "0.6.1",
     "rimraf": "^3.0.2",
     "stream-browserify": "^2.0.2",
     "stream-http": "^3.2.0",
@@ -155,6 +155,6 @@
   },
   "peerDependencies": {
     "react-native-piratechain": "^0.4.0",
-    "react-native-zcash": "^0.6.0"
+    "react-native-zcash": "^0.6.1"
   }
 }

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -6,6 +6,7 @@ import {
   Tools as PiratechainNativeTools
 } from 'react-native-piratechain'
 import {
+  InitializerConfig,
   makeSynchronizer as ZcashMakeSynchronizer,
   Synchronizer as ZcashSynchronizer,
   Tools as ZcashNativeTools
@@ -13,7 +14,6 @@ import {
 import { bridgifyObject, emit, onMethod } from 'yaob'
 
 import { PiratechainInitializerConfig } from './piratechain/piratechainTypes'
-import { ZcashInitializerConfig } from './zcash/zcashTypes'
 
 const { EdgeCurrencyAccountbasedModule } = NativeModules
 const { sourceUri } = EdgeCurrencyAccountbasedModule.getConstants()
@@ -61,7 +61,7 @@ const makePiratechainSynchronizer = async (
 }
 
 const makeZcashSynchronizer = async (
-  config: ZcashInitializerConfig
+  config: InitializerConfig
 ): Promise<ZcashSynchronizer> => {
   const realSynchronizer = await ZcashMakeSynchronizer(config)
 
@@ -124,7 +124,7 @@ export function makePluginIo(): EdgeOtherMethods {
     }),
     zcash: bridgifyObject({
       Tools: ZcashNativeTools,
-      async makeSynchronizer(config: ZcashInitializerConfig) {
+      async makeSynchronizer(config: InitializerConfig) {
         return await makeZcashSynchronizer(config)
       }
     })

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -92,6 +92,9 @@ const makeZcashSynchronizer = async (
     sendToAddress: async spendInfo => {
       return await realSynchronizer.sendToAddress(spendInfo)
     },
+    shieldFunds: async shieldFundsInfo => {
+      return await realSynchronizer.shieldFunds(shieldFundsInfo)
+    },
     stop: async () => {
       return await realSynchronizer.stop()
     }

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -55,7 +55,6 @@ export class ZcashEngine extends CurrencyEngine<
   makeSynchronizer: (config: InitializerConfig) => Promise<ZcashSynchronizer>
 
   // Synchronizer management
-  started: boolean
   stopSyncing?: (value: number | PromiseLike<number>) => void
   synchronizer?: ZcashSynchronizer
 
@@ -77,8 +76,6 @@ export class ZcashEngine extends CurrencyEngine<
       saplingAvailableZatoshi: '0',
       saplingTotalZatoshi: '0'
     }
-
-    this.started = false
   }
 
   setOtherData(raw: any): void {
@@ -204,7 +201,6 @@ export class ZcashEngine extends CurrencyEngine<
 
   async startEngine(): Promise<void> {
     this.engineOn = true
-    this.started = true
     await super.startEngine()
   }
 
@@ -247,7 +243,7 @@ export class ZcashEngine extends CurrencyEngine<
   }
 
   async syncNetwork(opts: EdgeEnginePrivateKeyOptions): Promise<number> {
-    if (!this.started) return 1000
+    if (!this.engineOn) return 1000
 
     const zcashPrivateKeys = asZcashPrivateKeys(this.currencyInfo.pluginId)(
       opts?.privateKeys
@@ -272,13 +268,12 @@ export class ZcashEngine extends CurrencyEngine<
   }
 
   async killEngine(): Promise<void> {
-    this.started = false
+    await super.killEngine()
     if (this.stopSyncing != null) {
       await this.stopSyncing(1000)
       this.stopSyncing = undefined
     }
     await this.synchronizer?.stop()
-    await super.killEngine()
   }
 
   async clearBlockchainCache(): Promise<void> {

--- a/src/zcash/ZcashTools.ts
+++ b/src/zcash/ZcashTools.ts
@@ -12,6 +12,7 @@ import {
   EdgeWalletInfo,
   JsonObject
 } from 'edge-core-js/types'
+import type { UnifiedViewingKey } from 'react-native-zcash'
 import { Tools as ToolsType } from 'react-native-zcash'
 
 import { PluginEnvironment } from '../common/innerPlugin'
@@ -22,7 +23,6 @@ import {
   asSafeZcashWalletInfo,
   asZcashPrivateKeys,
   asZecPublicKey,
-  UnifiedViewingKey,
   ZcashNetworkInfo
 } from './zcashTypes'
 

--- a/src/zcash/zcashInfo.ts
+++ b/src/zcash/zcashInfo.ts
@@ -37,10 +37,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   ],
 
   // https://zips.z.cash/zip-0302
-  memoOptions: [
-    // Disabled until the upstream SDK fixes the fee math:
-    // { type: 'text', maxLength: 512 }
-  ],
+  memoOptions: [{ type: 'text', maxLength: 512 }],
 
   // Deprecated:
   defaultSettings: {},

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -11,9 +11,11 @@ import type {
   Addresses,
   BalanceEvent,
   InitializerConfig,
+  ShieldFundsInfo,
   SpendInfo,
   SpendSuccess,
   StatusEvent,
+  Transaction,
   TransactionEvent,
   UpdateEvent
 } from 'react-native-zcash'
@@ -51,6 +53,7 @@ export interface ZcashSynchronizer {
   deriveUnifiedAddress: () => Promise<Addresses>
   rescan: () => Promise<string>
   sendToAddress: (arg: SpendInfo) => Promise<SpendSuccess>
+  shieldFunds: (shieldFundsInfo: ShieldFundsInfo) => Promise<Transaction>
 }
 
 export type ZcashMakeSynchronizer = () => (

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -47,11 +47,6 @@ export interface ZcashPendingTransaction {
   raw: string
 }
 
-export interface ZcashWalletBalance {
-  availableZatoshi: string
-  totalZatoshi: string
-}
-
 export interface UnifiedViewingKey {
   extfvk: string
   extpub: string
@@ -80,8 +75,10 @@ export type ZcashSynchronizerStatus =
   | 'SYNCED'
 
 export interface ZcashBalanceEvent {
-  availableZatoshi: string
-  totalZatoshi: string
+  transparentAvailableZatoshi: string
+  transparentTotalZatoshi: string
+  saplingAvailableZatoshi: string
+  saplingTotalZatoshi: string
 }
 
 export interface ZcashStatusEvent {

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -103,14 +103,6 @@ export interface ZcashUpdateEvent {
   networkBlockHeight: number
 }
 
-// Block range is inclusive
-export const asZcashBlockRange = asObject({
-  first: asNumber,
-  last: asNumber
-})
-
-export type ZcashBlockRange = ReturnType<typeof asZcashBlockRange>
-
 export const asZcashWalletOtherData = asObject({
   isSdkInitializedOnDisk: asMaybe(asBoolean, false)
 })
@@ -127,10 +119,8 @@ export interface ZcashSynchronizer {
   start: () => Promise<void>
   stop: () => Promise<void>
   deriveUnifiedAddress: () => Promise<ZcashAddresses>
-  getTransactions: (arg: ZcashBlockRange) => Promise<ZcashTransaction[]>
   rescan: () => Promise<string>
   sendToAddress: (arg: ZcashSpendInfo) => Promise<ZcashPendingTransaction>
-  getBalance: () => Promise<ZcashWalletBalance>
 }
 
 export type ZcashMakeSynchronizer = () => (

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -7,6 +7,16 @@ import {
   asString,
   Cleaner
 } from 'cleaners'
+import type {
+  Addresses,
+  BalanceEvent,
+  InitializerConfig,
+  SpendInfo,
+  SpendSuccess,
+  StatusEvent,
+  TransactionEvent,
+  UpdateEvent
+} from 'react-native-zcash'
 import { Subscriber } from 'yaob'
 
 import { asWalletInfo } from '../common/types'
@@ -23,83 +33,6 @@ export interface ZcashNetworkInfo {
   defaultBirthday: number
 }
 
-export interface ZcashSpendInfo {
-  zatoshi: string
-  toAddress: string
-  memo: string
-  fromAccountIndex: number
-  mnemonicSeed: string
-}
-
-export interface ZcashTransaction {
-  rawTransactionId: string
-  raw?: string
-  blockTimeInSeconds: number
-  minedHeight: number
-  value: string
-  fee?: string
-  toAddress?: string
-  memos: string[]
-}
-
-export interface ZcashPendingTransaction {
-  txId: string
-  raw: string
-}
-
-export interface UnifiedViewingKey {
-  extfvk: string
-  extpub: string
-}
-
-export interface ZcashInitializerConfig {
-  networkName: ZcashNetworkName
-  defaultHost: string
-  defaultPort: number
-  mnemonicSeed: string
-  alias: string
-  birthdayHeight: number
-  newWallet: boolean
-}
-
-export interface ZcashAddresses {
-  unifiedAddress: string
-  saplingAddress: string
-  transparentAddress: string
-}
-
-export type ZcashSynchronizerStatus =
-  | 'STOPPED'
-  | 'DISCONNECTED'
-  | 'SYNCING'
-  | 'SYNCED'
-
-export interface ZcashBalanceEvent {
-  transparentAvailableZatoshi: string
-  transparentTotalZatoshi: string
-  saplingAvailableZatoshi: string
-  saplingTotalZatoshi: string
-}
-
-export interface ZcashStatusEvent {
-  alias: string
-  name: ZcashSynchronizerStatus
-}
-
-export interface ZcashTransactionsEvent {
-  transactions: ZcashTransaction[]
-}
-
-export interface ZcashUpdateEvent {
-  alias: string
-  isDownloading: boolean
-  isScanning: boolean
-  lastDownloadedHeight: number
-  lastScannedHeight: number
-  scanProgress: number // 0 - 100
-  networkBlockHeight: number
-}
-
 export const asZcashWalletOtherData = asObject({
   isSdkInitializedOnDisk: asMaybe(asBoolean, false)
 })
@@ -108,21 +41,26 @@ export type ZcashWalletOtherData = ReturnType<typeof asZcashWalletOtherData>
 
 export interface ZcashSynchronizer {
   on: Subscriber<{
-    balanceChanged: ZcashBalanceEvent
-    statusChanged: ZcashStatusEvent
-    transactionsChanged: ZcashTransactionsEvent
-    update: ZcashUpdateEvent
+    balanceChanged: BalanceEvent
+    statusChanged: StatusEvent
+    transactionsChanged: TransactionEvent
+    update: UpdateEvent
   }>
   start: () => Promise<void>
   stop: () => Promise<void>
-  deriveUnifiedAddress: () => Promise<ZcashAddresses>
+  deriveUnifiedAddress: () => Promise<Addresses>
   rescan: () => Promise<string>
-  sendToAddress: (arg: ZcashSpendInfo) => Promise<ZcashPendingTransaction>
+  sendToAddress: (arg: SpendInfo) => Promise<SpendSuccess>
 }
 
 export type ZcashMakeSynchronizer = () => (
-  config: ZcashInitializerConfig
+  config: InitializerConfig
 ) => Promise<ZcashSynchronizer>
+
+export type ZcashBalances = Omit<
+  Omit<BalanceEvent, 'availableZatoshi'>,
+  'totalZatoshi'
+>
 
 export const asZecPublicKey = asObject({
   birthdayHeight: asNumber,

--- a/src/zcash/zcashTypes.ts
+++ b/src/zcash/zcashTypes.ts
@@ -1,4 +1,5 @@
 import {
+  asArray,
   asBoolean,
   asCodec,
   asMaybe,
@@ -36,6 +37,7 @@ export interface ZcashNetworkInfo {
 }
 
 export const asZcashWalletOtherData = asObject({
+  missingAndroidShieldedMemosHack: asMaybe(asArray(asString), () => []),
   isSdkInitializedOnDisk: asMaybe(asBoolean, false)
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6681,11 +6681,12 @@ react-native-piratechain@0.4.0:
   dependencies:
     rfc4648 "^1.3.0"
 
-react-native-zcash@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-zcash/-/react-native-zcash-0.6.0.tgz#27176dab6389b7f5279312661caf1aff1a50757e"
-  integrity sha512-b/Cd/nq08KitBSixxlc2ejWMX6h9foP9u9G2jbjuvxq08klkJsrZlXhLi/CNhAVkImhjCnWJUbM1kTkeaGDlMg==
+react-native-zcash@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-native-zcash/-/react-native-zcash-0.6.1.tgz#31896d9ae5a698f4269a38835b36a2018d090192"
+  integrity sha512-xOdh6SyFzQBWNeZ6Yshz3Apa+GvWKHpEV9g4MvlX6he6Ky2EjsvNSDdtH21G0Sw1BbIts8LMB/xXc7vK5pjy4Q==
   dependencies:
+    biggystring "^4.1.3"
     rfc4648 "^1.3.0"
 
 read-pkg-up@^3.0.0:


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x ] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/react-native-zcash/pull/42

### Description

Add autoshield support. As processor and balance updates come in, the engine will see if it's able to shield available transparent funds. If so, it will hijack the syncNetwork loop to do so. 

There are a handful of sdk issues I had to account for. Missing android memos and recipients on both platforms meant extra code to determine if a transaction was a shielding transaction so it can be tagged correctly.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205458575043813