### PR TITLE
Use walletId for synchronizer alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (Piratechain) Use walletId as synchronizer alias
+
 ## 2.9.1 (2023-11-01)
 
 - fixed: EdgeTxActionSwap direction parsing for XRP transactions

--- a/src/piratechain/PiratechainEngine.ts
+++ b/src/piratechain/PiratechainEngine.ts
@@ -288,7 +288,7 @@ export class PiratechainEngine extends CurrencyEngine<
     this.initializer = {
       mnemonicSeed: piratechainPrivateKeys.mnemonic,
       birthdayHeight: piratechainPrivateKeys.birthdayHeight,
-      alias: this.walletInfo.keys.publicKey.slice(0, 99),
+      alias: this.walletId,
       ...rpcNode
     }
 


### PR DESCRIPTION
On disk data issues can cause syncing loops that are only resolvable by reinstall. This change will allow import key to be an alternative troubleshooting step but at the cost of forcing each wallet to redownload and sync to initialize a synchronizer with a new alias


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205838825636596