### PR TITLE
Ensure at least a 2 GWEI 'tip' to miners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Add `MakeTxDeposit` to support THORChain swap transactions
 - changed: Move `makeTx` params types to common
+- fixed: Possible error in ETH transactions when calculated gasPrice is below baseFee
 
 ## 2.12.0 (2023-11-14)
 

--- a/src/ethereum/fees/ethMiningFees.ts
+++ b/src/ethereum/fees/ethMiningFees.ts
@@ -1,6 +1,6 @@
 import { Common } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
-import { add, ceil, div, gte, lt, lte, mul, sub } from 'biggystring'
+import { add, ceil, div, gte, lt, lte, max, mul, sub } from 'biggystring'
 import { EdgeCurrencyInfo, EdgeSpendInfo } from 'edge-core-js/types'
 import { base16 } from 'rfc4648'
 
@@ -19,6 +19,7 @@ export const ES_FEE_HIGH = 'high'
 export const ES_FEE_CUSTOM = 'custom'
 
 const WEI_MULTIPLIER = '1000000000'
+const TWO_GWEI = '2000000000'
 
 export function calcMiningFees(
   spendInfo: EdgeSpendInfo,
@@ -311,8 +312,13 @@ export async function getFeeParamsByTransactionType(
           'RPC node does not supporting EIP1559 block format.'
       )
     }
+    const maxFeePerGasUnPegged = sub(gasPrice, baseFeePerGas, 16)
+
+    // In case the calculated gasPrice creates a maxPriorityFeePerGas (tip)
+    // less than 2 GWEI, use at least 2 gwei
+    const maxPriorityFeePerGas = max(maxFeePerGasUnPegged, TWO_GWEI, 16)
     return {
-      maxPriorityFeePerGas: sub(gasPrice, baseFeePerGas, 16),
+      maxPriorityFeePerGas,
       maxFeePerGas: gasPrice
     }
   }


### PR DESCRIPTION
This check prevents the maxPriorityFeePerGas from going negative which would error in creating the transaction.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205973322768969