### PR TITLE
Update Coreum currency code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Network adaptor to zkSync for transaction querying
+- changed: (Coreum) Update currency code
 - fixed: Gas estimation regression for spend routines that use eth_estimateGas RPC call
 
 ## 2.17.0 (2023-12-04)

--- a/src/cosmos/info/coreumInfo.ts
+++ b/src/cosmos/info/coreumInfo.ts
@@ -27,7 +27,7 @@ const networkInfo: CosmosNetworkInfo = {
 }
 
 const currencyInfo: EdgeCurrencyInfo = {
-  currencyCode: 'CORE',
+  currencyCode: 'COREUM',
   displayName: 'Coreum',
   pluginId: 'coreum',
   walletType: 'wallet:coreum',
@@ -38,7 +38,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 
   denominations: [
     {
-      name: 'CORE',
+      name: 'COREUM',
       multiplier: '1000000',
       symbol: ''
     }


### PR DESCRIPTION
Coreum is standardizing the ticker as COREUM instead of CORE


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206099991498416