### PR TITLE
Overestimate Thorchain transaction fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: (Solana) Versioned transaction parsing
 - added: Add deprecated `memoType` to piratechainInfo for backwards compatibility
+- added: (Thorchain) Overestimate network fee to ensure confirmation
 - changed: (Cosmos) Ignore events with nonstandard hyphenated denoms
 
 ## 3.0.2 (2024-01-22)

--- a/src/cosmos/CosmosEngine.ts
+++ b/src/cosmos/CosmosEngine.ts
@@ -604,6 +604,11 @@ export class CosmosEngine extends CurrencyEngine<
     } else {
       // Only Thorchain uses defaultTransactionFeeUrl
       networkFee = await this.totalDynamicNetworkFee(messages)
+
+      // For Thorchain, the exact fee isn't known until the transaction is confirmed.
+      // This would most commonly be an issue for max spends but we should overestimate
+      // the fee for all spends.
+      networkFee = mul(networkFee, '1.01')
     }
 
     return {


### PR DESCRIPTION
The fee isn't finalized until confirmation so we need to leave for the fee to change until the transaction is broadcast.
