### PR TITLE
Use decimal values from EVM scan fee API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 3.0.4 (2024-01-30)
 
 - changed: (Solana) Incorporate rent threshold into insufficient funds checks
+- fixed: (Fantom) Include decimal values in fee rates from EVM scan to fix 'transaction underpriced' errors
 
 ## 3.0.3 (2024-01-29)
 

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -525,8 +525,7 @@ export class EthereumEngine extends CurrencyEngine<
    *  Fetch network fees from various providers in order of priority, stopping
    *  and writing upon successful result.
    */
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  async updateNetworkFees() {
+  async updateNetworkFees(): Promise<void> {
     // Update network gasPrice:
     for (const externalFeeProvider of this.externalFeeProviders) {
       try {
@@ -723,11 +722,13 @@ export class EthereumEngine extends CurrencyEngine<
         }
       })
       .catch(() => this.warn('Error fetching fees from Info Server'))
-      .finally(
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        async () =>
-          await this.addToLoop('updateNetworkFees', feeUpdateFrequencyMs)
-      )
+      .finally(() => {
+        this.addToLoop('updateNetworkFees', feeUpdateFrequencyMs).catch(err =>
+          this.warn(
+            `Error setting up updateNetworkFees addToLoop: ${String(err)}`
+          )
+        )
+      })
     this.addToLoop('updateL1RollupParams', ROLLUP_FEE_PARAMS).catch(() => {})
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.ethNetwork.needsLoop()

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -168,9 +168,9 @@ export const fetchFeesFromEvmScan = async (
 
   const { SafeGasPrice, ProposeGasPrice, FastGasPrice } =
     asEvmScanGasResponseResult(esGasResponse.result)
-  const newSafeLow = parseInt(SafeGasPrice)
-  let newAverage = parseInt(ProposeGasPrice)
-  let newFast = parseInt(FastGasPrice)
+  const newSafeLow = parseFloat(SafeGasPrice)
+  let newAverage = parseFloat(ProposeGasPrice)
+  let newFast = parseFloat(FastGasPrice)
 
   // Correct inconsistencies, convert values
   if (newAverage <= newSafeLow) newAverage = newSafeLow + 1


### PR DESCRIPTION
We should include the decimal value in our calculation to be more
precise in our conversion from GWEI to WEI. This is important for some
currencies like Fantom which will reject transactions if their fee is
too low which may happen due to rounding down.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206237652275804