### PR TITLE
Add fallback balance query for unstake funds chain bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (FIO) Use a backup balance method for accounts affected by unstake chain data issue
+
 ## 3.1.0 (2024-02-12)
 
 - added: Arbitrum One network support

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -261,12 +261,13 @@ export const fetchFeesFromEvmGasStation = async (
 
 export const fetchFeesFromInfoServer = async (
   fetch: EdgeFetchFunction,
-  { pluginId }: EdgeCurrencyInfo
+  { pluginId }: EdgeCurrencyInfo,
+  opts: { timeout?: number } = {}
 ): Promise<EthereumFees> => {
   const result = await fetchInfo(
     `v1/networkFees/${pluginId}`,
     undefined,
-    undefined,
+    opts.timeout,
     fetch
   )
   const json = await result.json()

--- a/src/fio/fioConst.ts
+++ b/src/fio/fioConst.ts
@@ -207,3 +207,5 @@ export type FioWalletOtherData = ReturnType<typeof asFioWalletOtherData>
 
 export const NO_FIO_NAMES = 'No FIO names'
 export const PUBLIC_KEY_NOT_FOUND = 'Public key not found'
+export const MAINNET_LOCKS_ERROR =
+  'Unexpected number of results found for main net locks'

--- a/test/engine/feeProvider.test.ts
+++ b/test/engine/feeProvider.test.ts
@@ -17,7 +17,10 @@ import { fakeLog } from '../fake/fakeLog'
 // TODO: Loop for all plugins
 describe(`FTM Network Fees`, function () {
   it('Validate Info Server Fees', async function () {
-    const fees = await fetchFeesFromInfoServer(fetch, ftmCurrencyInfo)
+    this.timeout(5000)
+    const fees = await fetchFeesFromInfoServer(fetch, ftmCurrencyInfo, {
+      timeout: 5000
+    })
     validateGasPrices(fees.default.gasPrice, true)
     // Info server should provide gas limit as well
     assert.equal(fees.default.gasLimit?.regularTransaction, '21000')


### PR DESCRIPTION
This allows the wallet to still get a balance if they are affected by the unstake bug. The balance is necessary so they can take the necessary actions to fix their account's onchain data.

https://fioprotocol.atlassian.net/wiki/spaces/DAO/pages/852688908/2024-02-07+Token+Locking+Issue+on+Unstake


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206526184999703