### PR TITLE
Update Pulsechain integrations for fetching transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: Cosmos token balance query
+- fixed: (PLS) update evmscan adapter servers for Pulsechain to fix transaction history queries
 
 ## 3.1.1 (2024-02-14)
 
@@ -97,7 +98,7 @@
 
 ## 2.17.1 (2023-12-07)
 
-- added: Network adaptor to zkSync for transaction querying
+- added: Network adapter to zkSync for transaction querying
 - changed: (Coreum) Update currency code
 - fixed: Gas estimation regression for spend routines that use eth_estimateGas RPC call
 - fixed: (Tron) Fix unstake v2 native amount

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (PLS) Integrate new v2 API for Pulsechain as a pulsechain-scan adapter
 - fixed: Cosmos token balance query
 - fixed: (PLS) update evmscan adapter servers for Pulsechain to fix transaction history queries
 

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -830,8 +830,8 @@ export class EthereumEngine extends CurrencyEngine<
           l1Fee = calcOptimismRollupFees(txData)
         } else if (this.networkInfo.arbitrumRollupParams != null) {
           const rpcServers = this.ethNetwork.networkAdapters
-            .filter(adaptor => adaptor.config.type === 'rpc')
-            .map(adaptor => adaptor.config.servers)
+            .filter(adapter => adapter.config.type === 'rpc')
+            .map(adapter => adapter.config.servers)
             .flat()
           const { l1Gas, l1GasPrice } = await calcArbitrumRollupFees({
             destinationAddress: publicAddress,
@@ -1054,8 +1054,8 @@ export class EthereumEngine extends CurrencyEngine<
       l1Fee = calcOptimismRollupFees(txData)
     } else if (this.networkInfo.arbitrumRollupParams != null) {
       const rpcServers = this.ethNetwork.networkAdapters
-        .filter(adaptor => adaptor.config.type === 'rpc')
-        .map(adaptor => adaptor.config.servers)
+        .filter(adapter => adapter.config.type === 'rpc')
+        .map(adapter => adapter.config.servers)
         .flat()
       const { l1Gas, l1GasPrice } = await calcArbitrumRollupFees({
         destinationAddress: publicAddress,

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -331,24 +331,6 @@ export class EthereumNetwork {
     }
   }
 
-  getQueryHeightWithLookback(queryHeight: number): number {
-    if (queryHeight > ADDRESS_QUERY_LOOKBACK_BLOCKS) {
-      // Only query for transactions as far back as ADDRESS_QUERY_LOOKBACK_BLOCKS from the last time we queried transactions
-      return queryHeight - ADDRESS_QUERY_LOOKBACK_BLOCKS
-    } else {
-      return 0
-    }
-  }
-
-  getQueryDateWithLookback(date: number): number {
-    if (date > ADDRESS_QUERY_LOOKBACK_SEC) {
-      // Only query for transactions as far back as ADDRESS_QUERY_LOOKBACK_SEC from the last time we queried transactions
-      return date - ADDRESS_QUERY_LOOKBACK_SEC
-    } else {
-      return 0
-    }
-  }
-
   async needsLoop(): Promise<void> {
     while (this.ethEngine.engineOn) {
       const preUpdateBlockHeight = this.ethEngine.walletLocalData.blockHeight
@@ -409,11 +391,17 @@ export class EthereumNetwork {
           preUpdateBlockHeight,
           async (): Promise<EthereumNetworkUpdate> => {
             const params = {
-              startBlock: this.getQueryHeightWithLookback(
-                this.ethEngine.walletLocalData.lastTransactionQueryHeight[tk]
+              // Only query for transactions as far back as ADDRESS_QUERY_LOOKBACK_BLOCKS from the last time we queried transactions
+              startBlock: Math.max(
+                this.ethEngine.walletLocalData.lastTransactionQueryHeight[tk] -
+                  ADDRESS_QUERY_LOOKBACK_BLOCKS,
+                0
               ),
-              startDate: this.getQueryDateWithLookback(
-                this.ethEngine.walletLocalData.lastTransactionDate[tk]
+              // Only query for transactions as far back as ADDRESS_QUERY_LOOKBACK_SEC from the last time we queried transactions
+              startDate: Math.max(
+                this.ethEngine.walletLocalData.lastTransactionDate[tk] -
+                  ADDRESS_QUERY_LOOKBACK_SEC,
+                0
               ),
               currencyCode: tk
             }

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -356,7 +356,7 @@ export class EthereumNetwork {
         currencyCodes.push(currencyCode)
       }
 
-      // The engine supports token balances batch queries if an adaptor provides
+      // The engine supports token balances batch queries if an adapter provides
       // the functionality.
       const isFetchTokenBalancesSupported =
         this.networkAdapters.find(

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -15,6 +15,7 @@ import { BlockchairAdapter } from './networkAdapters/BlockchairAdapter'
 import { BlockcypherAdapter } from './networkAdapters/BlockcypherAdapter'
 import { EvmScanAdapter } from './networkAdapters/EvmScanAdapter'
 import { FilfoxAdapter } from './networkAdapters/FilfoxAdapter'
+import { PulsechainScanAdapter } from './networkAdapters/PulsechainScanAdapter'
 import { RpcAdapter } from './networkAdapters/RpcAdapter'
 import {
   NetworkAdapter,
@@ -561,6 +562,8 @@ const makeNetworkAdapter = (
       return new EvmScanAdapter(ethEngine, config)
     case 'filfox':
       return new FilfoxAdapter(ethEngine, config)
+    case 'pulsechain-scan':
+      return new PulsechainScanAdapter(ethEngine, config)
     case 'rpc':
       return new RpcAdapter(ethEngine, config)
   }

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -53,6 +53,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       servers: ['https://api.scan.pulsechain.com']
+    },
+    {
+      type: 'pulsechain-scan',
+      servers: ['https://api.scan.pulsechain.com']
     }
   ],
   uriNetworks: ['pulsechain'],

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -52,7 +52,7 @@ const networkInfo: EthereumNetworkInfo = {
     },
     {
       type: 'evmscan',
-      servers: ['https://scan.pulsechain.com']
+      servers: ['https://api.scan.pulsechain.com']
     }
   ],
   uriNetworks: ['pulsechain'],

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -387,14 +387,8 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
         }
       }
     } else {
-      // Receive
-      if (tokenTx) {
-        nativeAmount = tx.value
-        networkFee = '0'
-      } else {
-        nativeAmount = tx.value
-        networkFee = '0'
-      }
+      nativeAmount = tx.value
+      networkFee = '0'
       ourReceiveAddresses.push(this.ethEngine.walletLocalData.publicKey)
     }
 

--- a/src/ethereum/networkAdapters/PulsechainScanAdapter.ts
+++ b/src/ethereum/networkAdapters/PulsechainScanAdapter.ts
@@ -1,0 +1,255 @@
+import { mul, sub } from 'biggystring'
+import {
+  asArray,
+  asBoolean,
+  asJSON,
+  asNumber,
+  asObject,
+  asOptional,
+  asString
+} from 'cleaners'
+import { EdgeTransaction } from 'edge-core-js/types'
+
+import { EthereumNetworkUpdate, getFeeRateUsed } from '../EthereumNetwork'
+import { EthereumTxOtherParams } from '../ethereumTypes'
+import { GetTxsParams, NetworkAdapter } from './types'
+
+export interface PulsechainScanAdapterConfig {
+  type: 'pulsechain-scan'
+  servers: string[]
+}
+
+export class PulsechainScanAdapter extends NetworkAdapter<PulsechainScanAdapterConfig> {
+  fetchBlockheight = null
+  broadcast = null
+  getBaseFeePerGas = null
+  multicastRpc = null
+  fetchNonce = null
+  fetchTokenBalance = null
+  fetchTokenBalances = null
+
+  currentScan: Promise<EthereumNetworkUpdate> | undefined
+
+  fetchTxs = async (params: GetTxsParams): Promise<EthereumNetworkUpdate> => {
+    try {
+      // We shouldn't start scanning if scanning is already happening:
+      if (this.currentScan != null) {
+        return await this.currentScan
+      }
+
+      this.currentScan = this.checkTransactions(params)
+      const update = await this.currentScan
+      return update
+    } catch (error) {
+      console.error(error)
+      throw error
+    } finally {
+      this.currentScan = undefined
+    }
+  }
+
+  private async checkTransactions(
+    params: GetTxsParams
+  ): Promise<EthereumNetworkUpdate> {
+    const { startBlock, currencyCode } = params
+    const address = this.ethEngine.walletLocalData.publicKey
+
+    const scanTransactions: PulsechainScanTransaction[] = []
+    let nextPageParams: NextPageParams | undefined
+
+    while (true) {
+      const responseData = await this.queryTransactions(address, nextPageParams)
+
+      scanTransactions.push(...responseData.items)
+      nextPageParams = responseData.next_page_params
+
+      // Exit if a transaction block height is less than/equal to the startBlock:
+      if (responseData.items.some(scanTx => scanTx.block <= startBlock)) break
+
+      // Exit if there is no next page of transactions:
+      if (nextPageParams == null) break
+    }
+
+    // Convert the transaction data into EdgeTransactions:
+    const edgeTransactions: EdgeTransaction[] = scanTransactions.map(tx =>
+      this.processScanTransaction(tx, currencyCode)
+    )
+
+    return {
+      tokenTxs: {
+        [currencyCode]: {
+          blockHeight: startBlock,
+          edgeTransactions
+        }
+      },
+      server: this.config.servers.join(',')
+    }
+  }
+
+  private processScanTransaction(
+    scanTx: PulsechainScanTransaction,
+    currencyCode: string
+  ): EdgeTransaction {
+    const ourReceiveAddresses: string[] = []
+
+    const txid = scanTx.hash
+    if (txid == null) {
+      throw new Error('Invalid transaction result format')
+    }
+
+    const isSpend =
+      scanTx.from.hash.toLowerCase() ===
+      this.ethEngine.walletLocalData.publicKey.toLowerCase()
+    const tokenTx = currencyCode !== this.ethEngine.currencyInfo.currencyCode
+
+    const gasPrice = scanTx.gas_price
+    const nativeNetworkFee: string =
+      gasPrice != null ? mul(gasPrice, scanTx.gas_used) : '0'
+
+    let nativeAmount: string
+    let networkFee: string
+    let parentNetworkFee: string | undefined
+
+    if (isSpend) {
+      if (tokenTx) {
+        nativeAmount = sub('0', scanTx.value)
+        networkFee = '0'
+        parentNetworkFee = nativeNetworkFee
+      } else {
+        // Spend to self. netNativeAmount is just the fee
+        if (scanTx.from.hash.toLowerCase() === scanTx.to.hash.toLowerCase()) {
+          nativeAmount = sub('0', nativeNetworkFee)
+          networkFee = nativeNetworkFee
+        } else {
+          nativeAmount = sub(sub('0', scanTx.value), nativeNetworkFee)
+          networkFee = nativeNetworkFee
+        }
+      }
+    } else {
+      nativeAmount = scanTx.value
+      networkFee = '0'
+      ourReceiveAddresses.push(this.ethEngine.walletLocalData.publicKey)
+    }
+
+    const otherParams: EthereumTxOtherParams = {
+      from: [scanTx.from.hash],
+      to: [scanTx.to.hash],
+      gas: scanTx.gas_limit,
+      gasPrice: gasPrice ?? '',
+      gasUsed: scanTx.gas_used,
+      isFromMakeSpend: false
+    }
+
+    let blockHeight = scanTx.block
+    if (blockHeight < 0) blockHeight = 0
+
+    const edgeTransaction: EdgeTransaction = {
+      blockHeight,
+      currencyCode,
+      date: parseInt(scanTx.timestamp),
+      feeRateUsed:
+        gasPrice != null
+          ? getFeeRateUsed(gasPrice, scanTx.gas_limit, scanTx.gas_used)
+          : undefined,
+      isSend: nativeAmount.startsWith('-'),
+      memos: [],
+      nativeAmount,
+      networkFee,
+      otherParams,
+      ourReceiveAddresses,
+      parentNetworkFee,
+      signedTx: '',
+      txid,
+      walletId: this.ethEngine.walletId
+    }
+
+    return edgeTransaction
+  }
+
+  private async queryTransactions(
+    address: string,
+    nextPageParams?: NextPageParams
+  ): Promise<PulsechainScanAddressTransactionsResponse> {
+    return await this.serialServers(async server => {
+      const endpoint = `addresses/${address}/transactions`
+      const params =
+        nextPageParams != null
+          ? new URLSearchParams(nextPageParams as any).toString()
+          : ''
+      const url = `${server}/api/v2/${endpoint}?${params}`
+      const response = await this.ethEngine.fetchCors(url, {
+        method: 'GET',
+        headers: {
+          'content-type': 'application/json'
+        }
+      })
+      const responseText = await response.text()
+      const responseData =
+        asPulsechainScanAddressTransactionsResponse(responseText)
+      return responseData
+    })
+  }
+}
+
+//
+// Cleaners
+//
+
+const asAddress = asObject({
+  hash: asString,
+  is_contract: asOptional(asBoolean),
+  is_verified: asOptional(asBoolean)
+})
+
+// Note: Commented out fields are not used by the plugin
+const asPulsechainScanAddressTransaction = asObject({
+  timestamp: asString,
+  // fee: asObject({
+  //   type: asString,
+  //   value: asString
+  // }),
+  gas_limit: asString,
+  block: asNumber,
+  // status: asString,
+  // confirmations: asNumber,
+  // type: asNumber,
+  to: asAddress,
+  from: asAddress,
+  hash: asString,
+  gas_price: asString,
+  // base_fee_per_gas: asOptional(asString),
+  gas_used: asString,
+  value: asString
+  // actions: asArray(asNull),
+  // tx_types: asArray(asString),
+  // position: asNumber,
+  // nonce: asNumber,
+  // has_error_in_internal_txs: asBoolean,
+  // confirmation_duration: asArray(asNumber)
+})
+type PulsechainScanTransaction = ReturnType<
+  typeof asPulsechainScanAddressTransaction
+>
+
+const asNextPageParams = asObject({
+  block_number: asNumber,
+  fee: asString,
+  hash: asString,
+  index: asNumber,
+  inserted_at: asString,
+  items_count: asNumber,
+  value: asString
+})
+
+type NextPageParams = ReturnType<typeof asNextPageParams>
+
+const asPulsechainScanAddressTransactionsResponse = asJSON(
+  asObject({
+    items: asArray(asPulsechainScanAddressTransaction),
+    next_page_params: asOptional(asNextPageParams)
+  })
+)
+
+type PulsechainScanAddressTransactionsResponse = ReturnType<
+  typeof asPulsechainScanAddressTransactionsResponse
+>

--- a/src/ethereum/networkAdapters/RpcAdapter.ts
+++ b/src/ethereum/networkAdapters/RpcAdapter.ts
@@ -282,7 +282,7 @@ export class RpcAdapter extends NetworkAdapter<RpcAdapterConfig> {
   /**
    * Check the eth-balance-checker contract for balances
    */
-  // fetchTokenBalances is defined on this adaptor only if ethBalCheckerContract is defined
+  // fetchTokenBalances is defined on this adapter only if ethBalCheckerContract is defined
   fetchTokenBalances =
     this.config.ethBalCheckerContract == null
       ? null

--- a/src/ethereum/networkAdapters/types.ts
+++ b/src/ethereum/networkAdapters/types.ts
@@ -16,6 +16,7 @@ import { BlockchairAdapterConfig } from './BlockchairAdapter'
 import { BlockcypherAdapterConfig } from './BlockcypherAdapter'
 import { EvmScanAdapterConfig } from './EvmScanAdapter'
 import { FilfoxAdapterConfig } from './FilfoxAdapter'
+import { PulsechainScanAdapterConfig } from './PulsechainScanAdapter'
 import { RpcAdapterConfig } from './RpcAdapter'
 
 export interface GetTxsParams {
@@ -31,6 +32,7 @@ export type NetworkAdapterConfig =
   | BlockcypherAdapterConfig
   | EvmScanAdapterConfig
   | FilfoxAdapterConfig
+  | PulsechainScanAdapterConfig
   | RpcAdapterConfig
 
 export type NetworkAdapterUpdateMethod = keyof Pick<


### PR DESCRIPTION
### Note about this PR

The old API which is evmscan/blockscout compatible was added as a commit after I did the integration even though that commit proceeds the new integration commit. The new API commit is to include all the new API for PLS as a fallback adaptor now. I figured it’s worth merging this integration into the codebase because I spent the time working on it. The new API isn’t as good as the evmscan adaptor because I am unable to figure out how to get the “next page” parameters to match the passed “startBlock” parameter.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206163473998245