### PR TITLE
Force Zcash and Piratechain imports to have 24 words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: (PLS) Integrate new v2 API for Pulsechain as a pulsechain-scan adapter
+- changed: (Zcash/Piratechain) Enforce 24 word seed length for imports
 - fixed: (PLS) update evmscan adapter servers for Pulsechain to fix transaction history queries
 - fixed: Polluting fetchTx call params with NaN causing error responses
 

--- a/src/piratechain/PiratechainTools.ts
+++ b/src/piratechain/PiratechainTools.ts
@@ -84,6 +84,9 @@ export class PiratechainTools implements EdgeCurrencyTools {
   ): Promise<Object> {
     const { pluginId } = this.currencyInfo
     const isValid = validateMnemonic(userInput)
+    if (userInput.split(' ').length !== 24) {
+      throw new Error('Mnemonic must be 24 words')
+    }
     if (!isValid)
       throw new Error(`Invalid ${this.currencyInfo.currencyCode} mnemonic`)
 

--- a/src/zcash/ZcashTools.ts
+++ b/src/zcash/ZcashTools.ts
@@ -84,6 +84,9 @@ export class ZcashTools implements EdgeCurrencyTools {
   ): Promise<Object> {
     const { pluginId } = this.currencyInfo
     const isValid = validateMnemonic(userInput)
+    if (userInput.split(' ').length !== 24) {
+      throw new Error('Mnemonic must be 24 words')
+    }
     if (!isValid)
       throw new Error(`Invalid ${this.currencyInfo.currencyCode} mnemonic`)
 


### PR DESCRIPTION
This is enforced by the sdk. Throwing here prevents the wallet from being created


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206270926523609