### PR TITLE
Add ss58 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Unique ss58 encoding for Polkadot currencies
 - fixed: Missing FIO transactions due to missing 'trnsfiopubky' tx type
 
 ## 3.2.2 (2024-03-05)

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -560,7 +560,7 @@ export class PolkadotEngine extends CurrencyEngine<
     )
 
     if (this.keypair == null) {
-      this.keypair = new Keyring({ ss58Format: 0 })
+      this.keypair = new Keyring({ ss58Format: this.networkInfo.ss58Format })
       if (polkadotPrivateKeys.mnemonic != null) {
         this.keypair.addFromUri(polkadotPrivateKeys.mnemonic)
       } else {

--- a/src/polkadot/PolkadotTools.ts
+++ b/src/polkadot/PolkadotTools.ts
@@ -91,7 +91,7 @@ export class PolkadotTools implements EdgeCurrencyTools {
 
   async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
     const { pluginId } = this.currencyInfo
-    const keyring = new Keyring({ ss58Format: 0 })
+    const keyring = new Keyring({ ss58Format: this.networkInfo.ss58Format })
     const pair = keyring.addFromUri(walletInfo.keys[`${pluginId}Mnemonic`])
     return {
       publicKey: pair.address

--- a/src/polkadot/info/liberlandInfo.ts
+++ b/src/polkadot/info/liberlandInfo.ts
@@ -18,6 +18,7 @@ const builtinTokens: EdgeTokenMap = {
 
 const networkInfo: PolkadotNetworkInfo = {
   rpcNodes: ['wss://mainnet.liberland.org/'],
+  ss58Format: 42,
   subscanBaseUrl: undefined,
   subscanQueryLimit: 100,
   partialFeeOffsetMultiplier: '2',

--- a/src/polkadot/info/liberlandTestnetInfo.ts
+++ b/src/polkadot/info/liberlandTestnetInfo.ts
@@ -18,6 +18,7 @@ const builtinTokens: EdgeTokenMap = {
 
 const networkInfo: PolkadotNetworkInfo = {
   rpcNodes: ['wss://testchain.liberland.org/'],
+  ss58Format: 42,
   subscanBaseUrl: undefined,
   subscanQueryLimit: 100,
   partialFeeOffsetMultiplier: '2',

--- a/src/polkadot/info/polkadotInfo.ts
+++ b/src/polkadot/info/polkadotInfo.ts
@@ -6,6 +6,7 @@ import type { PolkadotNetworkInfo } from '../polkadotTypes'
 
 const networkInfo: PolkadotNetworkInfo = {
   rpcNodes: ['wss://rpc.polkadot.io'],
+  ss58Format: 0,
   subscanBaseUrl: 'https://polkadot.api.subscan.io/api',
   subscanQueryLimit: 100,
   partialFeeOffsetMultiplier: '1',

--- a/src/polkadot/polkadotTypes.ts
+++ b/src/polkadot/polkadotTypes.ts
@@ -15,6 +15,7 @@ import { asSafeCommonWalletInfo } from '../common/types'
 
 export interface PolkadotNetworkInfo {
   rpcNodes: string[]
+  ss58Format: number
   subscanBaseUrl: string | undefined
   subscanQueryLimit: number
   lengthFeePerByte: string


### PR DESCRIPTION
Previous encodings do not impact the wallet's ability to get a balance or spend funds. This means new wallets do not need to save the ss58 encoding used at creation.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206701033325513