### PR TITLE
Remove `LastEstimatedGasLimit` caching mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (zkSync) fixed gas limit estimation failures due to caching last estimations
+
 ## 3.2.3 (2024-03-06)
 
 - added: Unique ss58 encoding for Polkadot currencies

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -188,12 +188,6 @@ export interface CalcOptimismRollupFeeParams {
   gasPriceL1Wei: string
 }
 
-export interface LastEstimatedGasLimit {
-  publicAddress: string
-  contractAddress: string | undefined
-  gasLimit: string
-}
-
 export const asEvmScancanTokenTransaction = asObject({
   blockNumber: asString,
   timeStamp: asString,


### PR DESCRIPTION
The reason for this caching appears to only be an optimization. This
optimization cannot be used because zkSync's gas estimation changes when
the transaction value parameter changes. Because chains like zkSync may
change the gas estimation based on the parameters, there is no reason to
cache unless all the parameters are the same. However, there is no
UX instance where the estimation call is made with identical parameters
to warrant the optimization.

Instead, anywhere that the caching is needed, whether for optimization
or for correctness, the implementation for the caching should be done
within that routine.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206673671805801