### PR TITLE
Unit-test the `validateMemos` function

### DIFF
--- a/src/common/validateMemos.ts
+++ b/src/common/validateMemos.ts
@@ -56,7 +56,7 @@ function getMemoError(
     option.maxLength != null &&
     memo.value.length > option.maxLength
   ) {
-    return `cannot be longer than ${option.maxLength}`
+    return `cannot be longer than ${option.maxLength} characters`
   }
 
   if (option.type === 'number') {

--- a/test/utils/validateMemos.test.ts
+++ b/test/utils/validateMemos.test.ts
@@ -1,0 +1,149 @@
+import { expect } from 'chai'
+import { EdgeCurrencyInfo, EdgeMemo } from 'edge-core-js'
+import { describe, it } from 'mocha'
+
+import { validateMemos } from '../../src/common/validateMemos'
+
+describe('validateMemos', function () {
+  function callValidateMemos(
+    memos: EdgeMemo[],
+    extraInfo: Partial<EdgeCurrencyInfo>
+  ): void {
+    return validateMemos(
+      {
+        spendTargets: [],
+        tokenId: null,
+        memos
+      },
+      {
+        addressExplorer: '',
+        currencyCode: 'MTC',
+        denominations: [],
+        displayName: 'Memo Test Coin',
+        pluginId: 'memoTest',
+        transactionExplorer: '',
+        walletType: 'wallet:memoTest',
+        ...extraInfo
+      }
+    )
+  }
+
+  it('rejects multiple memos', function () {
+    expect(() =>
+      callValidateMemos(
+        [
+          { type: 'hex', value: '' },
+          { type: 'hex', value: '' }
+        ],
+        { memoOptions: [{ type: 'hex' }] }
+      )
+    ).to.throw('Memo Test Coin only supports one memo')
+  })
+
+  it('accepts multiple memos', function () {
+    callValidateMemos(
+      [
+        { type: 'text', value: '' },
+        { type: 'hex', value: '' }
+      ],
+      {
+        memoOptions: [{ type: 'hex' }, { type: 'text' }],
+        multipleMemos: true
+      }
+    )
+  })
+
+  it('validates hex memos', function () {
+    const extraInfo: Partial<EdgeCurrencyInfo> = {
+      memoOptions: [
+        {
+          type: 'hex',
+          memoName: 'data',
+          minBytes: 2,
+          maxBytes: 4
+        }
+      ]
+    }
+
+    // Good:
+    callValidateMemos([{ type: 'hex', value: '1234' }], extraInfo)
+    callValidateMemos([{ type: 'hex', value: '123456' }], extraInfo)
+    callValidateMemos([{ type: 'hex', value: '12345678' }], extraInfo)
+
+    // Bad:
+    expect(() =>
+      callValidateMemos([{ type: 'hex', value: '0xff' }], extraInfo)
+    ).throws('Memo Test Coin data: is not valid hexadecimal')
+    expect(() =>
+      callValidateMemos([{ type: 'hex', value: 'ff' }], extraInfo)
+    ).throws('Memo Test Coin data: cannot be shorter than 2 bytes')
+    expect(() =>
+      callValidateMemos([{ type: 'hex', value: 'ff12345678' }], extraInfo)
+    ).throws('Memo Test Coin data: cannot be longer than 4 bytes')
+    expect(() =>
+      callValidateMemos([{ type: 'text', value: 'hello' }], extraInfo)
+    ).throws('Memo Test Coin data: cannot be type text')
+  })
+
+  it('validates number memos', function () {
+    const extraInfo: Partial<EdgeCurrencyInfo> = {
+      memoOptions: [
+        {
+          type: 'number',
+          memoName: 'tag',
+          maxValue: '256'
+        }
+      ]
+    }
+
+    // Good:
+    callValidateMemos([{ type: 'number', value: '255' }], extraInfo)
+    callValidateMemos([{ type: 'number', value: '256' }], extraInfo)
+
+    // Bad:
+    expect(() =>
+      callValidateMemos([{ type: 'number', value: '257' }], extraInfo)
+    ).throws('Memo Test Coin tag: cannot be greater than 256')
+    expect(() =>
+      callValidateMemos([{ type: 'number', value: '1b' }], extraInfo)
+    ).throws('Memo Test Coin tag: is not a valid number')
+    expect(() =>
+      callValidateMemos([{ type: 'number', value: '1.0' }], extraInfo)
+    ).throws('Memo Test Coin tag: is not a valid number')
+    expect(() =>
+      callValidateMemos([{ type: 'number', value: '-1' }], extraInfo)
+    ).throws('Memo Test Coin tag: is not a valid number')
+    expect(() =>
+      callValidateMemos([{ type: 'hex', value: '12345678' }], extraInfo)
+    ).throws('Memo Test Coin tag: cannot be type hex')
+  })
+
+  it('validates string memos', function () {
+    const extraInfo: Partial<EdgeCurrencyInfo> = {
+      memoOptions: [
+        {
+          type: 'text',
+          memoName: 'message',
+          maxLength: 6
+        }
+      ]
+    }
+
+    // Good:
+    callValidateMemos([{ type: 'text', value: '' }], extraInfo)
+    callValidateMemos([{ type: 'text', value: 'hello' }], extraInfo)
+    callValidateMemos([{ type: 'text', value: '1234' }], extraInfo)
+    callValidateMemos([{ type: 'text', value: '0x1234' }], extraInfo)
+
+    // Bad:
+    expect(() =>
+      callValidateMemos([{ type: 'text', value: 'hello!!' }], extraInfo)
+    ).throws('Memo Test Coin message: cannot be longer than 6 characters')
+    expect(() =>
+      callValidateMemos([{ type: 'hex', value: '1234' }], extraInfo)
+    ).throws('Memo Test Coin message: cannot be type hex')
+    expect(() =>
+      callValidateMemos([{ type: 'number', value: '12345678' }], extraInfo)
+    ).throws('Memo Test Coin message: cannot be type number')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

We had reports that `makeSpend` would succeed with "0x" in our memos, but that the transactions would fail on-chain. Well, no, `makeSpend` won't actually allow this situation, at least in the current release.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206985639130703