### PR TITLE
Fix DOT max spending caused by incorrectly checking `spendInfo.tokenId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (DOT) Fix incorrect insufficient funds error for max spend of native DOT currency in Polkadot engine
+
 ## 4.3.2 (2024-05-09)
 
 - changed: Update Zcash and Tezos nodes.

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -335,7 +335,7 @@ export class PolkadotEngine extends CurrencyEngine<
       tokenId
     })
 
-    if (tokenId == null) {
+    if (tokenId != null) {
       const tempSpendTarget = [
         {
           publicAddress: spendInfo.spendTargets[0].publicAddress,


### PR DESCRIPTION
It looks like this bug slipped in during the edge-core-js v2 upgrade.
The logic used to compare spend info currency code inequality with
engine currency code.
This change is the correct condition for the refactor.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207258762926303