### PR TITLE
Disable archive node for Cosmos Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - changed: (Solana) Upgrade SDKs
+- removed: (ATOM) Archive transaction query
 
 ## 4.5.3 (2024-05-28)
 

--- a/src/cosmos/CosmosEngine.ts
+++ b/src/cosmos/CosmosEngine.ts
@@ -496,6 +496,7 @@ export class CosmosEngine extends CurrencyEngine<
       )
     ]
     const clients =
+      this.networkInfo.archiveNode != null &&
       Date.now() - TWO_WEEKS > this.otherData.archivedTxLastCheckTime
         ? // Uses archive rpc for first sync and then only if it's been two weeks between syncs.
           await createCosmosClients(

--- a/src/cosmos/cosmosTypes.ts
+++ b/src/cosmos/cosmosTypes.ts
@@ -77,7 +77,7 @@ export interface CosmosNetworkInfo {
   nativeDenom: string
   pluginMnemonicKeyName: string
   rpcNode: HttpEndpoint
-  archiveNode: HttpEndpoint
+  archiveNode?: HttpEndpoint // If no archive node, the rpc node will be used and only grab transaction in a limited range
 }
 const asHttpEndpoint = asObject({
   url: asString,

--- a/src/cosmos/info/cosmoshubInfo.ts
+++ b/src/cosmos/info/cosmoshubInfo.ts
@@ -16,11 +16,11 @@ const networkInfo: CosmosNetworkInfo = {
   rpcNode: {
     url: 'https://cosmos-rpc.publicnode.com:443',
     headers: {}
-  },
-  archiveNode: {
-    url: 'https://cosmosarchive-rpc.quickapi.com:443',
-    headers: {}
   }
+  // archiveNode: {
+  //   url: 'https://cosmosarchive-rpc.quickapi.com:443',
+  //   headers: {}
+  // }
 }
 
 const currencyInfo: EdgeCurrencyInfo = {


### PR DESCRIPTION
Recent-ish transaction will still be visible but historical will not. Will need replacement.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207361376123588
  - https://app.asana.com/0/0/1207409592447625