### PR TITLE
Expose non-cached getters for addresses, names, and domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Public FIO fetch fns to return non-cached addresses and domains
+
 ## 4.21.0 (2024-08-29)
 
 - added: POL token on Ethereum.


### PR DESCRIPTION
We need the ability to provide fresh data on demand to the GUI. Previously, refreshing this data was only done in `checkAccountInnerLoop` .

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208153057785487