### PR TITLE
Fix Arbitrum fee calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: Display name COMBO (Ethereum) to Furucombo
+- fixed: Calculate Arbitrum fees more correctly.
 
 ## 4.20.0 (2024-08-19)
 

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -888,14 +888,14 @@ export class EthereumEngine extends CurrencyEngine<
           )
           .map(adapter => adapter.config.servers)
           .flat()
-        const { l1Gas, l1GasPrice } = await calcArbitrumRollupFees({
+        const arbitrumFee = await calcArbitrumRollupFees({
           destinationAddress: publicAddress,
           nodeInterfaceAddress:
             this.networkInfo.arbitrumRollupParams.nodeInterfaceAddress,
           rpcServers,
           txData: data ?? '0x'
         })
-        rollupFee = mul(mul(l1Gas, l1GasPrice), '1.1')
+        rollupFee = mul(miningFees.gasPrice, arbitrumFee.l1Gas)
       }
 
       // Update total fee:
@@ -1097,7 +1097,8 @@ export class EthereumEngine extends CurrencyEngine<
     let parentNetworkFee = null
     let l1Fee = '0'
 
-    //  Optimism-style L1 fees are deducted automatically from the account. Arbitrum-style L1 gas must be included in the transaction object.
+    // Optimism-style L1 fees are deducted automatically from the account.
+    // Arbitrum-style L1 gas must be included in the transaction object.
     if (this.optimismRollupParams != null) {
       const txData: CalcOptimismRollupFeeParams = {
         baseFee: this.optimismRollupParams.baseFee,
@@ -1119,15 +1120,14 @@ export class EthereumEngine extends CurrencyEngine<
         )
         .map(adapter => adapter.config.servers)
         .flat()
-      const { l1Gas, l1GasPrice } = await calcArbitrumRollupFees({
+      const arbitrumFees = await calcArbitrumRollupFees({
         destinationAddress: publicAddress,
         nodeInterfaceAddress:
           this.networkInfo.arbitrumRollupParams.nodeInterfaceAddress,
         rpcServers,
         txData: data ?? '0x'
       })
-      l1Fee = mul(mul(l1Gas, l1GasPrice), '1.1')
-      otherParams.gas = add(otherParams.gas, l1Gas)
+      otherParams.gas = add(otherParams.gas, arbitrumFees.l1Gas)
     }
 
     //

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -130,7 +130,7 @@ const networkFees: EthereumFees = {
       highFee: '40000000001',
       minGasPrice: '1000000000'
     },
-    minPriorityFee: '2000000000'
+    minPriorityFee: '100000000' // 0.1 Gwei
   }
 }
 
@@ -172,7 +172,8 @@ const networkInfo: EthereumNetworkInfo = {
   pluginMnemonicKeyName: 'arbitrumMnemonic',
   pluginRegularKeyName: 'arbitrumKey',
   ethGasStationUrl: null,
-  networkFees
+  networkFees,
+  supportsEIP1559: true
 }
 
 const currencyInfo: EdgeCurrencyInfo = {


### PR DESCRIPTION
- Enable EIP1559 support, since the L2 chain supports this.
- Priority fees can be much lower.
- Simply add `gasEstimateForL1` to the gas limit, without multiplying by the gas price. This value represents the number of gas units needed to store the compressed transaction bytes, not the total L1 cost in ETH.
- In the max-spend calculation, multiply `gasEstimateForL1` by the chosen L2 gas price, not the L1 gas price. Unlike `makeSpend`, `getMaxSpendable` deals with fee totals rather than separate prices and limits. The l1 gas price is irrelevant to this calculation, since the fee multiplication happens at L2.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208135023126679