### PR TITLE
Fix ETH requires a resync or log back in to see new transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (EVM) Fixed ETH requires a resync or log back in to see new transaction
+
 ## 4.24.2 (2024-09-12)
 
 - fixed: (EVM) Merge duplicate token transaction data from evmscan fixing incorrect transaction native amounts

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -517,7 +517,11 @@ export class EthereumNetwork {
             const txidNormal = normalizeAddress(txid)
             const hasTxidBeenProcessed = Object.keys(tokenTxs).some(
               currencyCode => {
-                return this.ethEngine.txIdMap[currencyCode][txidNormal] !== null
+                const txIndex =
+                  this.ethEngine.txIdMap[currencyCode][txidNormal] ?? -1
+                const edgeTx =
+                  this.ethEngine.transactionList[currencyCode][txIndex]
+                return edgeTx?.blockHeight > 0
               }
             )
             return !hasTxidBeenProcessed


### PR DESCRIPTION
# What was the problem?

We've introduced a WebSocket network adapter called BlockbookWsAdapter which would register an address subscription in order to get new transactions from the socket. It would then put the txid into a list. The regular fetchTx pulling routine would only continue under the condition that there are txid in this list. When a txid is pulled from the fetchTxs routine and processed, then it is removed from this txid list. This would eventually stop the pulling once all the txs have been processed. This means that the engine isn't re-fetching pending transactions to get the blockheight once it's confirmed.

# Solution
Include a condition that the transaction must not only be processed, but also confirmed (blockHeight > 0).

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208296004541884