### PR TITLE
Disable 'blockbook-ws' connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- removed: Ethereum WebSocket server connections, which were preventing incoming transactions appearing.
+
 ## 4.24.4 (2024-09-16)
 
 - changed: Upgrade chain-registry package.

--- a/src/ethereum/info/ethereumInfo.ts
+++ b/src/ethereum/info/ethereumInfo.ts
@@ -1163,17 +1163,17 @@ const networkInfo: EthereumNetworkInfo = {
         'https://eth2.trezor.io'
       ]
     },
-    {
-      type: 'blockbook-ws',
-      connections: [
-        // {
-        //   url: 'wss://eth-blockbook.nownodes.io/wss',
-        //   keyType: 'nowNodesApiKey'
-        // },
-        { url: 'wss://eth1.trezor.io/websocket' },
-        { url: 'wss://eth2.trezor.io/websocket' }
-      ]
-    },
+    // {
+    //   type: 'blockbook-ws',
+    //   connections: [
+    //     // {
+    //     //   url: 'wss://eth-blockbook.nownodes.io/wss',
+    //     //   keyType: 'nowNodesApiKey'
+    //     // },
+    //     { url: 'wss://eth1.trezor.io/websocket' },
+    //     { url: 'wss://eth2.trezor.io/websocket' }
+    //   ]
+    // },
     {
       type: 'blockchair',
       servers: ['https://api.blockchair.com']


### PR DESCRIPTION
These are preventing incoming transactions from appearing.

Because these adapters exist in the list, we call `setupAdapterSubscriptions` on them, which prevents the polling loop from checking any addresses.

Unfortunately, the two WebSocket URL's don't actually work, so we never actually subscribe to the addresses on the WebSocket side either.

This means that updates never appear, so the only way to see incoming transactions is to resync and log out.

This is a temporary solution to solve the immediate problem. The long-term solution is to fix the engine to poll for addresses unless there are active, live, working-for-real WebSocket subscriptions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
