### PR TITLE
Use `fetchCorsForced` for Solana RPC nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Use `corsBypass: 'always'` for Solana RPC nodes to fix issues with syncing transaction data.
+
 ## 4.31.1 (2024-12-06)
 
 - fixed: Fixed broken balance query method in `aquireTokenBalance` causing stalled syncing.

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "chai": "^4.2.0",
     "clipanion": "^4.0.0-rc.2",
     "crypto-browserify": "^3.12.0",
-    "edge-core-js": "^2.21.0",
+    "edge-core-js": "^2.22.0",
     "esbuild-loader": "^2.20.0",
     "eslint": "^8.19.0",
     "eslint-config-standard-kit": "0.15.1",

--- a/src/solana/SolanaTools.ts
+++ b/src/solana/SolanaTools.ts
@@ -1,6 +1,7 @@
 import {
   Connection,
   ConnectionConfig,
+  FetchFn,
   Keypair,
   PublicKey
 } from '@solana/web3.js'
@@ -13,6 +14,7 @@ import {
   EdgeCurrencyInfo,
   EdgeCurrencyTools,
   EdgeEncodeUri,
+  EdgeFetchFunction,
   EdgeIo,
   EdgeLog,
   EdgeMetaToken,
@@ -216,10 +218,14 @@ export class SolanaTools implements EdgeCurrencyTools {
   }
 
   makeConnections(rpcUrls: string[]): Connection[] {
+    const fetchCorsBypassed: EdgeFetchFunction = async (uri, opts) =>
+      await this.io.fetch(uri, {
+        ...opts,
+        corsBypass: 'always'
+      })
     const connectionConfig: ConnectionConfig = {
       commitment: this.networkInfo.commitment,
-      // @ts-expect-error our fetch is close enough to the fetch api
-      fetch: this.io.fetchCors
+      fetch: fetchCorsBypassed as FetchFn
     }
 
     const out: Connection[] = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,10 +4057,10 @@ ed25519@0.0.4:
     bindings "^1.2.1"
     nan "^2.0.9"
 
-edge-core-js@^2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-2.21.0.tgz#87b555d6fedb1d1504bc6601b25f6a7d8348b809"
-  integrity sha512-gabtjL0PDvNp+5E9XE47OOr8ae+4Z8lEo1LWBYXnbpb07TgpaRsCgtBfNSnQE9fzAf/rMVNveCQsbMr3F6iCTw==
+edge-core-js@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-2.22.0.tgz#24b3114aaa82cc80f1dabebc91ba5bd1e1dc1cd4"
+  integrity sha512-p74IDCcHUDMcbZd9G8GqdBA3BCVzFxQGNLZITNasBDdbow+ILJmI8+Li1AJO44hH8OvPNZp+VlvVPdVSlNUWxg==
   dependencies:
     aes-js "^3.1.0"
     base-x "^4.0.0"


### PR DESCRIPTION
Solana RPC nodes will throw RPC errors instead of throwing HTTP errors
so they'll fail silently and not reach the CORS fallback methods.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208916602572140