### PR TITLE
Use Helius RPC archival node exclusively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Use Helius archival nodes for Solana exclusively to fix transaction syncing issues.
+
 ## 4.32.0 (2024-12-16)
 
 - added: (XRP) Add mnemonic import support

--- a/src/solana/solanaInfo.ts
+++ b/src/solana/solanaInfo.ts
@@ -186,11 +186,13 @@ const builtinTokens: EdgeTokenMap = {
 const networkInfo: SolanaNetworkInfo = {
   rpcNodes: [
     'https://api.mainnet-beta.solana.com',
-    'https://solana-mainnet.rpc.grove.city/v1/{{poktPortalApiKey}}' // fails to return some transactions
+    'https://solana-mainnet.rpc.grove.city/v1/{{poktPortalApiKey}}', // fails to return some transactions
+    'https://mainnet.helius-rpc.com/?api-key={{heliusApiKey}}'
   ],
   rpcNodesArchival: [
-    'https://api.mainnet-beta.solana.com',
-    'https://solana-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}'
+    // 'https://api.mainnet-beta.solana.com',
+    // 'https://solana-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}',
+    'https://mainnet.helius-rpc.com/?api-key={{heliusApiKey}}'
   ],
   stakedConnectionRpcNodes: [
     'https://staked.helius-rpc.com?api-key={{heliusApiKey}}'

--- a/src/solana/solanaInfo.ts
+++ b/src/solana/solanaInfo.ts
@@ -185,8 +185,8 @@ const builtinTokens: EdgeTokenMap = {
 
 const networkInfo: SolanaNetworkInfo = {
   rpcNodes: [
-    'https://api.mainnet-beta.solana.com',
-    'https://solana-mainnet.rpc.grove.city/v1/{{poktPortalApiKey}}', // fails to return some transactions
+    // 'https://api.mainnet-beta.solana.com',
+    // 'https://solana-mainnet.rpc.grove.city/v1/{{poktPortalApiKey}}', // fails to return some transactions
     'https://mainnet.helius-rpc.com/?api-key={{heliusApiKey}}'
   ],
   rpcNodesArchival: [


### PR DESCRIPTION
The existing archival nodes were failing or too slow to sync. Using
Helius RPC node exclusively allows us to sync transactions quickly.

A future patch would be to fix the issues with the other two archival
nodes. Known issues with `solana.com` node is a rate limiting issue.
The issue with `alchemy.com` seems to be wide spread. The RPC node
seems to be returning responses that are unexpected to the web3 Solana
library. More debugging is needed to get these services back to a
working state.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208992843324853