### PR TITLE
Fix new transaction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Correctly issue notifications for new incoming transactions.
+
 ## 4.36.0 (2025-01-30)
 
 - added: Add eip681 chainId detection


### PR DESCRIPTION
We had a cacth-22 situation, where we needed a valid checkpoint to consider any transaction new, but we wouldn't update the checkpoint until we saw a new transaction.

Besides the catch-22, a fully-syncd wallet generally wouldn't have any activity that could update the checkpoint, leaving it stuck at undefined until a new transaction comes in, in which case that new transaction would never get a notification. Therefore, we need to set up an initial checkpoint at boot if we don't have one. This will be a one-time operation on a single device. After that, new devices will recieve the synced checkpoint.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209273441638964