### PR TITLE
Use a `PeriodicTask` in `addToLoop`

### DIFF
--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -474,14 +474,9 @@ export class AlgorandEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('queryTransactionParams', ACCOUNT_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactionParams', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/cardano/CardanoEngine.ts
+++ b/src/cardano/CardanoEngine.ts
@@ -332,14 +332,9 @@ export class CardanoEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop('queryBlockheight', BLOCKCHAIN_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('queryBlockheight', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/cosmos/engine/CosmosEngine.ts
+++ b/src/cosmos/engine/CosmosEngine.ts
@@ -839,15 +839,10 @@ export class CosmosEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     await this.tools.connectClient()
-    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('queryBlockheight', ACCOUNT_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('queryBlockheight', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/cosmos/engine/ThorchainEngine.ts
+++ b/src/cosmos/engine/ThorchainEngine.ts
@@ -58,7 +58,7 @@ export class ThorchainEngine extends CosmosEngine {
       const raw = await res.json()
       const clean = asChainIdUpdate(raw)
       this.chainId = clean.result.node_info.network
-      clearTimeout(this.timers.queryChainId)
+      this.removeFromLoop('queryChainId')
     } catch (e: any) {
       this.error(`queryChainId Error `, e)
     }
@@ -251,7 +251,7 @@ export class ThorchainEngine extends CosmosEngine {
   }
 
   async startEngine(): Promise<void> {
+    this.addToLoop('queryChainId', QUERY_POLL_MILLISECONDS)
     await super.startEngine()
-    this.addToLoop('queryChainId', QUERY_POLL_MILLISECONDS).catch(() => {})
   }
 }

--- a/src/eos/EosEngine.ts
+++ b/src/eos/EosEngine.ts
@@ -939,19 +939,10 @@ export class EosEngine extends CurrencyEngine<EosTools, SafeEosWalletInfo> {
 
   // This routine is called once a wallet needs to start querying the network
   async startEngine(): Promise<void> {
-    this.engineOn = true
     this.accountNameChecked = this.otherData.accountName !== ''
-    this.addToLoop(
-      'checkBlockchainInnerLoop',
-      BLOCKCHAIN_POLL_MILLISECONDS
-    ).catch(() => {})
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop(
-      'checkTransactionsInnerLoop',
-      TRANSACTION_POLL_MILLISECONDS
-    ).catch(() => {})
+    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -401,11 +401,6 @@ export class EthereumEngine extends CurrencyEngine<
     }
   }
 
-  async loadEngine(): Promise<void> {
-    await super.loadEngine()
-    this.engineOn = true
-  }
-
   /**
    * Returns the gasLimit from eth_estimateGas RPC call.
    */
@@ -736,9 +731,7 @@ export class EthereumEngine extends CurrencyEngine<
   // Public methods
   // ****************************************************************************
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  async startEngine() {
-    this.engineOn = true
+  async startEngine(): Promise<void> {
     const feeUpdateFrequencyMs =
       this.networkInfo.feeUpdateFrequencyMs ?? NETWORK_FEES_POLL_MILLISECONDS
     // Fetch the static fees from the info server only once to avoid overwriting live values.
@@ -764,15 +757,9 @@ export class EthereumEngine extends CurrencyEngine<
       })
       .catch(() => this.warn('Error fetching fees from Info Server'))
       .finally(() => {
-        this.addToLoop('updateNetworkFees', feeUpdateFrequencyMs).catch(err =>
-          this.warn(
-            `Error setting up updateNetworkFees addToLoop: ${String(err)}`
-          )
-        )
+        this.addToLoop('updateNetworkFees', feeUpdateFrequencyMs)
       })
-    this.addToLoop('updateOptimismRollupParams', ROLLUP_FEE_PARAMS).catch(
-      () => {}
-    )
+    this.addToLoop('updateOptimismRollupParams', ROLLUP_FEE_PARAMS)
     this.ethNetwork.start()
     await super.startEngine()
   }

--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -107,18 +107,6 @@ export class FilecoinEngine extends CurrencyEngine<
     this.availableAttoFil = '0'
   }
 
-  initSubscriptions(): void {
-    this.addToLoop('checkBalance', ACCOUNT_POLL_MILLISECONDS).catch(error =>
-      this.log(error)
-    )
-    this.addToLoop('checkBlockHeight', BLOCKCHAIN_POLL_MILLISECONDS).catch(
-      error => this.log(error)
-    )
-    this.addToLoop('checkTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      error => this.log(error)
-    )
-  }
-
   onUpdateBlockHeight(networkBlockHeight: number): void {
     if (this.walletLocalData.blockHeight !== networkBlockHeight) {
       this.walletLocalData.blockHeight = networkBlockHeight
@@ -137,9 +125,10 @@ export class FilecoinEngine extends CurrencyEngine<
   }
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     this.initData()
-    this.initSubscriptions()
+    this.addToLoop('checkBalance', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('checkBlockHeight', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 
@@ -344,11 +333,6 @@ export class FilecoinEngine extends CurrencyEngine<
 
   getDisplayPublicSeed(): string {
     return this.walletInfo.keys.publicKey
-  }
-
-  async loadEngine(): Promise<void> {
-    await super.loadEngine()
-    this.engineOn = true
   }
 
   //

--- a/src/fio/FioEngine.ts
+++ b/src/fio/FioEngine.ts
@@ -1299,18 +1299,9 @@ export class FioEngine extends CurrencyEngine<FioTools, SafeFioWalletInfo> {
 
   // This routine is called once a wallet needs to start querying the network
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop(
-      'checkBlockchainInnerLoop',
-      BLOCKCHAIN_POLL_MILLISECONDS
-    ).catch(() => {})
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop(
-      'checkTransactionsInnerLoop',
-      TRANSACTION_POLL_MILLISECONDS
-    ).catch(() => {})
+    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/hedera/HederaEngine.ts
+++ b/src/hedera/HederaEngine.ts
@@ -281,11 +281,9 @@ export class HederaEngine extends CurrencyEngine<
   }
 
   startActiveAccountLoops(): void {
-    clearTimeout(this.timers.checkAccountCreationStatus)
-    this.addToLoop('queryBalance', BALANCE_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('getNewTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.removeFromLoop('checkAccountCreationStatus')
+    this.addToLoop('queryBalance', BALANCE_POLL_MILLISECONDS)
+    this.addToLoop('getNewTransactions', TRANSACTION_POLL_MILLISECONDS)
   }
 
   // ****************************************************************************
@@ -293,13 +291,8 @@ export class HederaEngine extends CurrencyEngine<
   // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-
     if (this.otherData.hederaAccount == null) {
-      this.addToLoop(
-        'checkAccountCreationStatus',
-        ACCOUNT_POLL_MILLISECONDS
-      ).catch(() => {})
+      this.addToLoop('checkAccountCreationStatus', ACCOUNT_POLL_MILLISECONDS)
     } else {
       this.startActiveAccountLoops()
     }

--- a/src/piratechain/PiratechainEngine.ts
+++ b/src/piratechain/PiratechainEngine.ts
@@ -183,7 +183,6 @@ export class PiratechainEngine extends CurrencyEngine<
   }
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     this.started = true
     await super.startEngine()
   }

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -374,7 +374,7 @@ export class PolkadotEngine extends CurrencyEngine<
 
     while (hasNextPage) {
       const meritsOperationName = 'Merits'
-      const meritsQuery = `query Merits($userId: String, $cursor: Cursor) {  
+      const meritsQuery = `query Merits($userId: String, $cursor: Cursor) {
         merits(
         filter: {or: [{fromId: {equalTo: $userId}}, {toId: {equalTo: $userId}}]}
         after: $cursor
@@ -565,25 +565,20 @@ export class PolkadotEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     await this.tools.connectApi(this.walletId)
     this.api = this.tools.polkadotApi
     this.minimumAddressBalance =
       this.api.consts.balances.existentialDeposit.toString()
-    this.addToLoop('queryBlockheight', BLOCKCHAIN_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS).catch(() => {})
+    this.addToLoop('queryBlockheight', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS)
     if (this.networkInfo.liberlandScanUrl != null) {
       this.addToLoop(
         'queryLiberlandTransactions',
         TRANSACTION_POLL_MILLISECONDS
-      ).catch(() => {})
+      )
     }
     if (this.networkInfo.subscanBaseUrl != null)
-      this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-        () => {}
-      )
+      this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -745,11 +745,10 @@ export class XrpEngine extends CurrencyEngine<
   // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     try {
       await this.tools.connectApi(this.walletId)
-    } catch (e: any) {
-      this.error(`Error connecting to server `, e)
+    } catch (e: unknown) {
+      this.log.error(`Error connecting to server `, String(e))
       setTimeout(() => {
         if (this.engineOn) {
           this.startEngine().catch(e => console.log(e.message))
@@ -757,17 +756,9 @@ export class XrpEngine extends CurrencyEngine<
       }, 10000)
       return
     }
-    this.addToLoop(
-      'checkServerInfoInnerLoop',
-      BLOCKHEIGHT_POLL_MILLISECONDS
-    ).catch(e => console.log(e.message))
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS).catch(
-      e => console.log(e.message)
-    )
-    this.addToLoop(
-      'checkTransactionsInnerLoop',
-      TRANSACTION_POLL_MILLISECONDS
-    ).catch(e => console.log(e.message))
+    this.addToLoop('checkServerInfoInnerLoop', BLOCKHEIGHT_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -528,19 +528,16 @@ export class SolanaEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
     await this.tools.connectClient()
 
-    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS).catch(() => {})
+    this.addToLoop('queryBalance', ACCOUNT_POLL_MILLISECONDS)
     if (this.lightMode) {
       this.tokenCheckTransactionsStatus[this.currencyInfo.currencyCode] = 1
       for (const edgeToken of Object.values(this.allTokensMap)) {
         this.tokenCheckTransactionsStatus[edgeToken.currencyCode] = 1
       }
     } else {
-      this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-        () => {}
-      )
+      this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     }
     await super.startEngine()
   }

--- a/src/stellar/StellarEngine.ts
+++ b/src/stellar/StellarEngine.ts
@@ -454,19 +454,10 @@ export class StellarEngine extends CurrencyEngine<
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async startEngine() {
-    this.engineOn = true
-    this.addToLoop('queryFee', BLOCKCHAIN_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop(
-      'checkBlockchainInnerLoop',
-      BLOCKCHAIN_POLL_MILLISECONDS
-    ).catch(() => {})
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop(
-      'checkTransactionsInnerLoop',
-      TRANSACTION_POLL_MILLISECONDS
-    ).catch(() => {})
+    this.addToLoop('queryFee', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/sui/SuiEngine.ts
+++ b/src/sui/SuiEngine.ts
@@ -247,11 +247,8 @@ export class SuiEngine extends CurrencyEngine<SuiTools, SafeCommonWalletInfo> {
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop('queryBalance', ADDRESS_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('queryTransactions', ADDRESS_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('queryBalance', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', ADDRESS_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -385,12 +385,8 @@ export class TezosEngine extends CurrencyEngine<
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async startEngine() {
-    this.engineOn = true
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -241,11 +241,8 @@ export class TonEngine extends CurrencyEngine<TonTools, SafeCommonWalletInfo> {
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop('queryBalance', ADDRESS_POLL_MILLISECONDS).catch(() => {})
-    this.addToLoop('queryTransactions', ADDRESS_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('queryBalance', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', ADDRESS_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -1451,24 +1451,11 @@ export class TronEngine extends CurrencyEngine<TronTools, SafeTronWalletInfo> {
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.engineOn = true
-    this.addToLoop(
-      'checkBlockchainInnerLoop',
-      BLOCKCHAIN_POLL_MILLISECONDS
-    ).catch(() => {})
-    this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS).catch(
-      () => {}
-    )
-    this.addToLoop(
-      'checkUpdateNetworkFees',
-      NETWORKFEES_POLL_MILLISECONDS
-    ).catch(() => {})
-    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS).catch(
-      () => {}
-    )
+    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+    this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS)
+    this.addToLoop('checkUpdateNetworkFees', NETWORKFEES_POLL_MILLISECONDS)
+    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     await super.startEngine()
   }
 

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -238,11 +238,6 @@ export class ZcashEngine extends CurrencyEngine<
     }
   }
 
-  async startEngine(): Promise<void> {
-    this.engineOn = true
-    await super.startEngine()
-  }
-
   isSynced(): boolean {
     // Synchronizer status is updated regularly and should be checked before accessing the db to avoid errors
     return this.synchronizerStatus === 'SYNCED'


### PR DESCRIPTION
Instead of directly messing with timers, we can use a periodic task to ensure that there is exactly one copy of each task running at once, and automatically start & stop them as the engine toggles on or off.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209488312133556