### PR TITLE
Require `buyAddressRequest` api tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (FIO) Require apiToken for all calls to `buyAddressRequest`
+
 ## 4.40.0 (2025-03-11)
 
 - changed: (FTM) Rename depegged Multichain Bridged USDC as 'USDC-M'


### PR DESCRIPTION
FIO now requires api tokens to be set whenever requesting a `buyAddressRequest`

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209321700791831