### PR TITLE
Use Filfox API for balance data

### DIFF
--- a/src/filecoin/FilecoinEngine.ts
+++ b/src/filecoin/FilecoinEngine.ts
@@ -333,12 +333,10 @@ export class FilecoinEngine extends CurrencyEngine<
   //
 
   async checkBalance(): Promise<void> {
-    const response = await this.filRpc.walletBalance(this.address)
-    if ('error' in response) throw new Error(response.error.message)
-
-    const { result: balance } = response
-    this.availableAttoFil = balance
-    this.updateBalance(this.currencyInfo.currencyCode, balance)
+    const addressString = this.address.toString()
+    const response = await this.filfoxApi.getAccount(addressString)
+    this.availableAttoFil = response.balance
+    this.updateBalance(this.currencyInfo.currencyCode, response.balance)
     this.tokenCheckBalanceStatus[this.currencyInfo.currencyCode] = 1
     this.updateOnAddressesChecked()
     this.walletLocalDataDirty = true

--- a/src/filecoin/Filfox.ts
+++ b/src/filecoin/Filfox.ts
@@ -97,6 +97,31 @@ export const asFilfoxTransfer = asObject({
 })
 
 //
+// Account
+//
+
+export type FilfoxAccountResult = ReturnType<typeof asFilfoxAccountResult>
+export const asFilfoxAccountResult = asObject({
+  id: asString,
+  // robust: asString,
+  // actor: asString,
+  // createHeight: asNumber,
+  // createTimestamp: asNumber,
+  // lastSeenHeight: asNumber,
+  // lastSeenTimestamp: asNumber,
+  balance: asString,
+  // messageCount: asNumber,
+  // transferCount: asNumber,
+  // tokenTransferCount: asNumber,
+  // timestamp: asNumber,
+  // tokens: asNumber,
+  // ownedMiners: asArray(asString),
+  // workerMiners: asArray(asString),
+  // benefitedMiners: asArray(asString),
+  address: asString
+})
+
+//
 // Messages
 //
 
@@ -138,6 +163,23 @@ export class Filfox {
     this.fetch = fetchFn
   }
 
+  async getAccount(address: string): Promise<FilfoxAccountResult> {
+    const url = new URL(`${this.baseUrl}/address/${address}`)
+    const response = await this.fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json'
+      }
+    })
+    const responseText = await response.text()
+    const responseBody = asFilfoxEnvelope(asFilfoxAccountResult)(responseText)
+    if ('error' in responseBody)
+      throw new Error(
+        `Error response code ${responseBody.statusCode}: ${responseBody.message} ${responseBody.error}`
+      )
+    return responseBody
+  }
+
   async getAccountMessages(
     address: string,
     page: number,
@@ -157,12 +199,10 @@ export class Filfox {
     })
     const responseText = await response.text()
     const responseBody = asFilfoxEnvelope(asFilfoxMessagesResult)(responseText)
-
     if ('error' in responseBody)
       throw new Error(
         `Error response code ${responseBody.statusCode}: ${responseBody.message} ${responseBody.error}`
       )
-
     return responseBody
   }
 
@@ -185,12 +225,10 @@ export class Filfox {
     })
     const responseText = await response.text()
     const responseBody = asFilfoxEnvelope(asFilfoxTransfersResult)(responseText)
-
     if ('error' in responseBody)
       throw new Error(
         `Error response code ${responseBody.statusCode}: ${responseBody.message} ${responseBody.error}`
       )
-
     return responseBody
   }
 
@@ -207,12 +245,10 @@ export class Filfox {
     const responseBody = asFilfoxEnvelope(asFilfoxMessageDetailsResult)(
       responseText
     )
-
     if ('error' in responseBody)
       throw new Error(
         `Error response code ${responseBody.statusCode}: ${responseBody.message} ${responseBody.error}`
       )
-
     return responseBody
   }
 }


### PR DESCRIPTION
It appears the Glif API has added pricing models to their DePIN, so switching from using GLIF to Filfox as a dependency for the balance data seems reasonable.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
