### PR TITLE
Add isSpendable to CardanoTxOtherParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (ADA) Add `isSpendable` to `EdgeTransaction.otherParams`.
 - changed: (Ripple) Rotate servers on unhandled errors
 - changed: (Sui) Enforce the arbitrary max spend limit
 - changed: (Tron) Add note support to transaction query

--- a/src/cardano/cardanoTypes.ts
+++ b/src/cardano/cardanoTypes.ts
@@ -200,10 +200,17 @@ export const asKoiosTransactionsRes = asArray(asKoiosTransaction)
 
 export interface CardanoTxOtherParams {
   isStakeTx?: boolean
+  /**
+   * Whether the transaction is spendable wallet by comparison of the wallet's
+   * utxos with the transaction's inputs. This can happen from decoding a tx
+   * template created externally form the engine (e.g. Kiln).
+   **/
+  isSpendable?: boolean
   unsignedTx: string
 }
 export const asCardanoTxOtherParams = asObject<CardanoTxOtherParams>({
   isStakeTx: asOptional(asBoolean),
+  isSpendable: asOptional(asBoolean),
   unsignedTx: asString
 })
 


### PR DESCRIPTION
This is so that decodeStakingTx to communicate whether a transaction is valid by the engine's state.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209775828409824