### PR TITLE
Add ZKSync token detection using zks_getAllAccountBalances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (ZKSync) Add `zks_getAllAccountBalances` to `fetchTokenBalances`.
+
 ## 4.43.1 (2025-04-02)
 
 - changed: Upgrade chain-registry package.

--- a/src/common/tokenHelpers.ts
+++ b/src/common/tokenHelpers.ts
@@ -19,6 +19,8 @@ export const asMaybeContractLocation = asMaybe(
   })
 )
 
+export const asZksAccountBalances = asMaybe(asObject(asString))
+
 /**
  * Downgrades EdgeToken objects to the legacy EdgeMetaToken format.
  */


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

This PR improves token detection for ZKSync wallets by implementing support for the `zks_getAllAccountBalances` RPC method. This method is specific to ZKSync and provides a more efficient way to fetch all token balances for an address in a single call, rather than using the standard eth-balance-checker contract.

Changes include:
- Refactored `fetchTokenBalances` to use a factory pattern that creates the appropriate fetcher based on network configuration
- Added ZKSync-specific implementation that uses `zks_getAllAccountBalances` when on ZKSync network (chainId 324)
- Added proper type checking for the ZKSync response format
- Maintained backward compatibility with the existing eth-balance-checker implementation for other networks