### PR TITLE
Update TRX energy calculation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # edge-currency-accountbased
 
+- fixed: (TRX) Fees simplified to use `wallet/triggerconstantcontract` `energy_used`
+
 ## Unreleased
 
 ## 4.47.0 (2025-05-12)


### PR DESCRIPTION
- Rely purely on `total_energy` or `energy_used` for the energy estimation, depending on `recipientInStorage`
- Update the `recipientInStorage` check to compare against a self spend dryrun.
- Add heuristic specific to USDT per observations in TronLink wallet and onchain transactions.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210177602128615