### PR TITLE
Fix zano address parsing native currencyCode bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
+- fixed: Zano deeplink parsing bug when scanning for native ZANO currency.
+
 ## 4.52.1 (2025-07-01)
 
 - changed: Changed Fantom's block explorer to 'explorer.fantom.network'.
 
 ## 4.52.0 (2025-06-30)
 
-added: Support Zano deeplink URI parsing (e.g. zano: addresses).
+- added: Support Zano deeplink URI parsing (e.g. zano: addresses).
 
 ## 4.51.0 (2025-06-24)
 

--- a/src/zano/ZanoTools.ts
+++ b/src/zano/ZanoTools.ts
@@ -189,7 +189,9 @@ export class ZanoTools implements EdgeCurrencyTools {
         // Validate that the currency in the deeplink matches the requested
         // currency code:
         let deeplinkCurrencyCode: string | undefined
-        if (zanoDeeplink.asset_id != null) {
+        if (zanoDeeplink.asset_id == null) {
+          deeplinkCurrencyCode = this.currencyInfo.currencyCode
+        } else {
           deeplinkCurrencyCode =
             this.builtinTokens[zanoDeeplink.asset_id]?.currencyCode
         }


### PR DESCRIPTION
When scanning a zano address that doesn't have an asset_id, the currency code check always fails when it shouldn't fail for native currency URL parsing.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
