### PR TITLE
Fix DOT maxSpend fee calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (DOT) Mismatching fee calculations between `makeSpend` and `getMaxSpendable`
+
 ## 4.52.1 (2025-07-01)
 
 - changed: Changed Fantom's block explorer to 'explorer.fantom.network'.


### PR DESCRIPTION
DOT was calculating a different fee between `getMaxSpendable` (lower) and `makeSpend` (higher).

This change results in a longer `getMaxSpendable` calculation but at least it's correct.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
