### PR TITLE
Change HyperEVM block explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: HyperEVM block explorer links changed from hyperliquid.xyz to hyperevmscan.io.
+
 ## 4.55.2 (2025-07-22)
 
 - changed: Upgrade chain-registry package.

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -161,8 +161,8 @@ const currencyInfo: EdgeCurrencyInfo = {
   walletType: 'wallet:hyperevm',
 
   // Explorers:
-  addressExplorer: 'https://app.hyperliquid.xyz/explorer/address/%s',
-  transactionExplorer: 'https://app.hyperliquid.xyz/explorer/tx/%s',
+  addressExplorer: 'https://hyperevmscan.io/address/%s',
+  transactionExplorer: 'https://hyperevmscan.io/tx/%s',
 
   denominations: [
     {


### PR DESCRIPTION
The hyperliquid.xyz explorer only tracks the main network and not the HyperEVM network.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210882648647095