### PR TITLE
Implement ethFeeHistory fee algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Implement ethFeeHistory fee algorithm for EIP-1559 chains with percentile-based priority fee estimation, initially enabled for Botanix network
+
 ## 4.55.4 (2025-07-25)
 
 - fixed: Add xrp network support to RippleTools parseUri networks

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -20,6 +20,7 @@ import {
   asSafeCommonWalletInfo,
   WalletConnectPayload
 } from '../common/types'
+import { FeeAlgorithmConfig } from './feeAlgorithms/feeAlgorithmTypes'
 import type { NetworkAdapterConfig } from './networkAdapters/networkAdapterTypes'
 
 export interface EthereumInitOptions {
@@ -82,6 +83,7 @@ export interface EthereumNetworkInfo {
   feeUpdateFrequencyMs?: number
   chainParams: ChainParams
   supportsEIP1559?: boolean
+  feeAlgorithm?: FeeAlgorithmConfig
   optimismRollup?: boolean
   arbitrumRollupParams?: {
     nodeInterfaceAddress: string

--- a/src/ethereum/feeAlgorithms/ethFeeHistory.ts
+++ b/src/ethereum/feeAlgorithms/ethFeeHistory.ts
@@ -1,0 +1,170 @@
+import { add, div, mul } from 'biggystring'
+import { asArray, asMaybe, asObject, asString } from 'cleaners'
+import { EdgeFetchFunction, EdgeLog } from 'edge-core-js/types'
+
+import { asyncWaterfall } from '../../common/promiseUtils'
+import { hexToDecimal, pickRandom } from '../../common/utils'
+
+/**
+ *  This is the configuration type for the eth_feeHistory fee algorithm.
+ */
+export interface EthFeeHistoryConfig {
+  type: 'eth_feeHistory'
+  blocksToAnalyze: number
+}
+
+export type FeePriority = 'low' | 'standard' | 'high'
+
+export interface FeeResult {
+  maxFeePerGas: string
+  maxPriorityFeePerGas: string
+}
+
+//
+// Local Types
+//
+
+export interface EthFeeHistoryResponse {
+  baseFeePerGas: string[]
+  reward: string[][]
+}
+
+export const asRpcResultEthFeeHistory = asObject({
+  result: asObject({
+    baseFeePerGas: asArray(asString),
+    reward: asArray(asArray(asString))
+  })
+})
+
+const PERCENTILES = [10, 50, 90]
+
+export async function callEthFeeHistory(
+  fetch: EdgeFetchFunction,
+  rpcServers: string[],
+  blocksToAnalyze: number
+): Promise<EthFeeHistoryResponse> {
+  const server = pickRandom(rpcServers, 1)[0]
+
+  const opts = {
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      method: 'eth_feeHistory',
+      params: [
+        `0x${blocksToAnalyze.toString(16)}`, // number of blocks
+        'latest', // ending block
+        PERCENTILES // percentiles for tips: [10, 50, 90]
+      ],
+      id: 1,
+      jsonrpc: '2.0'
+    })
+  }
+
+  const fetchResponse = await fetch(server, opts)
+  if (!fetchResponse.ok) {
+    const text = await fetchResponse.text()
+    throw new Error(`eth_feeHistory fetch error: ${text}`)
+  }
+
+  const json = await fetchResponse.json()
+  const rpcResponse = asMaybe(asRpcResultEthFeeHistory)(json)
+
+  if (rpcResponse == null) {
+    throw new Error(
+      `eth_feeHistory ${server} returned invalid json: ${JSON.stringify(json)}`
+    )
+  }
+
+  // Return the result directly
+  return rpcResponse.result
+}
+
+/**
+ * Calculate EIP-1559 gas fees using percentile-based priority fee estimation.
+ *
+ * @param priority - The urgency level (10, 50, or 90)
+ * @param fetch - Edge fetch function
+ * @param rpcServers - Array of RPC server URLs
+ * @param log - Edge log function
+ * @param blocksToAnalyze - Number of recent blocks to analyze
+ * @returns Fee result with maxFeePerGas and maxPriorityFeePerGas
+ */
+export async function calculateFeeForPriority(
+  priority: 10 | 50 | 90,
+  fetch: EdgeFetchFunction,
+  rpcServers: string[],
+  log: EdgeLog,
+  blocksToAnalyze: number
+): Promise<FeeResult> {
+  const getFee = async (rpcUrl: string): Promise<FeeResult> => {
+    const feeHistory = await callEthFeeHistory(fetch, [rpcUrl], blocksToAnalyze)
+
+    // Extract next block's base fee (last entry in baseFeePerGas array)
+    const baseFees = feeHistory.baseFeePerGas.map(hex => hexToDecimal(hex))
+    if (baseFees.length === 0) {
+      throw new Error('eth_feeHistory returned empty baseFeePerGas data')
+    }
+    const nextBaseFee = baseFees[baseFees.length - 1]
+
+    // Calculate adjusted base fee (2x multiplier)
+    const adjustedBaseFee = mul(nextBaseFee, '2')
+
+    // Map priority to percentile index
+    const priorityToIndex: Record<number, number> = { 10: 0, 50: 1, 90: 2 }
+    const percentileIndex = priorityToIndex[priority]
+
+    // Extract priority fees at the specified percentile
+    const rewards = feeHistory.reward
+    if (rewards.length === 0) {
+      throw new Error('eth_feeHistory returned empty reward data')
+    }
+
+    // Calculate average tip at the selected percentile across all blocks
+    let totalTip = '0'
+    let validBlocks = 0
+
+    for (const blockRewards of rewards) {
+      if (blockRewards.length > percentileIndex) {
+        const tip = hexToDecimal(blockRewards[percentileIndex])
+        totalTip = add(totalTip, tip)
+        validBlocks++
+      }
+    }
+
+    if (validBlocks === 0) {
+      throw new Error(
+        `No valid reward data found for percentile index ${percentileIndex}`
+      )
+    }
+
+    const avgPriorityFee = div(totalTip, validBlocks.toString(), 0)
+
+    // Calculate final fees
+    const maxPriorityFeePerGas = avgPriorityFee
+    const maxFeePerGas = add(adjustedBaseFee, maxPriorityFeePerGas)
+
+    log(`eth_feeHistory priority ${priority}:`)
+    log(`  blocks analyzed: ${rewards.length}`)
+    log(`  nextBaseFee: ${div(nextBaseFee, '1000000000', 18)} gwei`)
+    log(
+      `  adjustedBaseFee (2x): ${div(adjustedBaseFee, '1000000000', 18)} gwei`
+    )
+    log(`  avgPriorityFee: ${div(avgPriorityFee, '1000000000', 18)} gwei`)
+    log(`  maxFeePerGas: ${div(maxFeePerGas, '1000000000', 18)} gwei`)
+
+    return {
+      maxFeePerGas,
+      maxPriorityFeePerGas
+    }
+  }
+
+  // Use asyncWaterfall to try multiple RPC servers
+  const result = await asyncWaterfall(
+    rpcServers.map(rpcUrl => async () => await getFee(rpcUrl))
+  )
+
+  return result
+}

--- a/src/ethereum/feeAlgorithms/feeAlgorithmTypes.ts
+++ b/src/ethereum/feeAlgorithms/feeAlgorithmTypes.ts
@@ -1,0 +1,12 @@
+import { EthFeeHistoryConfig } from './ethFeeHistory'
+
+/**
+ * The legacy fee algorithm config is used to configure the legacy fee algorithm.
+ * This is used for existing networks that haven't upgraded to fee algorithm
+ * adapters.
+ */
+export interface LegacyFeeAlgorithmConfig {
+  type: 'legacy'
+}
+
+export type FeeAlgorithmConfig = LegacyFeeAlgorithmConfig | EthFeeHistoryConfig

--- a/src/ethereum/info/botanixInfo.ts
+++ b/src/ethereum/info/botanixInfo.ts
@@ -68,6 +68,10 @@ const networkInfo: EthereumNetworkInfo = {
   },
   optimismRollup: false,
   supportsEIP1559: true,
+  feeAlgorithm: {
+    type: 'eth_feeHistory',
+    blocksToAnalyze: 12 // 2 minutes
+  },
   hdPathCoinType: 60,
   pluginMnemonicKeyName: 'botanixMnemonic',
   pluginRegularKeyName: 'botanixKey',

--- a/test/ethereum/fees/ethFeeHistory.test.ts
+++ b/test/ethereum/fees/ethFeeHistory.test.ts
@@ -1,0 +1,304 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { calculateFeeForPriority } from '../../../src/ethereum/feeAlgorithms/ethFeeHistory'
+import { fetchFeesFromFeeHistory } from '../../../src/ethereum/fees/feeProviders'
+
+describe('eth_feeHistory percentile-based fee calculation', function () {
+  // Mock fetch function that returns sample fee history data with percentiles [10, 50, 90]
+  const mockFetch = async (_url: string, options: any): Promise<any> => {
+    const body = JSON.parse(options.body)
+
+    if (body.method === 'eth_feeHistory') {
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            baseFeePerGas: [
+              '0x6fc23ac00', // 30 gwei
+              '0x77359400', // 32 gwei
+              '0x7ef40a00', // 34 gwei
+              '0x861c4680', // 36 gwei
+              '0x8d9ee800' // 38 gwei (next block base fee)
+            ],
+            reward: [
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei for percentiles [10, 50, 90]
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'] // [1, 2, 3] gwei
+            ]
+          }
+        })
+      }
+    }
+
+    throw new Error('Unexpected RPC call')
+  }
+
+  const mockLog = Object.assign((message: string) => console.log(message), {
+    breadcrumb: () => {},
+    crash: () => {},
+    warn: () => {},
+    error: () => {}
+  }) as any
+
+  it('should calculate fees for priority 10 (low urgency)', async function () {
+    const result = await calculateFeeForPriority(
+      10,
+      mockFetch,
+      ['https://test-rpc.com'],
+      mockLog,
+      4
+    )
+
+    // Next base fee is 2376001536 wei (0x8d9ee800)
+    // Adjusted base fee = 2376001536 * 2 = 4752003072 wei
+    // Average priority fee at 10th percentile = 1000000000 wei (1 gwei)
+    // maxFeePerGas = 4752003072 + 1000000000 = 5752003072
+    expect(result.maxFeePerGas).to.equal('5752003072')
+    expect(result.maxPriorityFeePerGas).to.equal('1000000000')
+  })
+
+  it('should calculate fees for priority 50 (standard urgency)', async function () {
+    const result = await calculateFeeForPriority(
+      50,
+      mockFetch,
+      ['https://test-rpc.com'],
+      mockLog,
+      4
+    )
+
+    // Next base fee is 2376001536 wei (0x8d9ee800)
+    // Adjusted base fee = 2376001536 * 2 = 4752003072 wei
+    // Average priority fee at 50th percentile = 2000000000 wei (2 gwei)
+    // maxFeePerGas = 4752003072 + 2000000000 = 6752003072
+    expect(result.maxFeePerGas).to.equal('6752003072')
+    expect(result.maxPriorityFeePerGas).to.equal('2000000000')
+  })
+
+  it('should calculate fees for priority 90 (high urgency)', async function () {
+    const result = await calculateFeeForPriority(
+      90,
+      mockFetch,
+      ['https://test-rpc.com'],
+      mockLog,
+      4
+    )
+
+    // Next base fee is 2376001536 wei (0x8d9ee800)
+    // Adjusted base fee = 2376001536 * 2 = 4752003072 wei
+    // Average priority fee at 90th percentile = 3000000000 wei (3 gwei)
+    // maxFeePerGas = 4752003072 + 3000000000 = 7752003072
+    expect(result.maxFeePerGas).to.equal('7752003072')
+    expect(result.maxPriorityFeePerGas).to.equal('3000000000')
+  })
+
+  it('should handle RPC errors gracefully', async function () {
+    const errorFetch = async (): Promise<any> => {
+      return {
+        ok: false,
+        text: async () => 'RPC Error'
+      }
+    }
+
+    try {
+      await calculateFeeForPriority(
+        50,
+        errorFetch,
+        ['https://test-rpc.com'],
+        mockLog,
+        4
+      )
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.include('eth_feeHistory fetch error')
+    }
+  })
+
+  it('should handle empty fee history data', async function () {
+    const emptyFetch = async (_url: string, _options: any): Promise<any> => {
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            baseFeePerGas: [],
+            reward: []
+          }
+        })
+      }
+    }
+
+    try {
+      await calculateFeeForPriority(
+        50,
+        emptyFetch,
+        ['https://test-rpc.com'],
+        mockLog,
+        4
+      )
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.include('empty baseFeePerGas data')
+    }
+  })
+})
+
+describe('fetchFeesFromFeeHistory integration', function () {
+  // Mock fetch function that returns sample fee history data with percentiles [10, 50, 90]
+  const mockFetch = async (_url: string, options: any): Promise<any> => {
+    const body = JSON.parse(options.body)
+
+    if (body.method === 'eth_feeHistory') {
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            baseFeePerGas: [
+              '0x6fc23ac00', // 30 gwei
+              '0x77359400', // 32 gwei
+              '0x7ef40a00', // 34 gwei
+              '0x861c4680', // 36 gwei
+              '0x8d9ee800' // 38 gwei (next block base fee)
+            ],
+            reward: [
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei for percentiles [10, 50, 90]
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'], // [1, 2, 3] gwei
+              ['0x3b9aca00', '0x77359400', '0xb2d05e00'] // [1, 2, 3] gwei
+            ]
+          }
+        })
+      }
+    }
+
+    throw new Error('Unexpected RPC call')
+  }
+
+  const mockLog = Object.assign((message: string) => console.log(message), {
+    breadcrumb: () => {},
+    crash: () => {},
+    warn: () => {},
+    error: () => {}
+  }) as any
+
+  const mockCurrencyInfo = {
+    currencyCode: 'BTC'
+  } as any
+
+  const mockInitOptions = {} as any
+
+  const mockNetworkInfo = {
+    supportsEIP1559: true,
+    feeAlgorithm: {
+      type: 'eth_feeHistory',
+      blocksToAnalyze: 4
+    },
+    networkAdapterConfigs: [
+      {
+        type: 'rpc',
+        servers: ['https://test-rpc.com']
+      }
+    ]
+  } as any
+
+  it('should calculate fees using percentile-based approach', async function () {
+    const result = await fetchFeesFromFeeHistory(
+      mockFetch,
+      mockCurrencyInfo,
+      mockInitOptions,
+      mockLog,
+      mockNetworkInfo
+    )
+
+    expect(result).to.not.equal(undefined)
+    if (result == null) return
+
+    // Expected calculations:
+    // Next base fee = 2376001536 wei (0x8d9ee800)
+    // Adjusted base fee = 2376001536 * 2 = 4752003072 wei
+    // Priority fees: 10th percentile = 1 gwei, 50th = 2 gwei, 90th = 3 gwei
+    // lowFee (10th percentile): 4752003072 + 1000000000 = 5752003072
+    // standardFee (50th percentile): 4752003072 + 2000000000 = 6752003072
+    // highFee (90th percentile): 4752003072 + 3000000000 = 7752003072
+
+    expect(result.lowFee).to.equal('5752003072')
+    expect(result.standardFeeLow).to.equal('6752003072')
+    expect(result.standardFeeHigh).to.equal('6752003072')
+    expect(result.highFee).to.equal('7752003072')
+  })
+
+  it('should return undefined for non-EIP1559 chains', async function () {
+    const nonEip1559NetworkInfo = {
+      ...mockNetworkInfo,
+      supportsEIP1559: false
+    }
+
+    const result = await fetchFeesFromFeeHistory(
+      mockFetch,
+      mockCurrencyInfo,
+      mockInitOptions,
+      mockLog,
+      nonEip1559NetworkInfo
+    )
+
+    expect(result).to.equal(undefined)
+  })
+
+  it('should return undefined for chains without eth_feeHistory algorithm', async function () {
+    const defaultAlgorithmNetworkInfo = {
+      ...mockNetworkInfo,
+      feeAlgorithm: { type: 'legacy' }
+    }
+
+    const result = await fetchFeesFromFeeHistory(
+      mockFetch,
+      mockCurrencyInfo,
+      mockInitOptions,
+      mockLog,
+      defaultAlgorithmNetworkInfo
+    )
+
+    expect(result).to.equal(undefined)
+  })
+
+  it('should return undefined when no RPC config is available', async function () {
+    const noRpcNetworkInfo = {
+      ...mockNetworkInfo,
+      networkAdapterConfigs: [
+        {
+          type: 'evmscan',
+          servers: ['https://api.etherscan.io']
+        }
+      ]
+    }
+
+    const result = await fetchFeesFromFeeHistory(
+      mockFetch,
+      mockCurrencyInfo,
+      mockInitOptions,
+      mockLog,
+      noRpcNetworkInfo
+    )
+
+    expect(result).to.equal(undefined)
+  })
+
+  it('should handle RPC errors and return undefined', async function () {
+    const errorFetch = async (): Promise<any> => {
+      return {
+        ok: false,
+        text: async () => 'RPC Error'
+      }
+    }
+
+    const result = await fetchFeesFromFeeHistory(
+      errorFetch,
+      mockCurrencyInfo,
+      mockInitOptions,
+      mockLog,
+      mockNetworkInfo
+    )
+
+    expect(result).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
Implement a new percentile-based EIP-1559 gas estimation algorithm using the eth_feeHistory RPC method. This replaces the previous multiplier-based approach with direct percentile sampling for more accurate fee estimation.

Algorithm details:
- Queries eth_feeHistory with percentiles [10, 50, 90] for priority levels
- Uses next block's baseFeePerGas multiplied by 2x for maxFeePerGas
- Calculates average priority fee at specified percentile across recent blocks
- Returns structured fee data for low, standard, and high urgency levels

Configuration changes:
- Updated EthFeeHistoryConfig to remove priorityMultipliers (simplified)
- Updated botanixInfo.ts to use new configuration format
- Added blocksToAnalyze parameter for configurable analysis depth

This algorithm is initially enabled for Botanix network as a pilot implementation before broader rollout to other EIP-1559 chains.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210877189862292