### PR TITLE
(ATOM) Implement 'MakeTxDexSwap'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: (COSMOS) Add DEX tx support
+- added: (OSMOSIS) Add ATOM to default tokens
 
 ## 4.60.1 (2025-09-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (COSMOS) Add DEX tx support
+
 ## 4.60.1 (2025-09-18)
 
 - fixed: Remove unintentional addition to 4.60.0: Added exponential backoff for syncNetwork "retriable" errors.
@@ -52,7 +54,6 @@
 ## 4.55.7 (2025-08-01)
 
 - fixed: Fix Botanix display name and chain name.
-
 ## 4.55.6 (2025-07-31)
 
 - fixed: (EVM) Fix missing rate-limit error detection

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -137,6 +137,8 @@ export type MakeTxParams =
       toTokenId?: string
       toNativeAmount: string
 
+      txData?: string
+
       /**
        * UNIX time (seconds) to expire the DEX swap if it hasn't executed
        */

--- a/src/cosmos/info/osmosisInfo.ts
+++ b/src/cosmos/info/osmosisInfo.ts
@@ -18,6 +18,15 @@ const builtinTokens: EdgeTokenMap = {
     networkLocation: {
       contractAddress: 'uion'
     }
+  },
+  ibc27394fb092d2eccd56123c74f36e4c1f926001ceada9ca97ea622b25f41e5eb2: {
+    currencyCode: 'ATOM',
+    displayName: 'Cosmos Hub',
+    denominations: [{ name: 'ATOM', multiplier: '1000000' }],
+    networkLocation: {
+      contractAddress:
+        'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2'
+    }
   }
 }
 


### PR DESCRIPTION

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/edge-exchange-plugins/pull/396

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208710977099009

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Cosmos DEX swap make/sign flow using Rango payloads, adds supporting utils and safer WC parsing, and adds ATOM to Osmosis default tokens.
> 
> - **Cosmos**:
>   - **DEX Swap Flow**: Implement `MakeTxDexSwap` in `CosmosEngine` using Rango provider payloads (`protoMsgs`/`msgs`), with gas simulation, fee calc, and memo handling.
>   - **Signing**: Extend `signTx` to handle Rango JSON payloads in addition to hex-encoded unsigned tx; build `TxBody/AuthInfo` and sign.
>   - **Utils**: Add `coerceToBytes` and integrate with Rango message values; reuse `safeParse`.
>   - **WalletConnect**: For unknown methods in `parseWalletConnectV2Payload`, return zero amounts instead of throwing.
>   - **Types**: Add `txData` field to `MakeTxParams` for `MakeTxDexSwap`.
> - **Osmosis**:
>   - Add `ATOM` (IBC denom) to `builtinTokens`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4175d591a2d60b0f9e56a4c640915d8a22d993a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->