### PR TITLE
Jon/fix/sweep private key

### DIFF
--- a/src/fio/FioTools.ts
+++ b/src/fio/FioTools.ts
@@ -163,8 +163,14 @@ export class FioTools implements EdgeCurrencyTools {
       uri,
       networks: { fio: true },
       builtinTokens: this.builtinTokens,
-      currencyCode: FIO_CURRENCY_CODE
+      currencyCode: FIO_CURRENCY_CODE,
+      testPrivateKeys: this.importPrivateKey.bind(this)
     })
+
+    if (edgeParsedUri.privateKeys != null) {
+      return edgeParsedUri
+    }
+
     const valid = checkAddress(edgeParsedUri.publicAddress ?? '')
     if (!valid) {
       throw new Error('InvalidPublicAddressError')

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -1,24 +1,27 @@
+// Force asm.js crypto on RN to avoid WASM crash paths
+import '@polkadot/wasm-crypto/initOnlyAsm'
 import '@polkadot/api-augment/polkadot'
 
 import { ApiPromise, Keyring } from '@polkadot/api'
+import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { Option } from '@polkadot/types/codec'
 import { PalletAssetsAssetAccount } from '@polkadot/types/lookup'
 import { abs, add, div, gt, lte, mul, sub } from 'biggystring'
 import {
-  EdgeCurrencyEngine,
-  EdgeCurrencyEngineOptions,
-  EdgeCurrencyInfo,
-  EdgeFetchFunction,
-  EdgeFreshAddress,
-  EdgeSpendInfo,
-  EdgeTokenId,
-  EdgeTokenMap,
-  EdgeTransaction,
-  EdgeTxAmount,
-  EdgeWalletInfo,
-  InsufficientFundsError,
-  JsonObject,
-  NoAmountSpecifiedError
+    EdgeCurrencyEngine,
+    EdgeCurrencyEngineOptions,
+    EdgeCurrencyInfo,
+    EdgeFetchFunction,
+    EdgeFreshAddress,
+    EdgeSpendInfo,
+    EdgeTokenId,
+    EdgeTokenMap,
+    EdgeTransaction,
+    EdgeTxAmount,
+    EdgeWalletInfo,
+    InsufficientFundsError,
+    JsonObject,
+    NoAmountSpecifiedError
 } from 'edge-core-js/types'
 import { base16 } from 'rfc4648'
 
@@ -27,28 +30,28 @@ import { PluginEnvironment } from '../common/innerPlugin'
 import { getRandomDelayMs } from '../common/network'
 import { asMaybeContractLocation } from '../common/tokenHelpers'
 import {
-  cleanTxLogs,
-  getDenomination,
-  getFetchCors,
-  getOtherParams,
-  makeMutex
+    cleanTxLogs,
+    getDenomination,
+    getFetchCors,
+    getOtherParams,
+    makeMutex
 } from '../common/utils'
 import { PolkadotTools } from './PolkadotTools'
 import {
-  asLiberlandMeritsResponse,
-  asLiberlandTransfersResponse,
-  asPolkadotWalletOtherData,
-  asPolkapolkadotPrivateKeys,
-  asSafePolkadotWalletInfo,
-  asSubscanResponse,
-  asTransactions,
-  asTransfer,
-  LiberlandTransfer,
-  PolkadotNetworkInfo,
-  PolkadotWalletOtherData,
-  SafePolkadotWalletInfo,
-  SubscanResponse,
-  SubscanTx
+    asLiberlandMeritsResponse,
+    asLiberlandTransfersResponse,
+    asPolkadotWalletOtherData,
+    asPolkapolkadotPrivateKeys,
+    asSafePolkadotWalletInfo,
+    asSubscanResponse,
+    asTransactions,
+    asTransfer,
+    LiberlandTransfer,
+    PolkadotNetworkInfo,
+    PolkadotWalletOtherData,
+    SafePolkadotWalletInfo,
+    SubscanResponse,
+    SubscanTx
 } from './polkadotTypes'
 
 const ACCOUNT_POLL_MILLISECONDS = getRandomDelayMs(20000)
@@ -792,6 +795,7 @@ export class PolkadotEngine extends CurrencyEngine<
     edgeTransaction: EdgeTransaction,
     privateKeys: JsonObject
   ): Promise<EdgeTransaction> {
+    await cryptoWaitReady()
     const polkadotPrivateKeys = asPolkapolkadotPrivateKeys(
       this.currencyInfo.pluginId
     )(privateKeys)
@@ -848,8 +852,10 @@ export class PolkadotEngine extends CurrencyEngine<
       if (polkadotPrivateKeys.mnemonic != null) {
         this.keypair.addFromUri(polkadotPrivateKeys.mnemonic)
       } else {
-        const uint8Array = base16.parse(polkadotPrivateKeys.privateKey)
-        this.keypair.addFromSeed(uint8Array)
+        const hex = polkadotPrivateKeys.privateKey.replace(/^0x/i, '')
+        const bytes = base16.parse(hex)
+        const seed = bytes.length === 32 ? bytes : bytes.subarray(0, 32)
+        this.keypair.addFromSeed(seed)
       }
     }
 

--- a/src/polkadot/PolkadotTools.ts
+++ b/src/polkadot/PolkadotTools.ts
@@ -1,3 +1,5 @@
+// Force asm.js crypto on RN to avoid WASM crash paths
+import '@polkadot/wasm-crypto/initOnlyAsm'
 import { ApiPromise, Keyring, WsProvider } from '@polkadot/api'
 import * as utilCrypto from '@polkadot/util-crypto'
 import { div } from 'biggystring'
@@ -27,7 +29,13 @@ import {
   PolkadotNetworkInfo
 } from './polkadotTypes'
 
-const { ed25519PairFromSeed, isAddress, mnemonicToMiniSecret } = utilCrypto
+const {
+  ed25519PairFromSeed,
+  isAddress,
+  mnemonicToMiniSecret,
+  encodeAddress,
+  cryptoWaitReady
+} = utilCrypto
 
 export class PolkadotTools implements EdgeCurrencyTools {
   io: EdgeIo
@@ -64,6 +72,7 @@ export class PolkadotTools implements EdgeCurrencyTools {
 
   async importPrivateKey(userInput: string): Promise<JsonObject> {
     const { pluginId } = this.currencyInfo
+    await cryptoWaitReady()
     if (validateMnemonic(userInput)) {
       const miniSecret = mnemonicToMiniSecret(userInput)
       const { secretKey } = ed25519PairFromSeed(miniSecret)
@@ -72,8 +81,10 @@ export class PolkadotTools implements EdgeCurrencyTools {
         [`${pluginId}Key`]: Buffer.from(secretKey).toString('hex')
       }
     } else if (isHex(userInput)) {
+      const hex = userInput.replace(/^0x/i, '')
+      if (hex.length !== 64 && hex.length !== 128) throw new Error('InvalidPrivateKey')
       return {
-        [`${pluginId}Key`]: userInput
+        [`${pluginId}Key`]: hex
       }
     } else {
       throw new Error('InvalidPrivateKey')
@@ -92,11 +103,27 @@ export class PolkadotTools implements EdgeCurrencyTools {
 
   async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
     const { pluginId } = this.currencyInfo
+    await cryptoWaitReady()
     const keyring = new Keyring({ ss58Format: this.networkInfo.ss58Format })
-    const pair = keyring.addFromUri(walletInfo.keys[`${pluginId}Mnemonic`])
-    return {
-      publicKey: pair.address
+
+    const mnemonic = walletInfo.keys[`${pluginId}Mnemonic`]
+    const privateKeyHex = walletInfo.keys[`${pluginId}Key`]
+
+    if (typeof mnemonic === 'string') {
+      const pair = keyring.addFromUri(mnemonic)
+      return { publicKey: pair.address }
     }
+
+    if (typeof privateKeyHex === 'string') {
+      const hex = privateKeyHex.replace(/^0x/i, '')
+      const bytes = Buffer.from(hex, 'hex')
+      const seed = bytes.length === 32 ? bytes : bytes.subarray(0, 32)
+      const { publicKey } = ed25519PairFromSeed(seed)
+      const address = encodeAddress(publicKey, this.networkInfo.ss58Format)
+      return { publicKey: address }
+    }
+
+    throw new Error('InvalidWalletKeys')
   }
 
   async parseUri(
@@ -113,8 +140,13 @@ export class PolkadotTools implements EdgeCurrencyTools {
       networks,
       builtinTokens: this.builtinTokens,
       currencyCode: currencyCode ?? this.currencyInfo.currencyCode,
-      customTokens
+      customTokens,
+      testPrivateKeys: this.importPrivateKey.bind(this)
     })
+
+    if (edgeParsedUri.privateKeys != null) {
+      return edgeParsedUri
+    }
     const address = edgeParsedUri.publicAddress ?? ''
 
     if (!isAddress(address) || address.toLowerCase().startsWith('0x')) {

--- a/src/solana/SolanaTools.ts
+++ b/src/solana/SolanaTools.ts
@@ -103,14 +103,30 @@ export class SolanaTools implements EdgeCurrencyTools {
         [`${pluginId}Key`]: Buffer.from(keypair.secretKey).toString('hex'),
         publicKey: keypair.publicKey.toBase58()
       }
-    } else {
-      const bytes = bs58.decode(input)
-      const keypair = await Keypair.fromSecretKey(bytes)
+    } else if (/^[0-9a-fA-F]{128}$/.test(input)) {
+      // Handle 64-byte hex private key (128 hex characters)
+      const keyBuffer = Buffer.from(input, 'hex')
+      const keypair = Keypair.fromSecretKey(keyBuffer)
 
       return {
-        [`${pluginId}Base58Key`]: input,
-        [`${pluginId}Key`]: Buffer.from(keypair.secretKey).toString('hex'),
+        [`${pluginId}Key`]: input,
         publicKey: keypair.publicKey.toBase58()
+      }
+    } else {
+      // Try base58 format
+      try {
+        const bytes = bs58.decode(input)
+        const keypair = Keypair.fromSecretKey(bytes)
+
+        return {
+          [`${pluginId}Base58Key`]: input,
+          [`${pluginId}Key`]: Buffer.from(keypair.secretKey).toString('hex'),
+          publicKey: keypair.publicKey.toBase58()
+        }
+      } catch (e) {
+        throw new Error(
+          'Invalid private key format. Expected mnemonic, base58, or hex format.'
+        )
       }
     }
   }
@@ -131,10 +147,16 @@ export class SolanaTools implements EdgeCurrencyTools {
       throw new Error('InvalidWalletType')
     }
 
-    const keys = await this.importPrivateKey(
+    const privateKeyInput =
       walletInfo.keys[`${pluginId}Mnemonic`] ??
-        walletInfo.keys[`${pluginId}Base58Key`]
-    )
+      walletInfo.keys[`${pluginId}Base58Key`] ??
+      walletInfo.keys[`${pluginId}Key`]
+
+    if (privateKeyInput == null) {
+      throw new Error('SOL: No private key found in wallet')
+    }
+
+    const keys = await this.importPrivateKey(privateKeyInput)
     return { publicKey: keys.publicKey.toString() }
   }
 

--- a/src/sui/SuiEngine.ts
+++ b/src/sui/SuiEngine.ts
@@ -428,7 +428,15 @@ export class SuiEngine extends CurrencyEngine<SuiTools, SafeCommonWalletInfo> {
     const tx = Transaction.from(unsignedBase64)
 
     const keys = asSuiPrivateKeys(this.currencyInfo.pluginId)(privateKeys)
-    const pair = Ed25519Keypair.deriveKeypair(keys.mnemonic)
+    let pair: Ed25519Keypair
+    if (keys.mnemonic != null) {
+      pair = Ed25519Keypair.deriveKeypair(keys.mnemonic)
+    } else if (keys.privateKey != null) {
+      const secretKey = Buffer.from(keys.privateKey.replace(/^0x/i, ''), 'hex')
+      pair = Ed25519Keypair.fromSecretKey(secretKey)
+    } else {
+      throw new Error('SUI: Missing keys for signing')
+    }
     const res = await tx.sign({ signer: pair })
     edgeTransaction.signedTx = JSON.stringify(res)
     edgeTransaction.txid = await tx.getDigest()

--- a/src/sui/SuiTools.ts
+++ b/src/sui/SuiTools.ts
@@ -1,9 +1,9 @@
+import { fromBech32, toBech32 } from '@cosmjs/encoding'
 import { getFullnodeUrl, SuiClient, SuiHTTPTransport } from '@mysten/sui/client'
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519'
 import { isValidSuiAddress, parseStructTag } from '@mysten/sui/utils'
 import { div } from 'biggystring'
 import { entropyToMnemonic, validateMnemonic } from 'bip39'
-import { uncleaner } from 'cleaners'
 import {
   EdgeCurrencyInfo,
   EdgeCurrencyTools,
@@ -23,7 +23,7 @@ import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { asSafeCommonWalletInfo } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getLegacyDenomination, mergeDeeply } from '../common/utils'
-import { asSuiPrivateKeys, SuiInfoPayload, SuiNetworkInfo } from './suiTypes'
+import { SuiInfoPayload, SuiNetworkInfo } from './suiTypes'
 
 export class SuiTools implements EdgeCurrencyTools {
   io: EdgeIo
@@ -55,8 +55,23 @@ export class SuiTools implements EdgeCurrencyTools {
     privateWalletInfo: EdgeWalletInfo
   ): Promise<string> {
     const { pluginId } = this.currencyInfo
-    const keys = asSuiPrivateKeys(pluginId)(privateWalletInfo.keys)
-    return keys.mnemonic
+    const mnemonic: unknown = privateWalletInfo.keys[`${pluginId}Mnemonic`]
+    if (typeof mnemonic === 'string') return mnemonic
+
+    const hexKey: unknown = privateWalletInfo.keys[`${pluginId}Key`]
+    if (typeof hexKey === 'string') {
+      const hex = hexKey.replace(/^0x/i, '').toLowerCase()
+      const keyBytes = Buffer.from(hex, 'hex')
+      if (keyBytes.length !== 32) {
+        throw new Error('InvalidPrivateKey')
+      }
+      const data = new Uint8Array(1 + keyBytes.length)
+      data[0] = 0x00 // ed25519 scheme flag
+      data.set(keyBytes, 1)
+      return toBech32('suiprivkey', data)
+    }
+
+    throw new Error('NoPrivateKey')
   }
 
   async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {
@@ -65,14 +80,77 @@ export class SuiTools implements EdgeCurrencyTools {
   }
 
   async importPrivateKey(input: string): Promise<JsonObject> {
-    const isValid = validateMnemonic(input)
-    if (!isValid) throw new Error('Invalid mnemonic')
+    const { pluginId } = this.currencyInfo
 
-    // test mnemonic
-    Ed25519Keypair.deriveKeypair(input)
+    const isMnemonic = validateMnemonic(input)
 
-    const wasKeys = uncleaner(asSuiPrivateKeys(this.currencyInfo.pluginId))
-    return wasKeys({ mnemonic: input })
+    if (isMnemonic) {
+      // Derive keypair to validate the mnemonic and to obtain the secret key bytes
+      const keyPair = Ed25519Keypair.deriveKeypair(input)
+      const secretKeyHex = Buffer.from(keyPair.getSecretKey()).toString('hex')
+
+      return {
+        [`${pluginId}Mnemonic`]: input,
+        [`${pluginId}Key`]: secretKeyHex
+      }
+    }
+
+    // Handle Bech32 encoded private key (suiprivkey1...)
+    if (input.startsWith('suiprivkey1')) {
+      try {
+        const decoded = fromBech32(input)
+        if (decoded.prefix === 'suiprivkey' && decoded.data.length === 33) {
+          const schemeFlag = decoded.data[0]
+          if (schemeFlag !== 0x00) throw new Error('UnsupportedKeyScheme')
+          const privateKeyBytes = decoded.data.slice(1)
+          if (privateKeyBytes.length !== 32)
+            throw new Error('InvalidPrivateKey')
+          const secretKeyHex = Buffer.from(privateKeyBytes).toString('hex')
+          return {
+            [`${pluginId}Key`]: secretKeyHex
+          }
+        }
+      } catch (error) {
+        // Fall through to error below
+      }
+    }
+
+    // If the input is ASCII-hex of a Bech32 string (common copy issue), detect & decode:
+    if (/^(?:0x)?[0-9a-fA-F]{2,}$/.test(input)) {
+      try {
+        const hexAscii = input.replace(/^0x/i, '')
+        const ascii = Buffer.from(hexAscii, 'hex').toString('ascii')
+        if (ascii.startsWith('suiprivkey1')) {
+          const decoded = fromBech32(ascii)
+          if (decoded.prefix === 'suiprivkey' && decoded.data.length === 33) {
+            const schemeFlag = decoded.data[0]
+            if (schemeFlag !== 0x00) throw new Error('UnsupportedKeyScheme')
+            const privateKeyBytes = decoded.data.slice(1)
+            if (privateKeyBytes.length !== 32)
+              throw new Error('InvalidPrivateKey')
+            const secretKeyHex = Buffer.from(privateKeyBytes).toString('hex')
+            return { [`${pluginId}Key`]: secretKeyHex }
+          }
+        }
+      } catch (error) {
+        // Ignore and fall through to other formats
+      }
+    }
+
+    // Fallback: allow importing a raw hex private key (64 or 32 bytes)
+    if (
+      /^(?:0x)?[0-9a-fA-F]{64}$/.test(input) ||
+      /^(?:0x)?[0-9a-fA-F]{128}$/.test(input)
+    ) {
+      // Ensure the input represents bytes
+      return {
+        [`${pluginId}Key`]: input.replace(/^0x/i, '').toLowerCase()
+      }
+    }
+
+    throw new Error(
+      'Invalid mnemonic or private key format. Expected mnemonic, hex, or suiprivkey1... bech32 format.'
+    )
   }
 
   async createPrivateKey(walletType: string): Promise<JsonObject> {
@@ -87,14 +165,29 @@ export class SuiTools implements EdgeCurrencyTools {
   }
 
   async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
+    const { pluginId } = this.currencyInfo
     if (walletInfo.type !== this.currencyInfo.walletType) {
       throw new Error('InvalidWalletType')
     }
-    const { mnemonic } = asSuiPrivateKeys(this.currencyInfo.pluginId)(
-      walletInfo.keys
-    )
 
-    const keyPair = Ed25519Keypair.deriveKeypair(mnemonic)
+    const privateKeyInput =
+      (walletInfo.keys as any)[`${pluginId}Mnemonic`] ??
+      (walletInfo.keys as any)[`${pluginId}Key`]
+
+    if (privateKeyInput == null) {
+      throw new Error('SUI: No private key found in wallet')
+    }
+
+    // Normalize via importPrivateKey to handle mnemonic, hex, or bech32
+    const keys = await this.importPrivateKey(String(privateKeyInput))
+    const privateKeyHex = (keys as any)[`${pluginId}Key`]
+    if (privateKeyHex == null) {
+      throw new Error('SUI: importPrivateKey did not return a private key')
+    }
+
+    const keyPair = Ed25519Keypair.fromSecretKey(
+      Buffer.from(privateKeyHex, 'hex')
+    )
     const publicKey = keyPair.getPublicKey()
     const publicKeyBytes = publicKey.toRawBytes()
 
@@ -115,8 +208,13 @@ export class SuiTools implements EdgeCurrencyTools {
       networks,
       builtinTokens: this.builtinTokens,
       currencyCode: currencyCode ?? this.currencyInfo.currencyCode,
-      customTokens
+      customTokens,
+      testPrivateKeys: this.importPrivateKey.bind(this)
     })
+
+    if (edgeParsedUri.privateKeys != null) {
+      return edgeParsedUri
+    }
 
     let address = ''
 

--- a/src/sui/suiTypes.ts
+++ b/src/sui/suiTypes.ts
@@ -24,23 +24,29 @@ export type SuiWalletOtherData = ReturnType<typeof asSuiWalletOtherData>
 //
 
 export interface SuiPrivateKeys {
-  mnemonic: string
+  mnemonic?: string
+  privateKey?: string
 }
 export const asSuiPrivateKeys = (pluginId: string): Cleaner<SuiPrivateKeys> => {
   const asKeys = asObject({
-    [`${pluginId}Mnemonic`]: asString
+    [`${pluginId}Mnemonic`]: asOptional(asString),
+    [`${pluginId}Key`]: asOptional(asString)
   })
 
   return asCodec(
     raw => {
       const from = asKeys(raw)
       return {
-        mnemonic: from[`${pluginId}Mnemonic`]
+        mnemonic: from[`${pluginId}Mnemonic`],
+        privateKey: from[`${pluginId}Key`]
       }
     },
     clean => {
       return {
-        [`${pluginId}Mnemonic`]: clean.mnemonic
+        [`${pluginId}Mnemonic`]: clean.mnemonic,
+        ...(clean.privateKey != null
+          ? { [`${pluginId}Key`]: clean.privateKey }
+          : {})
       }
     }
   )


### PR DESCRIPTION
### Summary

Fix sweep functionality across multiple plugins and harden private key handling.

- Sui
  - Add Bech32 `suiprivkey1…` import (33-byte flag||privkey, ed25519 flag 0x00) and support ASCII-hex-encoded Bech32 inputs
  - Normalize derive/sign to accept mnemonic or hex (via importPrivateKey); display stored hex as Bech32
  - Make `${pluginId}Mnemonic` and `${pluginId}Key` optional in cleaner

- Polkadot
  - Enable hex private key import (32/64 bytes; strip 0x, validate) and derive SS58 from mnemonic or 32-byte seed
  - Initialize crypto for RN (`@polkadot/wasm-crypto/initOnlyAsm` + `cryptoWaitReady`) to prevent WASM runtime errors during sweep
  - Use normalized 32-byte seed for engine signing; parseUri supports private key detection for sweeps

- Solana
  - Support 64-byte hex private keys and unify derivePublicKey across mnemonic/base58/hex via importPrivateKey
  - Improve invalid key error messaging

- FIO
  - parseUri: add `testPrivateKeys` and early return when private keys are present for sweep

Notes:
- Backward-compatible: existing wallets continue to work; new formats are additive

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
