### PR TITLE
(EVM) Use Etherscan V2 for `etherscan.io` gas oracle calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - changed: Upgrade chain-registry package.
+- changed: (EVM) Use Etherscan V2 for `etherscan.io` gas oracle calls
 
 ## 4.57.0 (2025-08-04)
 

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -218,7 +218,11 @@ export const fetchFeesFromEvmScan = async (
   const apiKey = `&apikey=${
     Array.isArray(scanApiKey) ? pickRandom(scanApiKey, 1)[0] : scanApiKey ?? ''
   }`
-  const url = `${server}/api?module=gastracker&action=gasoracle${apiKey}`
+  // Use Etherscan v2 API when targeting etherscan.io, otherwise use the network-specific scan API format
+  const chainId = networkInfo.chainParams.chainId
+  const url = server.includes('etherscan.io')
+    ? `${server}/v2/api?chainid=${chainId}&module=gastracker&action=gasoracle${apiKey}`
+    : `${server}/api?module=gastracker&action=gasoracle${apiKey}`
 
   const fetchResponse = await fetch(url)
   if (!fetchResponse.ok)


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

### Use Etherscan V2 for gas oracle calls; confirm v2 responses are compatible

#### Why
Etherscan V1 is being deprecated. We must ensure any calls to `etherscan.io` use the V2 API with `chainid`.

#### What changed
- `src/ethereum/fees/feeProviders.ts`:
  - `fetchFeesFromEvmScan`: When `server.includes('etherscan.io')`, build V2 URL:
    - `https://api.etherscan.io/v2/api?chainid=<chainId>&module=gastracker&action=gasoracle&apikey=...`
  - Non-etherscan explorers keep legacy `/api?...` format.

Note: Etherscan V2 routing within `EvmScanAdapter.fetchGetEtherscan` was already implemented separately and is unchanged by this PR.

#### Validation (live)
- Gas oracle (mainnet, chainid=1)
  - Request:
    ```
    curl -s 'https://api.etherscan.io/v2/api?chainid=1&module=gastracker&action=gasoracle&apikey=****'
    ```
  - Response (truncated):
    ```json
    {
      "status":"1",
      "message":"OK",
      "result":{
        "LastBlock":"23092608",
        "SafeGasPrice":"0.314206861",
        "ProposeGasPrice":"0.317146585",
        "FastGasPrice":"0.393098669",
        "suggestBaseFee":"0.314098669",
        "gasUsedRatio":"..."
      }
    }
    ```

- Account balance (mainnet, chainid=1)
  - Request:
    ```
    curl -s 'https://api.etherscan.io/v2/api?chainid=1&module=account&action=balance&address=0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae&tag=latest&apikey=****'
    ```
  - Response:
    ```json
    { "status":"1", "message":"OK", "result":"181774354746090829450458" }
    ```

#### Compatibility
- Responses match existing cleaners and parsing:
  - Gas oracle returns fractional Gwei (post-EIP-1559); existing logic parses via `parseFloat` and converts to wei.
  - Accounts/proxy modules maintain `{ status, message, result }`/JSON-RPC shapes supported by our cleaners.
- Result: Drop-in replacement for existing implementation.

#### References
- Etherscan V2 migration: https://docs.etherscan.io/etherscan-v2/v2-quickstart
- Accounts: https://docs.etherscan.io/etherscan-v2/api-endpoints/accounts
- Gas Tracker: https://docs.etherscan.io/api-endpoints/gas-tracker
