### PR TITLE
Add pre-built transaction support to SuiEngine

### DIFF
--- a/src/sui/suiTypes.ts
+++ b/src/sui/suiTypes.ts
@@ -1,5 +1,15 @@
 import type { SignatureWithBytes } from '@mysten/sui/cryptography'
 import { asCodec, asObject, asOptional, asString, Cleaner } from 'cleaners'
+import type {
+  EdgeAssetAction,
+  EdgeMemo,
+  EdgeMetadata,
+  EdgeTransaction,
+  EdgeTxAction,
+  EdgeTxSwap
+} from 'edge-core-js/types'
+
+import { MakeTxParams } from '../common/types'
 
 export interface SuiNetworkInfo {
   network: 'mainnet' | 'testnet'
@@ -66,3 +76,19 @@ export const asSuiSignedTx = asObject<SignatureWithBytes>({
   bytes: asString,
   signature: asString
 })
+
+//
+// Other Methods Types:
+//
+
+export interface MakeTxMetadata {
+  assetAction?: EdgeAssetAction
+  savedAction?: EdgeTxAction
+  metadata?: EdgeMetadata
+  swapData?: EdgeTxSwap
+  memos?: EdgeMemo[]
+}
+
+export interface SuiOtherMethods {
+  makeTx: (params: MakeTxParams) => Promise<EdgeTransaction>
+}


### PR DESCRIPTION
Enable SuiEngine to execute pre-built transactions passed via otherParams. This allows swap plugins like LI.FI to provide complete transaction data that will be executed as-is rather than being converted to simple transfers.

The implementation checks for unsignedTx or unsignedBase64 in otherParams and uses the pre-built transaction when provided, while maintaining backward compatibility for regular transfers.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211165107420343