### PR TITLE
SUI: Disallow 32-byte hex private key import from `parseUri`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: (Thorchain) Correctly parse incoming TCY transactions.
+- fixed: (Sui) Disallow 32-byte hex private key import from `parseUri`
 
 ## 4.59.0 (2025-09-03)
 

--- a/src/sui/SuiTools.ts
+++ b/src/sui/SuiTools.ts
@@ -170,7 +170,15 @@ export class SuiTools implements EdgeCurrencyTools {
       builtinTokens: this.builtinTokens,
       currencyCode: currencyCode ?? this.currencyInfo.currencyCode,
       customTokens,
-      testPrivateKeys: this.importPrivateKey.bind(this)
+      testPrivateKeys: async (input: string) => {
+        // Accept mnemonic and Bech32 suiprivkey for sweep during URI parsing.
+        if (validateMnemonic(input)) return await this.importPrivateKey(input)
+        if (input.startsWith('suiprivkey1'))
+          return await this.importPrivateKey(input)
+        // Do NOT accept raw 32-byte hex here, because it's ambiguous with a
+        // public address.
+        throw new Error('NotPrivateKey')
+      }
     })
 
     if (edgeParsedUri.privateKeys != null) {


### PR DESCRIPTION
It's a valid private key format, but ambiguous with public addresses

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211295392530573