### PR TITLE
feat: add usdrif and doc Rootstock tokens

### DIFF
--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -24,6 +24,22 @@ const builtinTokens: EdgeTokenMap = {
     networkLocation: {
       contractAddress: '0x2acc95758f8b5f583470ba265eb685a8f45fc9d5'
     }
+  },
+  '3a15461d8ae0f0fb5fa2629e9da7d66a794a6e37': {
+    currencyCode: 'USDRIF',
+    displayName: 'RIF US Dollar',
+    denominations: [{ name: 'USDRIF', multiplier: '1000000000000000000' }],
+    networkLocation: {
+      contractAddress: '0x3a15461d8ae0f0fb5fa2629e9da7d66a794a6e37'
+    }
+  },
+  e700691da7b9851f2f35f8b8182c69c53ccad9db: {
+    currencyCode: 'DOC',
+    displayName: 'Dollar On Chain',
+    denominations: [{ name: 'DOC', multiplier: '1000000000000000000' }],
+    networkLocation: {
+      contractAddress: '0xe700691da7b9851f2f35f8b8182c69c53ccad9db'
+    }
   }
 }
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [X] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

This PR adds USDRIF and DOC Tokens for Rootstock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add USDRIF and DOC RRC20 tokens to Rootstock with their contract addresses and denominations.
> 
> - **Rootstock tokens (`src/ethereum/info/rskInfo.ts`)**:
>   - Add `USDRIF` (`0x3a15461d8ae0f0fb5fa2629e9da7d66a794a6e37`) with denomination `USDRIF` (1e18).
>   - Add `DOC` (`0xe700691da7b9851f2f35f8b8182c69c53ccad9db`) with denomination `DOC` (1e18).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c309db90f37cc653986b5f00f84e6429fcf0add7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->