### PR TITLE
Jon/fix/xlm xrp memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: (XLM) Properly store only memo text or ID in a transaction, not both
+- fixed: (XRP) Parsing of on-chain memos
+
 ## 4.61.0 (2025-10-03)
 
 - added: (COSMOS) Add DEX tx support

--- a/src/common/validateMemos.ts
+++ b/src/common/validateMemos.ts
@@ -39,7 +39,11 @@ export function validateMemos(
 
   // Validate the number of memos:
   if (!multipleMemos && memos.length > 1) {
-    throw new Error(`${displayName} only supports one ${memoName}`)
+    // TODO: Localize. Also, if we expand this to other chains that don't call
+    // them memos, we need to make this more generic.
+    // For now, Stellar is the only chain that would throw here, so just
+    // hard-coding "memo" language.
+    throw new Error(`${displayName} only supports one memo type at a time.`)
   }
 }
 

--- a/src/stellar/stellarInfo.ts
+++ b/src/stellar/stellarInfo.ts
@@ -45,7 +45,7 @@ const currencyInfo: EdgeCurrencyInfo = {
     }
     // We also support a transaction ID for returned funds
   ],
-  multipleMemos: true,
+  multipleMemos: false,
 
   // Deprecated:
   displayName: 'Stellar'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description
#### Stellar (stellar/StellarEngine.ts):
Previously we set memos: [] on every transaction. We now parse Horizon’s memo_type plus memo/memo_bytes:

Also fixed incorrectly storing multiple memo types (text/id), only one or the other is allowed.

Stellar memos: [Stellar memos docs](https://developers.stellar.org/docs/encyclopedia/memos) — Horizon exposes memo_type, memo, and memo_bytes for hash/return.

#### XRP (ripple/RippleEngine.ts):
We already surfaced DestinationTag as a number memo (memoName: 'destination tag').
We were not parsing the on-chain Memos array. We now decode Memo.MemoData (hex) to UTF-8 where possible (fall back to hex) and add type: 'text' memos with memoName: 'memo'.

XRPL memos:[ XRPL “Memos” field ](https://xrpl.org/transaction-common-fields.html#memos-field)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parses XLM/XRP on-chain memos into EdgeTransaction, restricts XLM to a single memo type, and fixes XRP DestinationTag handling.
> 
> - **Memos**:
>   - **Stellar (XLM)**:
>     - Parse Horizon `memo_type` (`text`, `id`, `hash`/`return`) and attach as `memos` on transactions; decode base64 to hex for hash/return and mark hidden.
>     - Set `stellarInfo.multipleMemos` to `false` to allow only one memo type.
>   - **Ripple (XRP)**:
>     - Parse XRPL `Memos` array; decode `MemoFormat` text memos to UTF‑8, otherwise store hex (hidden).
>     - Fix `DestinationTag` assignment in `makeSpend` to use the current memo.
> - **Validation**:
>   - Update error message to indicate only one memo type is supported at a time.
> - **CHANGELOG**:
>   - Add entries for XLM single memo storage and XRP memo parsing fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fed515e6abb0aec3abf6e57db74d7f4cd8a68c49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210248399301358