### PR TITLE
Sam/etherscan v2 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## 4.64.0 (2025-11-14)
 
 - changed: Upgrade @polkadot/api to latest to support Asset Hub migration
+- removed: Removed 'api.bscscan.com' server due to deprecation
 
 ## 4.63.2 (2025-11-13)
 

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -117,22 +117,91 @@ export interface EthereumNetworkInfo {
   decoyAddressConfig?: DecoyAddressConfig
 }
 
-const asNetworkAdaptorConfigType = asValue(
-  'amberdata-rpc',
-  'blockbook',
-  'blockbook-ws',
-  'blockchair',
-  'blockcypher',
-  'evmscan',
-  'filfox',
-  'pulsechain-scan',
-  'rpc'
-)
-const asNetworkAdaptorConfig = asObject({
-  type: asNetworkAdaptorConfigType,
+const asAmberdataAdapterConfig: Cleaner<
+  import('./networkAdapters/AmberdataAdapter').AmberdataAdapterConfig
+> = asObject({
+  type: asValue('amberdata-rpc'),
+  amberdataBlockchainId: asString,
+  servers: asArray(asString)
+})
+
+const asBlockbookAdapterConfig: Cleaner<
+  import('./networkAdapters/BlockbookAdapter').BlockbookAdapterConfig
+> = asObject({
+  type: asValue('blockbook'),
+  servers: asArray(asString)
+})
+
+const asBlockbookWsAdapterConnection: Cleaner<
+  import('./networkAdapters/BlockbookWsAdapter').BlockbookWsAdapterConnection
+> = asObject({
+  url: asString,
+  keyType: asOptional(asValue('nowNodesApiKey'))
+})
+
+const asBlockbookWsAdapterConfig: Cleaner<
+  import('./networkAdapters/BlockbookWsAdapter').BlockbookWsAdapterConfig
+> = asObject({
+  type: asValue('blockbook-ws'),
+  connections: asArray(asBlockbookWsAdapterConnection)
+})
+
+const asBlockchairAdapterConfig: Cleaner<
+  import('./networkAdapters/BlockchairAdapter').BlockchairAdapterConfig
+> = asObject({
+  type: asValue('blockchair'),
+  servers: asArray(asString)
+})
+
+const asBlockcypherAdapterConfig: Cleaner<
+  import('./networkAdapters/BlockcypherAdapter').BlockcypherAdapterConfig
+> = asObject({
+  type: asValue('blockcypher'),
+  servers: asArray(asString)
+})
+
+const asEvmScanAdapterConfig: Cleaner<
+  import('./networkAdapters/EvmScanAdapter').EvmScanAdapterConfig
+> = asObject({
+  type: asValue('evmscan'),
+  servers: asArray(asString),
+  version: asValue(1, 2),
+  gastrackerSupport: asOptional(asBoolean)
+})
+
+const asFilfoxAdapterConfig: Cleaner<
+  import('./networkAdapters/FilfoxAdapter').FilfoxAdapterConfig
+> = asObject({
+  type: asValue('filfox'),
+  servers: asArray(asString)
+})
+
+const asPulsechainScanAdapterConfig: Cleaner<
+  import('./networkAdapters/PulsechainScanAdapter').PulsechainScanAdapterConfig
+> = asObject({
+  type: asValue('pulsechain-scan'),
+  servers: asArray(asString)
+})
+
+const asRpcAdapterConfig: Cleaner<
+  import('./networkAdapters/RpcAdapter').RpcAdapterConfig
+> = asObject({
+  type: asValue('rpc'),
   servers: asArray(asString),
   ethBalCheckerContract: asOptional(asString)
 })
+
+const asNetworkAdaptorConfig: Cleaner<NetworkAdapterConfig> = asEither(
+  asAmberdataAdapterConfig,
+  asBlockbookAdapterConfig,
+  asBlockbookWsAdapterConfig,
+  asBlockchairAdapterConfig,
+  asBlockcypherAdapterConfig,
+  asEvmScanAdapterConfig,
+  asFilfoxAdapterConfig,
+  asPulsechainScanAdapterConfig,
+  asRpcAdapterConfig
+)
 
 /**
  * Other Methods from EthereumTools

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -346,6 +346,8 @@ export const getEvmScanApiKey = (
   log: EdgeLog,
   serverUrl: string
 ): string | string[] | undefined => {
+  // TODO: This is total BS. We should just have a key associated with a domain name.
+  // This is getting out of hand.
   const { evmScanApiKey, etherscanApiKey, bscscanApiKey, polygonscanApiKey } =
     initOptions
 

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -222,11 +222,12 @@ export const fetchFeesFromEvmScan = async (
   const apiKey = `&apikey=${
     Array.isArray(scanApiKey) ? pickRandom(scanApiKey, 1)[0] : scanApiKey ?? ''
   }`
-  // Use Etherscan v2 API when targeting etherscan.io, otherwise use the network-specific scan API format
+  // Use version from config to determine URL format (server URLs already include full paths)
   const chainId = networkInfo.chainParams.chainId
-  const url = server.includes('etherscan.io')
-    ? `${server}/v2/api?chainid=${chainId}&module=gastracker&action=gasoracle${apiKey}`
-    : `${server}/api?module=gastracker&action=gasoracle${apiKey}`
+  const url =
+    evmScanConfig.version === 2
+      ? `${server}?chainid=${chainId}&module=gastracker&action=gasoracle${apiKey}`
+      : `${server}?module=gastracker&action=gasoracle${apiKey}`
 
   const fetchResponse = await fetch(url)
   if (!fetchResponse.ok)

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -52,7 +52,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.abscan.org/']
+      servers: ['https://api.abscan.org/'],
+      version: 2
     }
   ],
   uriNetworks: ['abstract'],

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -52,7 +52,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.abscan.org/'],
+      servers: ['https://api.abscan.org/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -47,7 +47,7 @@ const networkInfo: EthereumNetworkInfo = {
   networkAdapterConfigs: [
     {
       type: 'rpc',
-      servers: ['https://api.mainnet.abs.xyz	']
+      servers: ['https://api.mainnet.abs.xyz']
     },
     {
       type: 'evmscan',

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -52,7 +52,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.abscan.org/v2/api'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/amoyInfo.ts
+++ b/src/ethereum/info/amoyInfo.ts
@@ -58,7 +58,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api-amoy.polygonscan.com/']
+      servers: ['https://api-amoy.polygonscan.com/'],
+      version: 2
     }
   ],
   uriNetworks: ['amoy'],

--- a/src/ethereum/info/amoyInfo.ts
+++ b/src/ethereum/info/amoyInfo.ts
@@ -58,7 +58,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api-amoy.polygonscan.com/'],
+      servers: ['https://api-amoy.polygonscan.com/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -152,7 +152,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.arbiscan.io'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.arbiscan.io/v2/api'
+      ],
       version: 2
     },
     {

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -152,7 +152,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.arbiscan.io']
+      servers: ['https://api.etherscan.io', 'https://api.arbiscan.io'],
+      version: 2
     },
     {
       type: 'blockchair',

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -152,10 +152,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.arbiscan.io/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -198,11 +198,16 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
+      servers: ['https://api.etherscan.io', 'https://api.snowscan.xyz'],
+      version: 2
+    },
+    {
+      type: 'evmscan',
+      gastrackerSupport: true,
       servers: [
-        'https://api.etherscan.io',
-        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan',
-        'https://api.snowscan.xyz'
-      ]
+        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan'
+      ],
+      version: 1
     }
   ],
   uriNetworks: ['avalanche'],

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -198,14 +198,17 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.snowscan.xyz'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.snowscan.xyz/v2/api'
+      ],
       version: 2
     },
     {
       type: 'evmscan',
       gastrackerSupport: true,
       servers: [
-        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan'
+        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan/api'
       ],
       version: 1
     }

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -198,10 +198,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.snowscan.xyz/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -70,7 +70,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.basescan.org']
+      servers: ['https://api.etherscan.io', 'https://api.basescan.org'],
+      version: 2
     },
     {
       type: 'blockchair',

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -70,7 +70,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.basescan.org'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.basescan.org/v2/api'
+      ],
       version: 2
     },
     {

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -62,7 +62,6 @@ const networkInfo: EthereumNetworkInfo = {
       type: 'rpc',
       servers: [
         'https://base-mainnet.public.blastapi.io',
-        'https://rpc.ankr.com/base',
         'https://lb.drpc.org/ogrpc?network=base&dkey={{drpcApiKey}}'
       ],
       ethBalCheckerContract: '0x3ba5A41eA17fd4950a641a057dC0bEb8E8ff1521'
@@ -70,10 +69,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.basescan.org/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {

--- a/src/ethereum/info/binancesmartchainInfo.ts
+++ b/src/ethereum/info/binancesmartchainInfo.ts
@@ -154,7 +154,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.bscscan.com']
+      servers: ['https://api.etherscan.io', 'https://api.bscscan.com'],
+      version: 2
     }
   ],
   uriNetworks: ['smartchain'],

--- a/src/ethereum/info/binancesmartchainInfo.ts
+++ b/src/ethereum/info/binancesmartchainInfo.ts
@@ -154,10 +154,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.bscscan.com/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/binancesmartchainInfo.ts
+++ b/src/ethereum/info/binancesmartchainInfo.ts
@@ -154,7 +154,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.bscscan.com'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.bscscan.com/v2/api'
+      ],
       version: 2
     }
   ],

--- a/src/ethereum/info/bobevmInfo.ts
+++ b/src/ethereum/info/bobevmInfo.ts
@@ -56,7 +56,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://explorer.gobob.xyz']
+      servers: ['https://explorer.gobob.xyz'],
+      version: 1
     }
   ],
   uriNetworks: [],

--- a/src/ethereum/info/bobevmInfo.ts
+++ b/src/ethereum/info/bobevmInfo.ts
@@ -56,7 +56,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://explorer.gobob.xyz'],
+      servers: ['https://explorer.gobob.xyz/api'],
       version: 1
     }
   ],

--- a/src/ethereum/info/botanixInfo.ts
+++ b/src/ethereum/info/botanixInfo.ts
@@ -58,7 +58,8 @@ const networkInfo: EthereumNetworkInfo = {
       gastrackerSupport: true,
       servers: [
         'https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan'
-      ]
+      ],
+      version: 1
     }
   ],
   uriNetworks: [],

--- a/src/ethereum/info/botanixInfo.ts
+++ b/src/ethereum/info/botanixInfo.ts
@@ -57,7 +57,7 @@ const networkInfo: EthereumNetworkInfo = {
       type: 'evmscan',
       gastrackerSupport: true,
       servers: [
-        'https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan'
+        'https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan/api'
       ],
       version: 1
     }

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -78,13 +78,13 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://api.etherscan.io'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://explorer.celo.org/mainnet'],
+      servers: ['https://explorer.celo.org/mainnet/api'],
       version: 1
     }
   ],

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -71,7 +71,6 @@ const networkInfo: EthereumNetworkInfo = {
       servers: [
         'https://forno.celo.org',
         'https://rpc.ankr.com/celo',
-        'https://celo-mainnet-rpc.allthatnode.com',
         'https://lb.drpc.org/ogrpc?network=celo&dkey={{drpcApiKey}}'
       ]
     },

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -78,7 +78,14 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://api.etherscan.io', 'https://explorer.celo.org/mainnet']
+      servers: ['https://api.etherscan.io'],
+      version: 2
+    },
+    {
+      type: 'evmscan',
+      gastrackerSupport: false,
+      servers: ['https://explorer.celo.org/mainnet'],
+      version: 1
     }
   ],
   uriNetworks: ['celo'],

--- a/src/ethereum/info/ethereumInfo.ts
+++ b/src/ethereum/info/ethereumInfo.ts
@@ -1173,7 +1173,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {

--- a/src/ethereum/info/ethereumInfo.ts
+++ b/src/ethereum/info/ethereumInfo.ts
@@ -1173,7 +1173,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io']
+      servers: ['https://api.etherscan.io'],
+      version: 2
     },
     {
       type: 'blockbook',

--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -84,12 +84,7 @@ const networkInfo: EthereumNetworkInfo = {
   networkAdapterConfigs: [
     {
       type: 'rpc',
-      servers: [
-        'https://etc.rivet.link',
-        'https://geth-de.etc-network.info',
-        'https://geth-at.etc-network.info',
-        'https://etc.etcdesktop.com'
-      ],
+      servers: ['https://etc.rivet.link', 'https://etc.etcdesktop.com'],
       ethBalCheckerContract: '0xfC701A6b65e1BcF59fb3BDbbe5cb41f35FC7E009'
     },
     {

--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -95,7 +95,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://etc.blockscout.com'],
+      servers: ['https://etc.blockscout.com/api'],
       version: 1
     },
     {

--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -95,7 +95,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://etc.blockscout.com']
+      servers: ['https://etc.blockscout.com'],
+      version: 1
     },
     {
       type: 'blockbook',

--- a/src/ethereum/info/ethereumpowInfo.ts
+++ b/src/ethereum/info/ethereumpowInfo.ts
@@ -60,13 +60,6 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'rpc',
       servers: ['https://mainnet.ethereumpow.org']
-    },
-    {
-      type: 'evmscan',
-      gastrackerSupport: true,
-      servers: [
-        // TODO:
-      ]
     }
   ],
 

--- a/src/ethereum/info/fantomInfo.ts
+++ b/src/ethereum/info/fantomInfo.ts
@@ -299,7 +299,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://ftmscout.com/'],
+      servers: ['https://ftmscout.com/api'],
       version: 1
     }
   ],

--- a/src/ethereum/info/fantomInfo.ts
+++ b/src/ethereum/info/fantomInfo.ts
@@ -299,7 +299,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://ftmscout.com/']
+      servers: ['https://ftmscout.com/'],
+      version: 1
     }
   ],
   uriNetworks: ['fantom'],

--- a/src/ethereum/info/holeskyInfo.ts
+++ b/src/ethereum/info/holeskyInfo.ts
@@ -76,7 +76,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/holeskyInfo.ts
+++ b/src/ethereum/info/holeskyInfo.ts
@@ -76,7 +76,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io']
+      servers: ['https://api.etherscan.io'],
+      version: 2
     }
   ],
 

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -125,8 +125,7 @@ const networkInfo: EthereumNetworkInfo = {
       servers: [
         'https://rpc.hyperliquid.xyz/evm',
         'https://rpc.hypurrscan.io',
-        'https://hyperliquid-json-rpc.stakely.io',
-        'https://hyperliquid-json-rpc.stakely.io'
+        'https://rpc.hyperlend.finance'
       ]
     },
     {

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -132,7 +132,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.routescan.io/v2/network/mainnet/evm/999/etherscan']
+      servers: [
+        'https://api.routescan.io/v2/network/mainnet/evm/999/etherscan'
+      ],
+      version: 1
     }
   ],
   uriNetworks: [],

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -133,7 +133,7 @@ const networkInfo: EthereumNetworkInfo = {
       type: 'evmscan',
       gastrackerSupport: true,
       servers: [
-        'https://api.routescan.io/v2/network/mainnet/evm/999/etherscan'
+        'https://api.routescan.io/v2/network/mainnet/evm/999/etherscan/api'
       ],
       version: 1
     }

--- a/src/ethereum/info/optimismInfo.ts
+++ b/src/ethereum/info/optimismInfo.ts
@@ -190,7 +190,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io']
+      servers: ['https://api.etherscan.io'],
+      version: 2
     }
   ],
   uriNetworks: ['optimism'],

--- a/src/ethereum/info/optimismInfo.ts
+++ b/src/ethereum/info/optimismInfo.ts
@@ -190,7 +190,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/polygonInfo.ts
+++ b/src/ethereum/info/polygonInfo.ts
@@ -198,7 +198,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.polygonscan.com']
+      servers: ['https://api.etherscan.io', 'https://api.polygonscan.com'],
+      version: 2
     }
   ],
   uriNetworks: ['polygon'],

--- a/src/ethereum/info/polygonInfo.ts
+++ b/src/ethereum/info/polygonInfo.ts
@@ -185,9 +185,6 @@ const networkInfo: EthereumNetworkInfo = {
       type: 'rpc',
       servers: [
         'https://polygon-rpc.com/',
-        'https://rpc.polycat.finance',
-        'https://rpc-mainnet.maticvigil.com',
-        'https://matic-mainnet.chainstacklabs.com',
         'https://rpc.ankr.com/polygon',
         'https://poly.api.pocket.network',
         'https://rpc-mainnet.matic.quiknode.pro/{{quiknodeApiKey}}/',
@@ -198,10 +195,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.polygonscan.com/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/polygonInfo.ts
+++ b/src/ethereum/info/polygonInfo.ts
@@ -198,7 +198,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.polygonscan.com'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.polygonscan.com/v2/api'
+      ],
       version: 2
     }
   ],

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -64,7 +64,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://api.scan.pulsechain.com'],
+      servers: ['https://api.scan.pulsechain.com/api'],
       version: 1
     },
     {

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -64,7 +64,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://api.scan.pulsechain.com']
+      servers: ['https://api.scan.pulsechain.com'],
+      version: 1
     },
     {
       type: 'pulsechain-scan',

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -62,7 +62,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://blockscout.com/rsk/mainnet']
+      servers: ['https://blockscout.com/rsk/mainnet'],
+      version: 1
     }
   ],
   uriNetworks: ['rsk', 'rbtc'],

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -62,7 +62,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: false,
-      servers: ['https://blockscout.com/rsk/mainnet'],
+      servers: ['https://blockscout.com/rsk/mainnet/api'],
       version: 1
     }
   ],

--- a/src/ethereum/info/sepoliaInfo.ts
+++ b/src/ethereum/info/sepoliaInfo.ts
@@ -74,7 +74,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io'],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/sepoliaInfo.ts
+++ b/src/ethereum/info/sepoliaInfo.ts
@@ -74,7 +74,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io']
+      servers: ['https://api.etherscan.io'],
+      version: 2
     }
   ],
 

--- a/src/ethereum/info/sonicInfo.ts
+++ b/src/ethereum/info/sonicInfo.ts
@@ -145,7 +145,8 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.sonicscan.org']
+      servers: ['https://api.etherscan.io', 'https://api.sonicscan.org'],
+      version: 2
     }
   ],
   uriNetworks: ['sonic'],

--- a/src/ethereum/info/sonicInfo.ts
+++ b/src/ethereum/info/sonicInfo.ts
@@ -145,10 +145,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api.sonicscan.org/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     }
   ],

--- a/src/ethereum/info/sonicInfo.ts
+++ b/src/ethereum/info/sonicInfo.ts
@@ -145,7 +145,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api.sonicscan.org'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api.sonicscan.org/v2/api'
+      ],
       version: 2
     }
   ],

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -97,10 +97,7 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io/v2/api',
-        'https://api-era.zksync.network/v2/api'
-      ],
+      servers: ['https://api.etherscan.io/v2/api'],
       version: 2
     },
     {

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -97,13 +97,16 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.etherscan.io', 'https://api-era.zksync.network'],
+      servers: [
+        'https://api.etherscan.io/v2/api',
+        'https://api-era.zksync.network/v2/api'
+      ],
       version: 2
     },
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://block-explorer-api.mainnet.zksync.io'],
+      servers: ['https://block-explorer-api.mainnet.zksync.io/api'],
       version: 1
     }
   ],

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -97,11 +97,14 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io',
-        'https://block-explorer-api.mainnet.zksync.io',
-        'https://api-era.zksync.network'
-      ]
+      servers: ['https://api.etherscan.io', 'https://api-era.zksync.network'],
+      version: 2
+    },
+    {
+      type: 'evmscan',
+      gastrackerSupport: true,
+      servers: ['https://block-explorer-api.mainnet.zksync.io'],
+      version: 1
     }
   ],
   uriNetworks: ['zksync'],

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -59,6 +59,7 @@ const NUM_TRANSACTIONS_TO_QUERY = 50
 export interface EvmScanAdapterConfig {
   type: 'evmscan'
   servers: string[]
+  version: 1 | 2
 
   /** Whether the API supports gastracker module */
   gastrackerSupport?: boolean
@@ -301,7 +302,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
 
     // Determine if we should use v2 API
     let url: string
-    if (server.includes('etherscan.io')) {
+    if (this.config.version === 2) {
       // For etherscan.io API - use v2 with chainId
       url = `${server}/v2/api?chainid=${chainId}${
         cmd.startsWith('?') ? cmd.replace('?', '&') : cmd

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -325,7 +325,9 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
       'status' in cleanData &&
       cleanData.status === '0' &&
       typeof cleanData.result === 'string' &&
-      cleanData.result.match(/Max calls|rate limit/) != null
+      (cleanData.result.match(/Max calls|rate limit/) != null ||
+        cleanData.result.match(/Free API access is temporarily unavailable/) !=
+          null)
     ) {
       throw new RateLimitError(`fetchGetEtherscan rate limit for ${server}`)
     }

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -304,12 +304,12 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     let url: string
     if (this.config.version === 2) {
       // For etherscan.io API - use v2 with chainId
-      url = `${server}/v2/api?chainid=${chainId}${
+      url = `${server}?chainid=${chainId}${
         cmd.startsWith('?') ? cmd.replace('?', '&') : cmd
       }`
     } else {
       // For non-etherscan APIs like blockscout, continue using the old format
-      url = `${server}/api${cmd}`
+      url = `${server}${cmd}`
     }
 
     const response = await this.ethEngine.fetchCors(`${url}${apiKeyParam}`)

--- a/test/ethereum/fees/ethFeeHistory.test.ts
+++ b/test/ethereum/fees/ethFeeHistory.test.ts
@@ -269,7 +269,8 @@ describe('fetchFeesFromFeeHistory integration', function () {
         {
           type: 'evmscan',
           gastrackerSupport: true,
-          servers: ['https://api.etherscan.io']
+          servers: ['https://api.etherscan.io'],
+          version: 2
         }
       ]
     }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce versioned `evmscan` adapter and update network configs/fee provider to use Etherscan v2 and correct API paths; expand rate‑limit handling and add precise adapter cleaners.
> 
> - **EVM Core**:
>   - **EvmScan Adapter**: Add `version: 1 | 2` to config and build URLs accordingly (v2 uses `?chainid=`; v1 uses legacy `/api`). Expand rate‑limit detection strings.
>   - **Fees**: `fetchFeesFromEvmScan` now selects URL format based on adapter `version`; `getEvmScanApiKey` logic retained with clarifying comments.
>   - **Types/Cleaners**: Replace generic adapter cleaner with specific cleaners; add `EvmScanAdapterConfig.version` to schema.
> - **Network Configs** (multiple chains: `ethereum`, `arbitrum`, `base`, `optimism`, `polygon`, `avalanche`, `amoy`, `sepolia`, `holesky`, `sonic`, `binancesmartchain`, `bobevm`, `botanix`, `fantom`, `rsk`, `pulsechain`, `zksync`, etc.):
>   - Point `evmscan` servers to correct paths (Etherscan v2: `https://api.etherscan.io/v2/api` with `version: 2`; Blockscout/Routescan/etc.: append `/api` with `version: 1`).
>   - Minor RPC list tweaks (e.g., cleanup duplicates, remove defunct endpoints; ETC RPC list trimmed).
>   - Add/adjust secondary `evmscan` entries where needed (e.g., Avalanche Avascan, Celo explorer, zkSync explorer).
> - **Tests**:
>   - Update fee history test configs to include `version: 2` on `evmscan` entries.
> - **CHANGELOG**:
>   - Note removal of deprecated `api.bscscan.com` server.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59d4e909eca20750bd762ed01e7b219c95bfddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211862950877068
  - https://app.asana.com/0/0/1211985592167101
  - https://app.asana.com/0/0/1212121722792430