### PR TITLE
Add service keys

### DIFF
--- a/src/common/serviceKeys.ts
+++ b/src/common/serviceKeys.ts
@@ -1,0 +1,52 @@
+import { ServiceKeys } from './types'
+import { pickRandom } from './utils'
+
+/**
+ * Retrieves a random service key (API key) for a given host index.
+ *
+ * @param serviceKeys - An object mapping host strings to arrays of API keys
+ * @param index - The host string to look up (typically obtained from getServiceKeyIndex)
+ * @returns A randomly selected API key string, or undefined if no keys are available for the given index
+ *
+ * @example
+ * ```typescript
+ * const serviceKeys = {
+ *   'api.example.com': ['key1', 'key2', 'key3']
+ * }
+ * const key = getRandomServiceKey(serviceKeys, 'api.example.com')
+ * // Returns one of: 'key1', 'key2', or 'key3'
+ * ```
+ */
+export function getRandomServiceKey(
+  serviceKeys: ServiceKeys,
+  index: string
+): string | undefined {
+  const keys = serviceKeys[index]
+  if (keys == null || keys.length === 0) return undefined
+  return pickRandom(keys, 1)[0]
+}
+
+/**
+ * Extracts the host from a URL string to use as an index for ServiceKeys.
+ *
+ * This function normalizes URLs by constructing a proper URL object, which handles
+ * both full URLs and host-only strings. The host is used as the key to look up
+ * service keys in the ServiceKeys object.
+ *
+ * The reason for this function is to define the index or key for the
+ * ServiceKey object from a URL string to determine the relevant API keys for
+ * the service provider.
+ *
+ * @param urlString - A URL string or host string (e.g., 'https://api.example.com' or 'api.example.com')
+ * @returns The host portion of the URL (e.g., 'api.example.com')
+ *
+ * @example
+ * ```typescript
+ * getServiceKeyIndex('https://api.example.com/path') // Returns 'api.example.com'
+ * getServiceKeyIndex('api.example.com') // Returns 'api.example.com'
+ * ```
+ */
+export function getServiceKeyIndex(urlString: string): string {
+  const url = new URL(urlString, `https://${urlString}`)
+  return url.host
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -205,3 +205,8 @@ export const asEdgeToken = asObject({
 export const asInfoServerTokens = asObject({
   infoServerTokens: asMaybe(asArray(asUnknown))
 })
+
+export interface ServiceKeys {
+  [host: string]: string[]
+}
+export const asServiceKeys: Cleaner<ServiceKeys> = asObject(asArray(asString))

--- a/src/ethereum/EthereumTools.ts
+++ b/src/ethereum/EthereumTools.ts
@@ -29,6 +29,7 @@ import {
 } from '../common/utils'
 import { ethereumPlugins } from './ethereumInfos'
 import {
+  asEthereumInitOptions,
   asEthereumPrivateKeys,
   asSafeEthWalletInfo,
   EthereumInfoPayload,
@@ -50,7 +51,7 @@ export class EthereumTools implements EdgeCurrencyTools {
     this.currencyInfo = currencyInfo
     this.io = io
     this.networkInfo = networkInfo
-    this.initOptions = initOptions
+    this.initOptions = asEthereumInitOptions(initOptions)
   }
 
   async getDisplayPrivateKey(

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -18,29 +18,50 @@ import { EdgeSpendInfo } from 'edge-core-js/types'
 import {
   asIntegerString,
   asSafeCommonWalletInfo,
+  asServiceKeys,
+  ServiceKeys,
   WalletConnectPayload
 } from '../common/types'
 import { FeeAlgorithmConfig } from './feeAlgorithms/feeAlgorithmTypes'
 import type { NetworkAdapterConfig } from './networkAdapters/networkAdapterTypes'
 
 export interface EthereumInitOptions {
-  alchemyApiKey?: string
-  amberdataApiKey?: string
-  blockchairApiKey?: string
-  blockcypherApiKey?: string
-  drpcApiKey?: string
-  /** For Etherscan v2 API */
-  etherscanApiKey?: string | string[]
-  /** For bespoke scan APIs unsupported by Etherscan v2 API (e.g. fantomscan) */
-  evmScanApiKey?: string | string[]
-  gasStationApiKey?: string
+  serviceKeys: ServiceKeys
   infuraProjectId?: string
+
+  /** @deprecated Use serviceKeys instead */
+  alchemyApiKey?: string
+  /** @deprecated Use serviceKeys instead */
+  amberdataApiKey?: string
+  /** @deprecated Use serviceKeys instead */
+  blockchairApiKey?: string
+  /** @deprecated Use serviceKeys instead */
+  blockcypherApiKey?: string
+  /** @deprecated Use serviceKeys instead */
+  drpcApiKey?: string
+  /** For Etherscan v2 API
+   * @deprecated Use serviceKeys instead
+   */
+  etherscanApiKey?: string | string[]
+  /** For bespoke scan APIs unsupported by Etherscan v2 API (e.g. fantomscan)
+   * @deprecated Use serviceKeys instead
+   */
+  evmScanApiKey?: string | string[]
+  /** @deprecated Use serviceKeys instead */
+  gasStationApiKey?: string
+  /** @deprecated Use serviceKeys instead */
   nowNodesApiKey?: string
+  /** @deprecated Use serviceKeys instead */
   poktPortalApiKey?: string
+  /** @deprecated Use serviceKeys instead */
   quiknodeApiKey?: string
 }
 
 export const asEthereumInitOptions = asObject<EthereumInitOptions>({
+  serviceKeys: asOptional(asServiceKeys, () => ({})),
+  infuraProjectId: asOptional(asString),
+
+  // Deprecated:
   alchemyApiKey: asOptional(asString),
   amberdataApiKey: asOptional(asString),
   blockchairApiKey: asOptional(asString),
@@ -49,7 +70,6 @@ export const asEthereumInitOptions = asObject<EthereumInitOptions>({
   etherscanApiKey: asOptional(asEither(asString, asArray(asString))),
   evmScanApiKey: asOptional(asEither(asString, asArray(asString))),
   gasStationApiKey: asOptional(asString),
-  infuraProjectId: asOptional(asString),
   nowNodesApiKey: asOptional(asString),
   poktPortalApiKey: asOptional(asString),
   quiknodeApiKey: asOptional(asString)

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -8,6 +8,10 @@ import {
 } from 'edge-core-js/types'
 
 import { fetchInfo } from '../../common/network'
+import {
+  getRandomServiceKey,
+  getServiceKeyIndex
+} from '../../common/serviceKeys'
 import { hexToDecimal, pickRandom } from '../../common/utils'
 import {
   GAS_PRICE_SANITY_CHECK,
@@ -346,36 +350,55 @@ export const getEvmScanApiKey = (
   log: EdgeLog,
   serverUrl: string
 ): string | string[] | undefined => {
-  const { evmScanApiKey, etherscanApiKey, bscscanApiKey, polygonscanApiKey } =
-    initOptions
+  const {
+    evmScanApiKey,
+    etherscanApiKey,
+    bscscanApiKey,
+    polygonscanApiKey,
+    serviceKeys
+  } = initOptions
 
   const { currencyCode } = info
+  const serviceKey = getRandomServiceKey(
+    serviceKeys,
+    getServiceKeyIndex(serverUrl)
+  )
+
+  if (serviceKey != null) return serviceKey
 
   // If we have a server URL and it's etherscan.io, use the Ethereum API key
   if (serverUrl.includes('etherscan.io')) {
     if (etherscanApiKey == null)
       throw new Error(`Missing etherscanApiKey for etherscan.io`)
+    log.warn(
+      "INIT OPTION 'etherscanApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
+    )
     return etherscanApiKey
   }
 
-  if (evmScanApiKey != null) return evmScanApiKey
+  if (evmScanApiKey != null) {
+    log.warn(
+      "INIT OPTION 'evmScanApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
+    )
+    return evmScanApiKey
+  }
 
   // For networks that don't support Etherscan v2, fall back to network-specific keys
   if (currencyCode === 'ETH' && etherscanApiKey != null) {
     log.warn(
-      "INIT OPTION 'etherscanApiKey' IS DEPRECATED. USE 'evmScanApiKey' INSTEAD"
+      "INIT OPTION 'etherscanApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
     )
     return etherscanApiKey
   }
   if (currencyCode === 'BNB' && bscscanApiKey != null) {
     log.warn(
-      "INIT OPTION 'bscscanApiKey' IS DEPRECATED. USE 'evmScanApiKey' INSTEAD"
+      "INIT OPTION 'bscscanApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
     )
     return bscscanApiKey
   }
   if (currencyCode === 'POL' && polygonscanApiKey != null) {
     log.warn(
-      "INIT OPTION 'polygonscanApiKey' IS DEPRECATED. USE 'evmScanApiKey' INSTEAD"
+      "INIT OPTION 'polygonscanApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
     )
     return polygonscanApiKey
   }

--- a/src/ethereum/networkAdapters/BlockcypherAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockcypherAdapter.ts
@@ -1,6 +1,10 @@
 import { EdgeTransaction } from 'edge-core-js/types'
 import parse from 'url-parse'
 
+import {
+  getRandomServiceKey,
+  getServiceKeyIndex
+} from '../../common/serviceKeys'
 import { BroadcastResults } from '../EthereumNetwork'
 import { NetworkAdapter } from './networkAdapterTypes'
 
@@ -50,13 +54,21 @@ export class BlockcypherAdapter extends NetworkAdapter<BlockcypherAdapterConfig>
     body: any,
     baseUrl: string
   ): Promise<any> {
-    const { blockcypherApiKey } = this.ethEngine.initOptions
-    let apiKey = ''
-    if (blockcypherApiKey != null && blockcypherApiKey.length > 5) {
-      apiKey = '&token=' + blockcypherApiKey
+    const { blockcypherApiKey, serviceKeys } = this.ethEngine.initOptions
+    let apiKey = getRandomServiceKey(serviceKeys, getServiceKeyIndex(baseUrl))
+
+    if (
+      apiKey == null &&
+      blockcypherApiKey != null &&
+      blockcypherApiKey.length > 5
+    ) {
+      apiKey = blockcypherApiKey
+      this.ethEngine.log.warn(
+        "INIT OPTION 'blockcypherApiKey' IS DEPRECATED. USE 'serviceKeys' INSTEAD"
+      )
     }
 
-    const url = `${baseUrl}/${cmd}${apiKey}`
+    const url = `${baseUrl}/${cmd}${apiKey != null ? `&token=${apiKey}` : ''}`
     const response = await this.ethEngine.fetchCors(url, {
       headers: {
         Accept: 'application/json',

--- a/test/engine/feeProvider.test.ts
+++ b/test/engine/feeProvider.test.ts
@@ -33,11 +33,13 @@ describe(`FTM Network Fees`, function () {
       fetch,
       ftmCurrencyInfo,
       {
-        evmScanApiKey: [
-          'EG16P5AF5FNJ3XR8ICP3UAYHT68G53TAKU',
-          '63YA67UBCWPG6SEREC9GNRRR31SDPGSQY9',
-          'D925MHYVPJH3ZBSJKES5EFC876FFMW3ZHX'
-        ]
+        serviceKeys: {
+          'api.etherscan.io': [
+            'EG16P5AF5FNJ3XR8ICP3UAYHT68G53TAKU',
+            '63YA67UBCWPG6SEREC9GNRRR31SDPGSQY9',
+            'D925MHYVPJH3ZBSJKES5EFC876FFMW3ZHX'
+          ]
+        }
       },
       fakeLog,
       ftmNetworkInfo


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds centralized serviceKeys for API keys and updates Ethereum tools/adapters/fees to use them with deprecation fallbacks.
> 
> - **Common**:
>   - **Service Keys**: Add `ServiceKeys` type and cleaner in `src/common/types.ts` and new helpers `getRandomServiceKey`/`getServiceKeyIndex` in `src/common/serviceKeys.ts`.
> - **Ethereum**:
>   - **Init Options**: Extend `EthereumInitOptions` with `serviceKeys` (and `infuraProjectId`), mark legacy keys (e.g., `etherscanApiKey`, `evmScanApiKey`, `amberdataApiKey`, etc.) as deprecated via `asEthereumInitOptions`.
>   - **Tools**: Validate init options with `asEthereumInitOptions` in `EthereumTools`.
>   - **Fees**: Update `getEvmScanApiKey` to prefer `serviceKeys` (by host via `getServiceKeyIndex`), fallback to deprecated keys with warnings.
>   - **Network Adapters**: Migrate API key resolution to `serviceKeys` with fallbacks in `AmberdataAdapter`, `BlockchairAdapter`, `BlockcypherAdapter`, `BlockbookWsAdapter`, and `RpcAdapter` (including RPC URL template key replacement and error messaging).
> - **Tests**:
>   - Update `feeProvider.test.ts` to supply `serviceKeys` for EvmScan test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80e245eea26217def70100abc589d19607c9347e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210654475275310