### PR TITLE
Reduce UI lag: gate redundant callbacks in accountbased engines

### DIFF
--- a/src/algorand/AlgorandEngine.ts
+++ b/src/algorand/AlgorandEngine.ts
@@ -208,7 +208,7 @@ export class AlgorandEngine extends CurrencyEngine<
       }
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
 
       this.updateBlockHeight(round)

--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -196,6 +196,7 @@ export class CurrencyEngine<
       publicKey: '',
       totalBalances: {},
       numTransactions: {},
+      detectedTokenIds: {},
       unactivatedTokenIds: [],
       otherData: undefined
     }
@@ -653,6 +654,15 @@ export class CurrencyEngine<
       this.currencyEngineCallbacks.onTokenBalanceChanged(tokenId, balance)
     }
     this.syncTracker.balanceComplete?.(tokenId)
+  }
+
+  reportDetectedTokens(tokenIds: string[]): void {
+    const known = this.walletLocalData.detectedTokenIds
+    const newTokenIds = tokenIds.filter(id => known[id] == null)
+    if (newTokenIds.length === 0) return
+    for (const id of newTokenIds) known[id] = true
+    this.walletLocalDataDirty = true
+    this.currencyEngineCallbacks.onNewTokens(Object.keys(known))
   }
 
   updateConfirmations(tx: EdgeTransaction): boolean {

--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -717,10 +717,12 @@ export class CurrencyEngine<
 
     this.walletLocalData.blockHeight = blockHeight
     this.walletLocalDataDirty = true
-    this.currencyEngineCallbacks.onBlockHeightChanged(blockHeight)
 
+    // Update confirmations directly on all in-memory transactions and emit
+    // any that changed via onTransactions. Confirmations are owned by the engine;
+    // core-js learns of changes only when we send txs with updated confirmations
+    // via onTransactions (i.e. the deprecated onBlockHeightChanged is not called).
     const activeTokenIds = [null, ...this.enabledTokenIds]
-
     for (const tokenId of activeTokenIds) {
       const txList = this.transactionList[tokenId ?? ''] ?? []
       for (let i = 0; i < txList.length; i++) {

--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -15,6 +15,7 @@ import {
   EdgeLog,
   EdgeMetaToken,
   EdgeSpendInfo,
+  EdgeStakingStatus,
   EdgeSubscribedAddress,
   EdgeSyncStatus,
   EdgeToken,
@@ -654,6 +655,15 @@ export class CurrencyEngine<
       this.currencyEngineCallbacks.onTokenBalanceChanged(tokenId, balance)
     }
     this.syncTracker.balanceComplete?.(tokenId)
+  }
+
+  private lastStakingStatusJson: string = ''
+
+  protected reportStakingStatus(status: EdgeStakingStatus): void {
+    const json = JSON.stringify(status)
+    if (json === this.lastStakingStatusJson) return
+    this.lastStakingStatusJson = json
+    this.currencyEngineCallbacks.onStakingStatusChanged(status)
   }
 
   reportDetectedTokens(tokenIds: string[]): void {

--- a/src/common/SyncTracker.ts
+++ b/src/common/SyncTracker.ts
@@ -43,6 +43,7 @@ export function makeTokenSyncTracker(engine: SyncEngine): TokenSyncTracker {
   // Each tokenId can be a 0-1 value:
   const balanceRatios = new Map<EdgeTokenId, number>()
   const historyRatios = new Map<EdgeTokenId, number>()
+  let lastSyncStatus: EdgeSyncStatus | undefined
 
   function getSyncStatus(): EdgeSyncStatus {
     const activeTokenIds = [null, ...engine.enabledTokenIds]
@@ -66,10 +67,22 @@ export function makeTokenSyncTracker(engine: SyncEngine): TokenSyncTracker {
     return { totalRatio }
   }
 
+  function sendSyncStatusIfChanged(): void {
+    const currentStatus = getSyncStatus()
+    if (
+      lastSyncStatus == null ||
+      lastSyncStatus.totalRatio !== currentStatus.totalRatio
+    ) {
+      lastSyncStatus = currentStatus
+      engine.sendSyncStatus(currentStatus)
+    }
+  }
+
   const out: TokenSyncTracker = {
     resetSync() {
       balanceRatios.clear()
       historyRatios.clear()
+      lastSyncStatus = undefined
     },
 
     balanceComplete(tokenId) {
@@ -78,12 +91,12 @@ export function makeTokenSyncTracker(engine: SyncEngine): TokenSyncTracker {
 
     setBalanceRatios(tokenIds, ratio) {
       for (const tokenId of tokenIds) balanceRatios.set(tokenId, ratio)
-      engine.sendSyncStatus(getSyncStatus())
+      sendSyncStatusIfChanged()
     },
 
     setHistoryRatios(tokenIds, ratio) {
       for (const tokenId of tokenIds) historyRatios.set(tokenId, ratio)
-      engine.sendSyncStatus(getSyncStatus())
+      sendSyncStatusIfChanged()
     },
 
     updateBalanceRatio(tokenId, ratio) {
@@ -94,7 +107,7 @@ export function makeTokenSyncTracker(engine: SyncEngine): TokenSyncTracker {
       if (ratio <= lastRatio) return
 
       balanceRatios.set(tokenId, ratio)
-      engine.sendSyncStatus(getSyncStatus())
+      sendSyncStatusIfChanged()
     },
 
     updateHistoryRatio(tokenId, ratio, minStep) {
@@ -108,7 +121,7 @@ export function makeTokenSyncTracker(engine: SyncEngine): TokenSyncTracker {
       if (minStep != null && ratio - lastRatio < minStep && ratio < 1) return
 
       historyRatios.set(tokenId, ratio)
-      engine.sendSyncStatus(getSyncStatus())
+      sendSyncStatusIfChanged()
     }
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,6 @@
 import {
   asArray,
+  asBoolean,
   asCodec,
   asEither,
   asMaybe,
@@ -60,6 +61,7 @@ export const asWalletLocalData = asObject({
     asObject(asNumber),
     () => ({})
   ),
+  detectedTokenIds: asMaybe(asObject(asBoolean), () => ({})),
   unactivatedTokenIds: asMaybe(asArray(asString), () => []),
   otherData: asOptional(asUnknown, () => ({}))
 })

--- a/src/cosmos/engine/CosmosEngine.ts
+++ b/src/cosmos/engine/CosmosEngine.ts
@@ -637,7 +637,7 @@ export class CosmosEngine extends CurrencyEngine<
       })
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
 
       if (this.stakingSupported) {

--- a/src/cosmos/engine/CosmosEngine.ts
+++ b/src/cosmos/engine/CosmosEngine.ts
@@ -656,7 +656,7 @@ export class CosmosEngine extends CurrencyEngine<
                 }
               ]
             }
-            this.currencyEngineCallbacks.onStakingStatusChanged(stakingStatus)
+            this.reportStakingStatus(stakingStatus)
             this.stakedBalanceCache = stakedBalance.amount
           }
         } catch (e) {

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -456,7 +456,7 @@ export class EthereumNetwork {
       for (const [tokenId, bal] of tokenBal) {
         this.ethEngine.updateBalance(tokenId, bal)
       }
-      this.ethEngine.currencyEngineCallbacks.onNewTokens(
+      this.ethEngine.reportDetectedTokens(
         ethereumNetworkUpdate.detectedTokenIds ?? []
       )
     }
@@ -723,7 +723,7 @@ function makeThrottledFunction<Args extends any[], Rtn>(
   fn: (...args: Args) => Promise<Rtn>
 ): () => Promise<Rtn> {
   let lastTime = 0
-  let lastTimeout: NodeJS.Timeout | undefined
+  let lastTimeout: ReturnType<typeof setTimeout> | undefined
   return async (...args: Args) => {
     return await new Promise((resolve, reject) => {
       const timeSinceLast = Date.now() - lastTime

--- a/src/fio/FioEngine.ts
+++ b/src/fio/FioEngine.ts
@@ -318,9 +318,7 @@ export class FioEngine extends CurrencyEngine<
     super.doInitialBalanceCallback()
 
     try {
-      this.currencyEngineCallbacks.onStakingStatusChanged({
-        ...this.otherData.stakingStatus
-      })
+      this.reportStakingStatus({ ...this.otherData.stakingStatus })
     } catch (e: any) {
       this.error(`doInitialBalanceCallback onStakingStatusChanged`, e)
     }
@@ -428,9 +426,7 @@ export class FioEngine extends CurrencyEngine<
     }
     this.localDataDirty()
     try {
-      this.currencyEngineCallbacks.onStakingStatusChanged({
-        ...this.otherData.stakingStatus
-      })
+      this.reportStakingStatus({ ...this.otherData.stakingStatus })
     } catch (e: any) {
       this.error('onStakingStatusChanged error')
     }

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -705,7 +705,7 @@ export class XrpEngine extends CurrencyEngine<
       })
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
 
       // If get here, we've checked balances for all possible tokens the user

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -217,7 +217,7 @@ export class SolanaEngine extends CurrencyEngine<
       }
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
     } catch (e: any) {
       // Nodes will return 0 for uninitiated accounts so thrown errors should be logged

--- a/src/sui/SuiEngine.ts
+++ b/src/sui/SuiEngine.ts
@@ -157,7 +157,7 @@ export class SuiEngine extends CurrencyEngine<
       }
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
 
       this.syncTracker.setBalanceRatios([null, ...this.enabledTokenIds], 1)

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -256,7 +256,7 @@ export class TronEngine extends CurrencyEngine<
       }
 
       if (detectedTokenIds.length > 0) {
-        this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+        this.reportDetectedTokens(detectedTokenIds)
       }
     } catch (e) {
       this.log.error('checkTokenBalances error', e)

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -345,9 +345,7 @@ export class TronEngine extends CurrencyEngine<
       }
 
       this.stakingStatus = { stakedAmounts }
-      this.currencyEngineCallbacks.onStakingStatusChanged({
-        ...this.stakingStatus
-      })
+      this.reportStakingStatus({ ...this.stakingStatus })
     } catch (e: any) {
       this.log.error('Error checking TRX address balance: ', e)
     }

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -192,7 +192,7 @@ export class ZanoEngine extends CurrencyEngine<
     }
 
     if (detectedTokenIds.length > 0) {
-      this.currencyEngineCallbacks.onNewTokens(detectedTokenIds)
+      this.reportDetectedTokens(detectedTokenIds)
     }
 
     this.syncTracker.updateBalanceRatio(1)


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Reduces RN JS thread starvation by eliminating redundant callbacks from accountbased currency engines. Five targeted fixes:

- **Stop calling `onBlockHeightChanged`**: EVM/accountbased engines no longer call `onBlockHeightChanged`, removing ~130 expensive core-js callbacks per 10s (polygon/fantom fire ~1/sec). Confirmations are now updated directly on transactions and emitted via `onTransactions`.
- **Gate `onNewTokens` via `reportDetectedTokens`**: Adds a `detectedTokenIds` cache (persisted to `walletLocalData`) in the base class. Engines called `onNewTokens` on every poll cycle even when the token list hadn't changed. Only fires when genuinely new tokens are discovered.
- **Gate `onStakingStatusChanged` via `reportStakingStatus`**: Deduplicates staking status callbacks using JSON.stringify comparison. Tron and FIO engines were firing on every poll cycle with identical data.
- **`SyncTracker` per-engine dedup**: Adds `sendSyncStatusIfChanged` to suppress `onSyncStatusChanged` when the `totalRatio` hasn't changed. Solana alone produced 129 redundant calls per 10s at steady state.
- **Global 500ms throttle on `sendSyncStatus`**: Limits aggregate sync status volume to 2/sec across all 30+ accountbased engines during the post-login burst.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared engine plumbing and callback emission semantics across many chains, so regressions could affect token discovery, staking UI updates, or confirmation/sync progress reporting despite being performance-focused.
> 
> **Overview**
> Reduces JS-thread/UI lag by **deduplicating high-volume callbacks** emitted by account-based currency engines.
> 
> Adds base `CurrencyEngine` helpers `reportDetectedTokens` (with persisted `walletLocalData.detectedTokenIds`) and `reportStakingStatus` (JSON-based dedupe), and migrates multiple engines (Algorand, Cosmos, Ripple, Solana, Sui, Tron, Zano, and `EthereumNetwork`) to use them instead of firing `onNewTokens`/`onStakingStatusChanged` repeatedly.
> 
> Stops emitting the deprecated `onBlockHeightChanged` callback; `updateBlockHeight` now updates in-memory tx confirmations and emits changes via `onTransactions`. `SyncTracker` now suppresses unchanged `onSyncStatusChanged` updates and applies a global 500ms throttle for non-`totalRatio=1` statuses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93692e0e676a502839c4973c5e915da2e0952358. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->