### PR TITLE
feat: add change-server support for ripple, tezos, and tron

### DIFF
--- a/src/ethereum/info/fantomInfo.ts
+++ b/src/ethereum/info/fantomInfo.ts
@@ -282,7 +282,7 @@ const networkFees: EthereumFees = {
 }
 
 // Exported for fee provider test
-const networkInfo: EthereumNetworkInfo = {
+export const networkInfo: EthereumNetworkInfo = {
   addressQueryLookbackBlocks: 60, // 2 minutes
   networkAdapterConfigs: [
     {
@@ -322,7 +322,7 @@ const networkInfo: EthereumNetworkInfo = {
   }
 }
 
-const currencyInfo: EdgeCurrencyInfo = {
+export const currencyInfo: EdgeCurrencyInfo = {
   canReplaceByFee: true,
   currencyCode: 'FTM',
   evmChainId: 250,

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -23,6 +23,7 @@ import {
   EdgeCurrencyEngineOptions,
   EdgeEngineActivationOptions,
   EdgeEngineGetActivationAssetsOptions,
+  EdgeEngineSyncNetworkOptions,
   EdgeGetActivationAssetsResults,
   EdgeMemo,
   EdgeSpendInfo,
@@ -88,6 +89,7 @@ type AccountTransaction = AccountTxResponse['result']['transactions'][number]
 const ADDRESS_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const BLOCKHEIGHT_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const TRANSACTION_POLL_MILLISECONDS = getRandomDelayMs(20000)
+const SYNC_NETWORK_INTERVAL = 10000
 const ADDRESS_QUERY_LOOKBACK_BLOCKS = 30 * 60 // ~ one minute
 
 // How long to wait before a transaction is accepted into a ledge close (block)
@@ -784,7 +786,39 @@ export class XrpEngine extends CurrencyEngine<
     this.addToLoop('checkServerInfoInnerLoop', BLOCKHEIGHT_POLL_MILLISECONDS)
     this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
     this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
+
+    if (this.subscribedAddresses.length === 0) {
+      this.subscribedAddresses.push({
+        address: this.walletLocalData.publicKey,
+        checkpoint: this.walletLocalData.highestTxBlockHeight.toString()
+      })
+    }
+    this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
+
     await super.startEngine()
+  }
+
+  async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {
+    const { subscribeParam } = opts
+
+    if (subscribeParam == null) {
+      await this.checkAccountInnerLoop()
+      await this.checkTransactionsInnerLoop()
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    const { needsSync = true } = subscribeParam
+
+    if (!needsSync) {
+      if (!this.syncComplete) {
+        this.setOneHundoSyncRatio()
+      }
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    await this.checkAccountInnerLoop()
+    await this.checkTransactionsInnerLoop()
+    return SYNC_NETWORK_INTERVAL
   }
 
   async killEngine(): Promise<void> {

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -783,9 +783,19 @@ export class XrpEngine extends CurrencyEngine<
       }, 10000)
       return
     }
-    this.addToLoop('checkServerInfoInnerLoop', BLOCKHEIGHT_POLL_MILLISECONDS)
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
-    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
+    // When change-server is active, syncNetwork drives all sync work.
+    // Polling loops are only needed as fallback when change-server is off.
+    // Block height is not polled separately because:
+    // - requiredConfirmations defaults to 1, so txs confirm immediately
+    // - block height is updated as a side effect of account/transaction queries
+    if (!this.currencyInfo.usesChangeServer) {
+      this.addToLoop('checkServerInfoInnerLoop', BLOCKHEIGHT_POLL_MILLISECONDS)
+      this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+      this.addToLoop(
+        'checkTransactionsInnerLoop',
+        TRANSACTION_POLL_MILLISECONDS
+      )
+    }
 
     if (this.subscribedAddresses.length === 0) {
       this.subscribedAddresses.push({
@@ -802,6 +812,7 @@ export class XrpEngine extends CurrencyEngine<
     const { subscribeParam } = opts
 
     if (subscribeParam == null) {
+      await this.checkServerInfoInnerLoop()
       await this.checkAccountInnerLoop()
       await this.checkTransactionsInnerLoop()
       return SYNC_NETWORK_INTERVAL
@@ -816,6 +827,7 @@ export class XrpEngine extends CurrencyEngine<
       return SYNC_NETWORK_INTERVAL
     }
 
+    await this.checkServerInfoInnerLoop()
     await this.checkAccountInnerLoop()
     await this.checkTransactionsInnerLoop()
     return SYNC_NETWORK_INTERVAL

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -788,7 +788,7 @@ export class XrpEngine extends CurrencyEngine<
     // Block height is not polled separately because:
     // - requiredConfirmations defaults to 1, so txs confirm immediately
     // - block height is updated as a side effect of account/transaction queries
-    if (!this.currencyInfo.usesChangeServer) {
+    if (this.currencyInfo.usesChangeServer !== true) {
       this.addToLoop('checkServerInfoInnerLoop', BLOCKHEIGHT_POLL_MILLISECONDS)
       this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
       this.addToLoop(

--- a/src/ripple/RippleEngine.ts
+++ b/src/ripple/RippleEngine.ts
@@ -806,6 +806,15 @@ export class XrpEngine extends CurrencyEngine<
     this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
 
     await super.startEngine()
+
+    // Legacy engine startup implicitly performed an immediate first block
+    // height check because polling tasks start running right away. Preserve
+    // that startup signal in change-server mode without re-enabling polling.
+    if (this.currencyInfo.usesChangeServer === true) {
+      this.checkServerInfoInnerLoop().catch(error => {
+        this.error('Initial block height check failed:', error)
+      })
+    }
   }
 
   async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {

--- a/src/ripple/rippleInfo.ts
+++ b/src/ripple/rippleInfo.ts
@@ -41,6 +41,8 @@ const currencyInfo: EdgeCurrencyInfo = {
   ],
   multipleMemos: true,
 
+  usesChangeServer: true,
+
   // Deprecated:
   displayName: 'XRPL' // Matches chainDisplayName
 }

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -269,7 +269,7 @@ export class TezosEngine extends CurrencyEngine<
     // Block height is not polled separately because:
     // - requiredConfirmations defaults to 1, so txs confirm immediately
     // - block height is updated as a side effect of account/transaction queries
-    if (!this.currencyInfo.usesChangeServer) {
+    if (this.currencyInfo.usesChangeServer !== true) {
       this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
       this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
       this.addToLoop(

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -287,6 +287,15 @@ export class TezosEngine extends CurrencyEngine<
     this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
 
     await super.startEngine()
+
+    // Legacy engine startup implicitly performed an immediate first block
+    // height check because polling tasks start running right away. Preserve
+    // that startup signal in change-server mode without re-enabling polling.
+    if (this.currencyInfo.usesChangeServer === true) {
+      this.checkBlockchainInnerLoop().catch(error => {
+        this.error('Initial block height check failed:', error)
+      })
+    }
   }
 
   async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -264,9 +264,19 @@ export class TezosEngine extends CurrencyEngine<
   // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
-    this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
-    this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
+    // When change-server is active, syncNetwork drives all sync work.
+    // Polling loops are only needed as fallback when change-server is off.
+    // Block height is not polled separately because:
+    // - requiredConfirmations defaults to 1, so txs confirm immediately
+    // - block height is updated as a side effect of account/transaction queries
+    if (!this.currencyInfo.usesChangeServer) {
+      this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+      this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
+      this.addToLoop(
+        'checkTransactionsInnerLoop',
+        TRANSACTION_POLL_MILLISECONDS
+      )
+    }
 
     if (this.subscribedAddresses.length === 0) {
       this.subscribedAddresses.push({
@@ -283,6 +293,7 @@ export class TezosEngine extends CurrencyEngine<
     const { subscribeParam } = opts
 
     if (subscribeParam == null) {
+      await this.checkBlockchainInnerLoop()
       await this.checkAccountInnerLoop()
       await this.checkTransactionsInnerLoop()
       return SYNC_NETWORK_INTERVAL
@@ -297,6 +308,7 @@ export class TezosEngine extends CurrencyEngine<
       return SYNC_NETWORK_INTERVAL
     }
 
+    await this.checkBlockchainInnerLoop()
     await this.checkAccountInnerLoop()
     await this.checkTransactionsInnerLoop()
     return SYNC_NETWORK_INTERVAL

--- a/src/tezos/TezosEngine.ts
+++ b/src/tezos/TezosEngine.ts
@@ -6,6 +6,7 @@ import { add, eq, gt } from 'biggystring'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
+  EdgeEngineSyncNetworkOptions,
   EdgeFetchFunction,
   EdgeSpendInfo,
   EdgeTransaction,
@@ -48,6 +49,7 @@ import {
 const ADDRESS_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const BLOCKCHAIN_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const TRANSACTION_POLL_MILLISECONDS = getRandomDelayMs(20000)
+const SYNC_NETWORK_INTERVAL = 10000
 
 const makeSpendMutex = makeMutex()
 
@@ -265,7 +267,39 @@ export class TezosEngine extends CurrencyEngine<
     this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
     this.addToLoop('checkAccountInnerLoop', ADDRESS_POLL_MILLISECONDS)
     this.addToLoop('checkTransactionsInnerLoop', TRANSACTION_POLL_MILLISECONDS)
+
+    if (this.subscribedAddresses.length === 0) {
+      this.subscribedAddresses.push({
+        address: this.walletLocalData.publicKey,
+        checkpoint: this.walletLocalData.highestTxBlockHeight.toString()
+      })
+    }
+    this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
+
     await super.startEngine()
+  }
+
+  async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {
+    const { subscribeParam } = opts
+
+    if (subscribeParam == null) {
+      await this.checkAccountInnerLoop()
+      await this.checkTransactionsInnerLoop()
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    const { needsSync = true } = subscribeParam
+
+    if (!needsSync) {
+      if (!this.syncComplete) {
+        this.setOneHundoSyncRatio()
+      }
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    await this.checkAccountInnerLoop()
+    await this.checkTransactionsInnerLoop()
+    return SYNC_NETWORK_INTERVAL
   }
 
   async resyncBlockchain(): Promise<void> {

--- a/src/tezos/tezosInfo.ts
+++ b/src/tezos/tezosInfo.ts
@@ -67,6 +67,8 @@ const currencyInfo: EdgeCurrencyInfo = {
   // No memo support:
   memoOptions: [],
 
+  usesChangeServer: true,
+
   // Deprecated:
   displayName: 'Tezos'
 }

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -3,6 +3,7 @@ import { asMaybe, Cleaner } from 'cleaners'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
+  EdgeEngineSyncNetworkOptions,
   EdgeFetchFunction,
   EdgeMemo,
   EdgeSpendInfo,
@@ -91,6 +92,7 @@ const ACCOUNT_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const BLOCKCHAIN_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const TRANSACTION_POLL_MILLISECONDS = getRandomDelayMs(20000)
 const NETWORKFEES_POLL_MILLISECONDS = getRandomDelayMs(60 * 60 * 1000) // 1 hour
+const SYNC_NETWORK_INTERVAL = 10000
 const DEFAULT_ENERGY_NO_BALANCE = 130000
 
 type TronFunction =
@@ -1418,7 +1420,39 @@ export class TronEngine extends CurrencyEngine<
     this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS)
     this.addToLoop('checkUpdateNetworkFees', NETWORKFEES_POLL_MILLISECONDS)
     this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
+
+    if (this.subscribedAddresses.length === 0) {
+      this.subscribedAddresses.push({
+        address: this.walletLocalData.publicKey,
+        checkpoint: this.walletLocalData.highestTxBlockHeight.toString()
+      })
+    }
+    this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
+
     await super.startEngine()
+  }
+
+  async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {
+    const { subscribeParam } = opts
+
+    if (subscribeParam == null) {
+      await this.checkAccountInnerLoop()
+      await this.queryTransactions()
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    const { needsSync = true } = subscribeParam
+
+    if (!needsSync) {
+      if (!this.syncComplete) {
+        this.setOneHundoSyncRatio()
+      }
+      return SYNC_NETWORK_INTERVAL
+    }
+
+    await this.checkAccountInnerLoop()
+    await this.queryTransactions()
+    return SYNC_NETWORK_INTERVAL
   }
 
   async getStakingStatus(): Promise<EdgeStakingStatus> {

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -1438,6 +1438,15 @@ export class TronEngine extends CurrencyEngine<
     this.currencyEngineCallbacks.onSubscribeAddresses(this.subscribedAddresses)
 
     await super.startEngine()
+
+    // Legacy engine startup implicitly performed an immediate first block
+    // height check because polling tasks start running right away. Preserve
+    // that startup signal in change-server mode without re-enabling polling.
+    if (this.currencyInfo.usesChangeServer === true) {
+      this.checkBlockchainInnerLoop().catch(error => {
+        this.error('Initial block height check failed:', error)
+      })
+    }
   }
 
   async syncNetwork(opts: EdgeEngineSyncNetworkOptions): Promise<number> {

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -1415,11 +1415,19 @@ export class TronEngine extends CurrencyEngine<
   // // ****************************************************************************
 
   async startEngine(): Promise<void> {
-    this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
-    this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS)
-    this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS)
+    // When change-server is active, syncNetwork drives all sync work.
+    // Polling loops are only needed as fallback when change-server is off.
+    // Block height is not polled separately because:
+    // - requiredConfirmations defaults to 1, so txs confirm immediately
+    // - block height is updated as a side effect of account/transaction queries
+    if (!this.currencyInfo.usesChangeServer) {
+      this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
+      this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS)
+      this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS)
+      this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
+    }
+    // Fee updates always run regardless of change-server (matches Ethereum pattern)
     this.addToLoop('checkUpdateNetworkFees', NETWORKFEES_POLL_MILLISECONDS)
-    this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
 
     if (this.subscribedAddresses.length === 0) {
       this.subscribedAddresses.push({
@@ -1436,7 +1444,9 @@ export class TronEngine extends CurrencyEngine<
     const { subscribeParam } = opts
 
     if (subscribeParam == null) {
+      await this.checkBlockchainInnerLoop()
       await this.checkAccountInnerLoop()
+      await this.checkTokenBalances()
       await this.queryTransactions()
       return SYNC_NETWORK_INTERVAL
     }
@@ -1450,7 +1460,9 @@ export class TronEngine extends CurrencyEngine<
       return SYNC_NETWORK_INTERVAL
     }
 
+    await this.checkBlockchainInnerLoop()
     await this.checkAccountInnerLoop()
+    await this.checkTokenBalances()
     await this.queryTransactions()
     return SYNC_NETWORK_INTERVAL
   }

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -1420,7 +1420,7 @@ export class TronEngine extends CurrencyEngine<
     // Block height is not polled separately because:
     // - requiredConfirmations defaults to 1, so txs confirm immediately
     // - block height is updated as a side effect of account/transaction queries
-    if (!this.currencyInfo.usesChangeServer) {
+    if (this.currencyInfo.usesChangeServer !== true) {
       this.addToLoop('checkBlockchainInnerLoop', BLOCKCHAIN_POLL_MILLISECONDS)
       this.addToLoop('checkAccountInnerLoop', ACCOUNT_POLL_MILLISECONDS)
       this.addToLoop('checkTokenBalances', ACCOUNT_POLL_MILLISECONDS)

--- a/src/tron/tronInfo.ts
+++ b/src/tron/tronInfo.ts
@@ -145,6 +145,8 @@ const currencyInfo: EdgeCurrencyInfo = {
   // https://developers.tron.network/v3.7/docs/how-to-build-a-transaction-locally
   memoOptions: [{ type: 'text', memoName: 'note' }],
 
+  usesChangeServer: true,
+
   // Deprecated:
   displayName: 'Tron',
   metaTokens: makeMetaTokens(builtinTokens)

--- a/test/changeServer/changeServer.test.ts
+++ b/test/changeServer/changeServer.test.ts
@@ -1,0 +1,410 @@
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyEngineCallbacks,
+  EdgeCurrencyEngineOptions,
+  EdgeCurrencyPlugin,
+  EdgeSubscribedAddress,
+  EdgeWalletInfo,
+  makeFakeIo
+} from 'edge-core-js'
+import EventEmitter from 'events'
+import { after, before, describe, it } from 'mocha'
+import fetch from 'node-fetch'
+
+import edgeCorePlugins from '../../src/index'
+import { fakeLog } from '../fake/fakeLog'
+
+/**
+ * Change-server integration tests for Ripple, Tezos, and Tron.
+ *
+ * These tests verify contract conformance with the change-server engine
+ * protocol defined in edge-core-js PR #718:
+ * - currencyInfo.usesChangeServer === true
+ * - onSubscribeAddresses called on startEngine
+ * - syncNetwork handles all sync paths
+ * - Polling loops disabled when change-server is active
+ */
+
+interface ChangeServerFixture {
+  pluginId: string
+  walletType: string
+  currencyCode: string
+  walletInfo: EdgeWalletInfo
+  /** Method names that should NOT be in addToLoop when change-server is on */
+  disabledLoops: string[]
+  /** Method names that SHOULD still be in addToLoop */
+  activeLoops: string[]
+}
+
+const fixtures: ChangeServerFixture[] = [
+  {
+    pluginId: 'ripple',
+    walletType: 'wallet:ripple',
+    currencyCode: 'XRP',
+    walletInfo: {
+      id: '1',
+      type: 'wallet:ripple',
+      keys: {}
+    },
+    disabledLoops: [
+      'checkServerInfoInnerLoop',
+      'checkAccountInnerLoop',
+      'checkTransactionsInnerLoop'
+    ],
+    activeLoops: []
+  },
+  {
+    pluginId: 'tezos',
+    walletType: 'wallet:xtz',
+    currencyCode: 'XTZ',
+    walletInfo: {
+      id: '1',
+      type: 'wallet:xtz',
+      keys: {
+        mnemonic:
+          'canal head puzzle gravity keep response bulb diagram time oak mesh faith match quit hole sand laptop cycle group crunch say nose border later',
+        publicKey: 'tz1TC6ETpRC1awG3Sq226TgMx4wHbJRTzod6',
+        publicKeyEd: 'edpku2JAJHC6k68KpUjzL6FsekWczHKDopgCBgxtkViof3iFYiFJN1',
+        privateKey:
+          'edskSAdy4abu2a7rzfnhmpWxU3oXDT6bP4J1yXywd5NHNSsgBrnhuWjsFpVuqQP8Ce4Je3f5kcVjUuQVN69PWH5fYztc7xcYjJ'
+      }
+    },
+    disabledLoops: [
+      'checkBlockchainInnerLoop',
+      'checkAccountInnerLoop',
+      'checkTransactionsInnerLoop'
+    ],
+    activeLoops: []
+  },
+  {
+    pluginId: 'tron',
+    walletType: 'wallet:tron',
+    currencyCode: 'TRX',
+    walletInfo: {
+      id: '1',
+      type: 'wallet:tron',
+      keys: {}
+    },
+    disabledLoops: [
+      'checkBlockchainInnerLoop',
+      'checkAccountInnerLoop',
+      'checkTokenBalances',
+      'queryTransactions'
+    ],
+    // Fee updates always run (matches Ethereum pattern)
+    activeLoops: ['checkUpdateNetworkFees']
+  }
+]
+
+for (const fixture of fixtures) {
+  describe(`Change-server: ${fixture.pluginId}`, function () {
+    const fakeIo = makeFakeIo()
+    const opts: EdgeCorePluginOptions = {
+      infoPayload: {},
+      initOptions: {},
+      io: {
+        ...fakeIo,
+        fetch,
+        fetchCors: fetch,
+        random: size => new Uint8Array(size)
+      },
+      log: fakeLog,
+      nativeIo: {},
+      pluginDisklet: fakeIo.disklet
+    }
+    // @ts-expect-error - indexing by dynamic pluginId
+    const factory = edgeCorePlugins[fixture.pluginId]
+    const plugin: EdgeCurrencyPlugin = factory(opts)
+
+    const emitter = new EventEmitter()
+    let subscribedAddressesCalls: EdgeSubscribedAddress[][] = []
+    let syncStatusChanges: Array<{ totalRatio: number }> = []
+
+    const callbacks: EdgeCurrencyEngineCallbacks = {
+      onAddressesChecked(totalRatio) {
+        emitter.emit('onSyncStatusChanged', { totalRatio })
+      },
+      onTxidsChanged() {},
+      onBalanceChanged() {},
+      onBlockHeightChanged(height) {
+        emitter.emit('onBlockHeightChange', height)
+      },
+      onSeenTxCheckpoint() {},
+      onStakingStatusChanged() {},
+      onSubscribeAddresses(addresses: EdgeSubscribedAddress[] | string[]) {
+        // Normalize to EdgeSubscribedAddress[]
+        const normalized = addresses.map(a =>
+          typeof a === 'string' ? { address: a } : a
+        )
+        subscribedAddressesCalls.push(normalized)
+      },
+      onSyncStatusChanged(status) {
+        syncStatusChanges.push(status)
+        emitter.emit('onSyncStatusChanged', status)
+      },
+      onNewTokens() {},
+      onTokenBalanceChanged() {},
+      onTransactions() {},
+      onTransactionsChanged() {},
+      onAddressChanged() {},
+      onUnactivatedTokenIdsChanged() {},
+      onWcNewContractCall() {}
+    }
+
+    const walletLocalDisklet = fakeIo.disklet
+    const currencyEngineOptions: EdgeCurrencyEngineOptions = {
+      callbacks,
+      log: fakeLog,
+      userSettings: undefined,
+      walletLocalDisklet,
+      walletLocalEncryptedDisklet: walletLocalDisklet,
+      customTokens: {},
+      enabledTokenIds: []
+    }
+
+    let engine: any
+
+    before('Create engine', async function () {
+      this.timeout(30000)
+      const tools = await plugin.makeCurrencyTools()
+
+      let walletInfo = fixture.walletInfo
+      // Generate real keys for plugins that need them
+      if (fixture.pluginId !== 'tezos') {
+        const privateKeys = await tools.createPrivateKey(fixture.walletType)
+        walletInfo = {
+          ...fixture.walletInfo,
+          keys: privateKeys
+        }
+        const publicKey = await tools.derivePublicKey(walletInfo)
+        Object.assign(walletInfo.keys, publicKey)
+      }
+
+      engine = await plugin.makeCurrencyEngine(
+        walletInfo,
+        currencyEngineOptions
+      )
+    })
+
+    // Reset tracking state before each test
+    beforeEach(function () {
+      subscribedAddressesCalls = []
+      syncStatusChanges = []
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 1: usesChangeServer flag
+    // ---------------------------------------------------------------
+    describe('currencyInfo.usesChangeServer', function () {
+      it('should be true', function () {
+        assert.strictEqual(
+          plugin.currencyInfo.usesChangeServer,
+          true,
+          `${fixture.pluginId} currencyInfo.usesChangeServer should be true`
+        )
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 2: onSubscribeAddresses called on startEngine
+    // ---------------------------------------------------------------
+    describe('startEngine', function () {
+      it('should call onSubscribeAddresses with wallet address', async function () {
+        this.timeout(30000)
+        subscribedAddressesCalls = []
+
+        await engine.startEngine()
+
+        assert(
+          subscribedAddressesCalls.length >= 1,
+          'onSubscribeAddresses should be called at least once'
+        )
+        const addresses: EdgeSubscribedAddress[] = subscribedAddressesCalls[0]
+        assert(addresses.length >= 1, 'Should subscribe at least one address')
+        assert(
+          typeof addresses[0].address === 'string' &&
+            addresses[0].address.length > 0,
+          'Subscribed address should be a non-empty string'
+        )
+      })
+
+      // ---------------------------------------------------------------
+      // Vector 7: Polling loops disabled when usesChangeServer is true
+      // ---------------------------------------------------------------
+      for (const loopName of fixture.disabledLoops) {
+        it(`should NOT have '${loopName}' in polling loops`, function () {
+          // Access private tasks map via type assertion
+          const tasks: Map<string, unknown> = engine.tasks
+          assert(
+            !tasks.has(loopName),
+            `'${loopName}' should not be in tasks when usesChangeServer is true`
+          )
+        })
+      }
+
+      // ---------------------------------------------------------------
+      // Vector 10: Tron fee loop always active
+      // ---------------------------------------------------------------
+      for (const loopName of fixture.activeLoops) {
+        it(`should HAVE '${loopName}' in polling loops`, function () {
+          const tasks: Map<string, unknown> = engine.tasks
+          assert(
+            tasks.has(loopName),
+            `'${loopName}' should still be in tasks (auxiliary loop)`
+          )
+        })
+      }
+
+      after('Kill engine after startEngine tests', async function () {
+        this.timeout(10000)
+        await engine.killEngine()
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 3: syncNetwork exists and returns a number
+    // ---------------------------------------------------------------
+    describe('syncNetwork contract', function () {
+      it('should exist as a function', function () {
+        assert.strictEqual(
+          typeof engine.syncNetwork,
+          'function',
+          'syncNetwork should be a function on the engine'
+        )
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 4: syncNetwork — initial sync (subscribeParam == null)
+    // ---------------------------------------------------------------
+    describe('syncNetwork: initial sync', function () {
+      it('should return a positive interval when subscribeParam is undefined', async function () {
+        this.timeout(30000)
+        const interval = await engine.syncNetwork({})
+        assert(
+          typeof interval === 'number' && interval > 0,
+          `syncNetwork should return a positive interval, got ${interval}`
+        )
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 5: syncNetwork — address wakeup (needsSync = true)
+    // ---------------------------------------------------------------
+    describe('syncNetwork: address wakeup', function () {
+      it('should return a positive interval when subscribeParam has needsSync=true', async function () {
+        this.timeout(30000)
+        const address = engine.walletLocalData?.publicKey ?? 'test-address'
+        const interval = await engine.syncNetwork({
+          subscribeParam: {
+            address,
+            needsSync: true
+          }
+        })
+        assert(
+          typeof interval === 'number' && interval > 0,
+          `syncNetwork should return a positive interval, got ${interval}`
+        )
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 6: syncNetwork — needsSync = false (caught up)
+    // ---------------------------------------------------------------
+    describe('syncNetwork: needsSync=false', function () {
+      it('should return a positive interval and not trigger sync work', async function () {
+        this.timeout(10000)
+        const address = engine.walletLocalData?.publicKey ?? 'test-address'
+
+        const interval = await engine.syncNetwork({
+          subscribeParam: {
+            address,
+            needsSync: false
+          }
+        })
+
+        assert(
+          typeof interval === 'number' && interval > 0,
+          `syncNetwork should return a positive interval, got ${interval}`
+        )
+      })
+
+      it('should set sync ratio to 100% if not already synced', async function () {
+        this.timeout(10000)
+        // Force incomplete sync state
+        engine.syncComplete = false
+
+        const address = engine.walletLocalData?.publicKey ?? 'test-address'
+        await engine.syncNetwork({
+          subscribeParam: {
+            address,
+            needsSync: false
+          }
+        })
+
+        // After needsSync=false with incomplete sync, should mark complete
+        assert.strictEqual(
+          engine.syncComplete,
+          true,
+          'syncComplete should be true after needsSync=false'
+        )
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 8: subscribedAddresses restoration from core
+    // ---------------------------------------------------------------
+    describe('subscribedAddresses restoration', function () {
+      it('should call onSubscribeAddresses with restored checkpoint', async function () {
+        this.timeout(30000)
+        subscribedAddressesCalls = []
+
+        // Set up pre-existing subscribed addresses on the engine
+        // to simulate core restoring them from disk
+        const testCheckpoint = '12345'
+        const address = engine.walletLocalData?.publicKey ?? 'test-address'
+        engine.subscribedAddresses = [{ address, checkpoint: testCheckpoint }]
+
+        await engine.startEngine()
+
+        assert(
+          subscribedAddressesCalls.length >= 1,
+          'onSubscribeAddresses should be called'
+        )
+
+        const subscribedAddresses: EdgeSubscribedAddress[] =
+          subscribedAddressesCalls[0]
+        const restoredAddr = subscribedAddresses.find(
+          (a: EdgeSubscribedAddress) => a.checkpoint === testCheckpoint
+        )
+        assert(
+          restoredAddr != null,
+          `Should find address with restored checkpoint '${testCheckpoint}'`
+        )
+      })
+
+      after('Kill engine after restoration tests', async function () {
+        this.timeout(10000)
+        await engine.killEngine()
+        // Reset subscribed addresses for clean state
+        engine.subscribedAddresses = []
+      })
+    })
+
+    // ---------------------------------------------------------------
+    // Vector 9: Tron-specific — token balances in syncNetwork
+    // ---------------------------------------------------------------
+    if (fixture.pluginId === 'tron') {
+      describe('tron: checkTokenBalances available for syncNetwork', function () {
+        it('should have checkTokenBalances as a method', function () {
+          assert.strictEqual(
+            typeof engine.checkTokenBalances,
+            'function',
+            'checkTokenBalances should exist on TronEngine'
+          )
+        })
+      })
+    }
+  })
+}

--- a/test/engine/feeProvider.test.ts
+++ b/test/engine/feeProvider.test.ts
@@ -7,9 +7,7 @@ import {
   fetchFeesFromInfoServer
 } from '../../src/ethereum/fees/feeProviders'
 import {
-  // @ts-expect-error
   currencyInfo as ftmCurrencyInfo,
-  // @ts-expect-error
   networkInfo as ftmNetworkInfo
 } from '../../src/ethereum/info/fantomInfo'
 import { fakeLog } from '../fake/fakeLog'


### PR DESCRIPTION
Enable change-server protocol integration for XRP, Tezos, and Tron engines following the contract defined in edge-core-js PR #718.

## Changes
- **Ripple (XRP)**: syncNetwork + onSubscribeAddresses + usesChangeServer
- **Tezos**: syncNetwork + onSubscribeAddresses + usesChangeServer  
- **Tron**: syncNetwork + onSubscribeAddresses + usesChangeServer

## Contract compliance (per edge-core-js PR #718)
- [x] Set currencyInfo.usesChangeServer = true
- [x] Accept seenTxCheckpoint and subscribedAddresses (via base class)
- [x] Call onSubscribeAddresses() with wallet address on startup
- [x] Implement syncNetwork({ subscribeParam }) for change-server wakeups
- [x] Keep ordinary polling as fallback
- [x] Handle needsSync === false gracefully
- [x] Handle missing checkpoints gracefully

Relates to Asana task 1213394471711297