### PR TITLE
TON - Add Jetton support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (TON) Replace Orbs servers with dRPC
+
 ## 4.77.2 (2026-03-24)
 
 - changed: Update chain-registry package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (TON) Add Jetton support
 - changed: (TON) Replace Orbs servers with dRPC
 
 ## 4.77.2 (2026-03-24)

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -34,14 +34,18 @@ import { parse_tx } from 'ton-watcher/build/modules/txs/Transaction'
 import { CurrencyEngine } from '../common/CurrencyEngine'
 import { PluginEnvironment } from '../common/innerPlugin'
 import { getRandomDelayMs } from '../common/network'
-import {
-  asyncWaterfall,
-  formatAggregateError,
-  promiseAny
-} from '../common/promiseUtils'
+import { asyncWaterfall } from '../common/promiseUtils'
 import { makeTokenSyncTracker, TokenSyncTracker } from '../common/SyncTracker'
 import { asSafeCommonWalletInfo, SafeCommonWalletInfo } from '../common/types'
 import { snooze } from '../common/utils'
+import {
+  asDrpcAddressInfo,
+  asDrpcEstimateFee,
+  asDrpcGetTransactions,
+  asDrpcRunGetMethod,
+  asDrpcSendBoc,
+  parseSeqnoFromStack
+} from './tonDrpc'
 import { TonTools } from './TonTools'
 import {
   asParsedTx,
@@ -91,17 +95,16 @@ export class TonEngine extends CurrencyEngine<
 
   async queryBalance(): Promise<void> {
     try {
-      const clients = this.tools.getOrbsClients()
-      const funcs = clients.map(async client => {
-        return await client.getContractState(this.wallet.address)
-      })
-      const contractState: Awaited<ReturnType<TonClient['getContractState']>> =
-        await promiseAny(funcs)
+      const addr = encodeURIComponent(this.wallet.address.toRawString())
+      const raw = await this.tools.fetchDrpc(
+        `/getAddressInformation?address=${addr}`
+      )
+      const { result } = asDrpcAddressInfo(raw)
 
-      this.updateBalance(null, contractState.balance.toString())
+      this.updateBalance(null, result.balance)
 
-      if (contractState.state !== this.otherData.contractState) {
-        this.otherData.contractState = contractState.state
+      if (result.state !== this.otherData.contractState) {
+        this.otherData.contractState = result.state
         this.walletLocalDataDirty = true
       }
     } catch (e) {
@@ -304,24 +307,27 @@ export class TonEngine extends CurrencyEngine<
 
     let networkFee = '0'
     if (nativeAmount !== '0') {
-      // Only estimate fee if we're sending something
-      const clients = this.tools.getOrbsClients()
-      const feeFuncs = clients.map(async client => {
-        return await client.estimateExternalMessageFee(this.wallet.address, {
-          body: transfer,
-          initCode: needsInit ? this.wallet.init.code : null,
-          initData: needsInit ? this.wallet.init.data : null,
-          ignoreSignature: false
-        })
-      })
-      const fees: Awaited<ReturnType<TonClient['estimateExternalMessageFee']>> =
-        await promiseAny(feeFuncs)
+      const addr = this.wallet.address.toRawString()
+      const bodyBoc = base64.stringify(transfer.toBoc())
+      const initCodeBoc = needsInit
+        ? base64.stringify(this.wallet.init.code.toBoc())
+        : ''
+      const initDataBoc = needsInit
+        ? base64.stringify(this.wallet.init.data.toBoc())
+        : ''
 
+      const feeRaw = await this.tools.fetchDrpc('/estimateFee', {
+        address: addr,
+        body: bodyBoc,
+        init_code: initCodeBoc,
+        init_data: initDataBoc
+      })
+      const { result: feeResult } = asDrpcEstimateFee(feeRaw)
       const totalFee =
-        fees.source_fees.fwd_fee +
-        fees.source_fees.gas_fee +
-        fees.source_fees.in_fwd_fee +
-        fees.source_fees.storage_fee
+        feeResult.source_fees.fwd_fee +
+        feeResult.source_fees.gas_fee +
+        feeResult.source_fees.in_fwd_fee +
+        feeResult.source_fees.storage_fee
       networkFee = totalFee.toString()
     }
 
@@ -376,13 +382,19 @@ export class TonEngine extends CurrencyEngine<
     )[0].asSlice()
     const transferMessage = loadMessageRelaxed(messageSlice)
 
-    const clients = this.tools.getOrbsClients()
-    const seqnoFuncs = clients.map(async client => {
-      const contract = client.open(this.wallet)
-      return await contract.getSeqno()
+    const addr = this.wallet.address.toRawString()
+    const seqnoRaw = await this.tools.fetchDrpc('/runGetMethod', {
+      address: addr,
+      method: 'seqno',
+      stack: []
     })
-    const seqno: Awaited<ReturnType<typeof this.wallet['getSeqno']>> =
-      await promiseAny(seqnoFuncs)
+    const { result: seqnoResult } = asDrpcRunGetMethod(seqnoRaw)
+    if (seqnoResult.exit_code !== 0) {
+      throw new Error(
+        `seqno query failed with exit_code ${seqnoResult.exit_code}`
+      )
+    }
+    const seqno = parseSeqnoFromStack(seqnoResult.stack)
 
     const transferArgs: Parameters<WalletContractV5R1['createTransfer']>[0] = {
       sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
@@ -404,53 +416,46 @@ export class TonEngine extends CurrencyEngine<
       const txBoc = base64.parse(edgeTransaction.signedTx)
       const txCell = Cell.fromBoc(Buffer.from(txBoc))[0]
 
-      const clients = this.tools.getOrbsClients()
-      const broadcastFuncs = clients.map(async client => {
-        const contract = client.open(this.wallet)
-        return await contract.send(txCell)
+      const externalMessage = external({
+        to: this.wallet.address,
+        body: txCell
       })
-      await formatAggregateError(
-        promiseAny(broadcastFuncs),
-        'Broadcast failed:'
-      )
+      const externalBoc = beginCell()
+        .store(storeMessage(externalMessage))
+        .endCell()
+      const bocBase64 = base64.stringify(externalBoc.toBoc())
+
+      const sendRaw = await this.tools.fetchDrpc('/sendBoc', {
+        boc: bocBase64
+      })
+      asDrpcSendBoc(sendRaw)
 
       if (this.otherData.contractState === 'uninitialized') {
         // It's not possible to calculate the txid for a wallet's first send so we need to look for it once it's confirmed
+        const addr = encodeURIComponent(this.wallet.address.toRawString())
         let attempts = 0
         do {
           attempts++
           await snooze(1000)
-          const txidFuncs = clients.map(async client => {
-            return await client.getTransactions(this.wallet.address, {
-              limit: 50
-            })
-          })
-          const transactions: Awaited<
-            ReturnType<TonClient['getTransactions']>
-          > = await promiseAny(txidFuncs)
-
-          const tx = transactions.find(tx => {
-            return tx.oldStatus === 'uninitialized' && tx.endStatus === 'active'
-          })
-          if (tx != null) {
-            const txid = base16.stringify(tx.hash()).toLowerCase()
-            edgeTransaction.txid = txid
-            edgeTransaction.date = Date.now() / 1000
-            this.otherData.contractState = 'active'
-            this.walletLocalDataDirty = true
-            return edgeTransaction
+          try {
+            const raw = await this.tools.fetchDrpc(
+              `/getTransactions?address=${addr}&limit=1`
+            )
+            const { result: txs } = asDrpcGetTransactions(raw)
+            if (txs.length > 0) {
+              const hashBytes = base64.parse(txs[0].transaction_id.hash)
+              edgeTransaction.txid = base16.stringify(hashBytes).toLowerCase()
+              edgeTransaction.date = Date.now() / 1000
+              this.otherData.contractState = 'active'
+              this.walletLocalDataDirty = true
+              return edgeTransaction
+            }
+          } catch (e) {
+            // retry
           }
         } while (attempts <= 30) // In testing, the tx was found after ~10 seconds
         throw new Error('Transaction broadcast but unable to find txid')
       } else {
-        // We can calculate the txid from the signedTx
-        const externalMessage = external({
-          to: this.wallet.address,
-          body: txCell
-        })
-        const externalBoc = beginCell()
-          .store(storeMessage(externalMessage))
-          .endCell()
         const txid = base16.stringify(externalBoc.hash()).toLowerCase()
         edgeTransaction.txid = txid
         edgeTransaction.date = Date.now() / 1000

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -44,7 +44,9 @@ import {
   asDrpcGetTransactions,
   asDrpcRunGetMethod,
   asDrpcSendBoc,
-  parseSeqnoFromStack
+  parseSeqnoFromStack,
+  parseStackAddress,
+  parseStackNumber
 } from './tonDrpc'
 import { TonTools } from './TonTools'
 import {
@@ -52,6 +54,7 @@ import {
   asTonPrivateKeys,
   asTonTxOtherParams,
   asTonWalletOtherData,
+  JettonTransferInfo,
   ParsedTx,
   TonNetworkInfo,
   TonWalletOtherData
@@ -70,6 +73,7 @@ export class TonEngine extends CurrencyEngine<
 
   wallet: WalletContractV5R1
   archiveTransactions: boolean
+  jettonWalletToTokenId: Map<string, string> = new Map()
 
   constructor(
     env: PluginEnvironment<TonNetworkInfo>,
@@ -93,6 +97,45 @@ export class TonEngine extends CurrencyEngine<
     this.otherData = asTonWalletOtherData(raw)
   }
 
+  async changeEnabledTokenIds(tokenIds: string[]): Promise<void> {
+    await super.changeEnabledTokenIds(tokenIds)
+    await this.resolveJettonWalletAddresses()
+  }
+
+  async resolveJettonWalletAddresses(): Promise<void> {
+    for (const tokenId of this.enabledTokenIds) {
+      if (this.otherData.jettonWalletAddresses[tokenId] == null) {
+        try {
+          const addrCell = beginCell()
+            .storeAddress(this.wallet.address)
+            .endCell()
+          const addrBoc = base64.stringify(addrCell.toBoc())
+
+          const raw = await this.tools.fetchDrpc('/runGetMethod', {
+            address: tokenId,
+            method: 'get_wallet_address',
+            stack: [['tvm.Slice', addrBoc]]
+          })
+          const { result } = asDrpcRunGetMethod(raw)
+          if (result.exit_code !== 0) {
+            throw new Error(`get_wallet_address exit_code ${result.exit_code}`)
+          }
+          const jettonWalletAddr = parseStackAddress(result.stack, 0)
+          this.otherData.jettonWalletAddresses[tokenId] =
+            jettonWalletAddr.toRawString()
+          this.walletLocalDataDirty = true
+        } catch (e) {
+          this.log.warn(`resolveJettonWalletAddresses error for ${tokenId}:`, e)
+        }
+      }
+
+      const walletAddr = this.otherData.jettonWalletAddresses[tokenId]
+      if (walletAddr != null) {
+        this.jettonWalletToTokenId.set(walletAddr, tokenId)
+      }
+    }
+  }
+
   async queryBalance(): Promise<void> {
     try {
       const addr = encodeURIComponent(this.wallet.address.toRawString())
@@ -109,6 +152,30 @@ export class TonEngine extends CurrencyEngine<
       }
     } catch (e) {
       this.log.warn('queryBalance error:', e)
+    }
+  }
+
+  async queryJettonBalances(): Promise<void> {
+    for (const tokenId of this.enabledTokenIds) {
+      const walletAddr = this.otherData.jettonWalletAddresses[tokenId]
+      if (walletAddr == null) continue
+
+      try {
+        const raw = await this.tools.fetchDrpc('/runGetMethod', {
+          address: walletAddr,
+          method: 'get_wallet_data',
+          stack: []
+        })
+        const { result } = asDrpcRunGetMethod(raw)
+        if (result.exit_code !== 0) {
+          this.updateBalance(tokenId, '0')
+          continue
+        }
+        const balance = parseStackNumber(result.stack, 0)
+        this.updateBalance(tokenId, balance)
+      } catch (e) {
+        this.log.warn(`queryJettonBalances error for ${tokenId}:`, e)
+      }
     }
   }
 
@@ -173,6 +240,9 @@ export class TonEngine extends CurrencyEngine<
 
     this.sendTransactionEvents()
     this.syncTracker.updateHistoryRatio(null, 1)
+    for (const tokenId of this.enabledTokenIds) {
+      this.syncTracker.updateHistoryRatio(tokenId, 1)
+    }
   }
 
   processTonTransaction(tx: ParsedTx): void {
@@ -229,6 +299,74 @@ export class TonEngine extends CurrencyEngine<
       walletId: this.walletId
     }
     this.addTransaction(null, edgeTransaction)
+
+    this.processJettonTransaction(tx)
+  }
+
+  processJettonTransaction(tx: ParsedTx): void {
+    const { inMessage, outMessages } = tx
+
+    if (
+      inMessage.txType === 'jetton_notification' &&
+      inMessage.jetton_notify != null
+    ) {
+      const senderAddr = inMessage.sender
+      if (senderAddr != null) {
+        const senderRaw = Address.parse(senderAddr).toRawString()
+        const tokenId = this.jettonWalletToTokenId.get(senderRaw)
+        if (tokenId != null) {
+          this.addJettonTransaction(tx, tokenId, inMessage.jetton_notify, false)
+        }
+      }
+    }
+
+    for (const outMsg of outMessages) {
+      if (outMsg.txType === 'jetton_request' && outMsg.jetton_req != null) {
+        const recipientRaw = Address.parse(outMsg.recipient).toRawString()
+        const tokenId = this.jettonWalletToTokenId.get(recipientRaw)
+        if (tokenId != null) {
+          this.addJettonTransaction(tx, tokenId, outMsg.jetton_req, true)
+        }
+      }
+    }
+  }
+
+  addJettonTransaction(
+    tx: ParsedTx,
+    tokenId: string,
+    jettonInfo: JettonTransferInfo,
+    isSend: boolean
+  ): void {
+    const memos: EdgeMemo[] = []
+    if (jettonInfo.message != null && jettonInfo.message !== '') {
+      memos.push({ type: 'text', value: jettonInfo.message })
+    }
+
+    const jettonAmount = jettonInfo.jettonAmount.toString()
+    const nativeAmount = isSend ? `-${jettonAmount}` : jettonAmount
+    const currencyCode = this.allTokensMap[tokenId]?.currencyCode ?? 'UNKNOWN'
+    const networkFee = tx.originalTx.totalFees.coins.toString()
+
+    const edgeTransaction: EdgeTransaction = {
+      blockHeight: 1,
+      confirmations: 'confirmed',
+      currencyCode,
+      date: tx.now,
+      isSend,
+      nativeAmount,
+      networkFee: '0',
+      networkFees: [],
+      memos,
+      ourReceiveAddresses: isSend
+        ? []
+        : [this.wallet.address.toString({ bounceable: false })],
+      parentNetworkFee: isSend ? networkFee : undefined,
+      tokenId,
+      txid: tx.hash,
+      signedTx: '',
+      walletId: this.walletId
+    }
+    this.addTransaction(tokenId, edgeTransaction)
   }
 
   getTxCheckpoint(edgeTransaction: EdgeTransaction): string {
@@ -241,7 +379,9 @@ export class TonEngine extends CurrencyEngine<
 
   async startEngine(): Promise<void> {
     this.addToLoop('queryBalance', ADDRESS_POLL_MILLISECONDS)
+    this.addToLoop('queryJettonBalances', ADDRESS_POLL_MILLISECONDS)
     this.addToLoop('queryTransactions', ADDRESS_POLL_MILLISECONDS)
+    await this.resolveJettonWalletAddresses()
     await super.startEngine()
   }
 
@@ -252,10 +392,23 @@ export class TonEngine extends CurrencyEngine<
   }
 
   async getMaxSpendable(spendInfo: EdgeSpendInfo): Promise<string> {
-    // TON allows sending the entire balance but we need to be able to craft the entire transaction here instead of just an amount
-    const spendInfoCopy = { ...spendInfo }
+    const { tokenId } = spendInfo
 
-    const balance = this.getBalance({ tokenId: spendInfoCopy.tokenId })
+    if (tokenId != null) {
+      const tokenBalance = this.getBalance({ tokenId })
+      const nativeBalance = this.getBalance({ tokenId: null })
+      const requiredNative = add(
+        this.networkInfo.jettonTransferGas,
+        this.networkInfo.minimumAddressBalance
+      )
+      if (gt(requiredNative, nativeBalance)) {
+        throw new InsufficientFundsError({ tokenId: null })
+      }
+      return tokenBalance
+    }
+
+    const spendInfoCopy = { ...spendInfo }
+    const balance = this.getBalance({ tokenId: null })
     spendInfoCopy.spendTargets[0].nativeAmount = balance
     spendInfoCopy.skipChecks = true
 
@@ -280,33 +433,65 @@ export class TonEngine extends CurrencyEngine<
       throw new Error('makeSpend Missing publicAddress')
     }
 
-    let memoCell: Cell | undefined
-    if (memo != null) {
-      memoCell = beginCell().storeUint(0, 32).storeStringTail(memo).endCell()
-    }
-
     const needsInit = this.otherData.contractState === 'uninitialized'
+    let transferMessage: MessageRelaxed
 
-    const transferMessage: MessageRelaxed = internal({
-      value: fromNano(nativeAmount),
-      to: Address.parse(publicAddress),
-      body: memoCell,
-      init: needsInit ? this.wallet.init : null,
-      bounce: false
-    })
+    if (tokenId != null) {
+      // Jetton transfer (TEP-74)
+      const jettonWalletAddr = this.otherData.jettonWalletAddresses[tokenId]
+      if (jettonWalletAddr == null) {
+        throw new Error('Jetton wallet address not resolved')
+      }
+
+      const forwardPayload =
+        memo != null
+          ? beginCell().storeUint(0, 32).storeStringTail(memo).endCell()
+          : null
+
+      const jettonBody = beginCell()
+        .storeUint(0x0f8a7ea5, 32)
+        .storeUint(0, 64)
+        .storeCoins(BigInt(nativeAmount))
+        .storeAddress(Address.parse(publicAddress))
+        .storeAddress(this.wallet.address)
+        .storeMaybeRef(null)
+        .storeCoins(BigInt(1))
+        .storeMaybeRef(forwardPayload)
+        .endCell()
+
+      transferMessage = internal({
+        value: fromNano(this.networkInfo.jettonTransferGas),
+        to: Address.parse(jettonWalletAddr),
+        body: jettonBody,
+        init: needsInit ? this.wallet.init : null,
+        bounce: true
+      })
+    } else {
+      // Native TON transfer
+      let memoCell: Cell | undefined
+      if (memo != null) {
+        memoCell = beginCell().storeUint(0, 32).storeStringTail(memo).endCell()
+      }
+
+      transferMessage = internal({
+        value: fromNano(nativeAmount),
+        to: Address.parse(publicAddress),
+        body: memoCell,
+        init: needsInit ? this.wallet.init : null,
+        bounce: false
+      })
+    }
 
     const transferArgs: Parameters<WalletContractV5R1['createTransfer']>[0] = {
       sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
       messages: [transferMessage],
-
-      // Fake data that doesn't impact fee calc
       seqno: 0,
       secretKey: Buffer.alloc(64)
     }
     const transfer = this.wallet.createTransfer(transferArgs)
 
     let networkFee = '0'
-    if (nativeAmount !== '0') {
+    if (tokenId != null || nativeAmount !== '0') {
       const addr = this.wallet.address.toRawString()
       const bodyBoc = base64.stringify(transfer.toBoc())
       const initCodeBoc = needsInit
@@ -331,15 +516,32 @@ export class TonEngine extends CurrencyEngine<
       networkFee = totalFee.toString()
     }
 
-    const total = add(nativeAmount, networkFee)
-    const balance = this.getBalance({ tokenId })
-    if (
-      edgeSpendInfoIn.skipChecks !== true &&
-      gt(add(total, this.networkInfo.minimumAddressBalance), balance)
-    ) {
-      throw new InsufficientFundsError({
-        tokenId: null
-      })
+    if (tokenId != null) {
+      // Token sufficiency checks
+      const tokenBalance = this.getBalance({ tokenId })
+      const nativeBalance = this.getBalance({ tokenId: null })
+      if (edgeSpendInfoIn.skipChecks !== true) {
+        if (gt(nativeAmount, tokenBalance)) {
+          throw new InsufficientFundsError({ tokenId })
+        }
+        const requiredNative = add(
+          this.networkInfo.jettonTransferGas,
+          this.networkInfo.minimumAddressBalance
+        )
+        if (gt(requiredNative, nativeBalance)) {
+          throw new InsufficientFundsError({ tokenId: null })
+        }
+      }
+    } else {
+      // Native sufficiency check
+      const total = add(nativeAmount, networkFee)
+      const balance = this.getBalance({ tokenId: null })
+      if (
+        edgeSpendInfoIn.skipChecks !== true &&
+        gt(add(total, this.networkInfo.minimumAddressBalance), balance)
+      ) {
+        throw new InsufficientFundsError({ tokenId: null })
+      }
     }
 
     // Serialize transferMessage
@@ -350,7 +552,27 @@ export class TonEngine extends CurrencyEngine<
       unsignedTxBase64: base64.stringify(messageSlice.asCell().toBoc())
     }
 
-    const edgeTransaction: EdgeTransaction = {
+    if (tokenId != null) {
+      return {
+        blockHeight: 0,
+        currencyCode,
+        date: 0,
+        isSend: true,
+        memos,
+        nativeAmount: `-${nativeAmount}`,
+        networkFee: '0',
+        networkFees: [],
+        otherParams,
+        ourReceiveAddresses: [],
+        parentNetworkFee: networkFee,
+        signedTx: '',
+        tokenId,
+        txid: '',
+        walletId: this.walletId
+      }
+    }
+
+    return {
       blockHeight: 0,
       currencyCode,
       date: 0,
@@ -366,7 +588,6 @@ export class TonEngine extends CurrencyEngine<
       txid: '',
       walletId: this.walletId
     }
-    return edgeTransaction
   }
 
   async signTx(

--- a/src/ton/TonTools.ts
+++ b/src/ton/TonTools.ts
@@ -20,13 +20,11 @@ import {
 import { base16 } from 'rfc4648'
 
 import { PluginEnvironment } from '../common/innerPlugin'
+import { asyncStaggeredRace } from '../common/promiseUtils'
 import { asSafeCommonWalletInfo } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
-import {
-  getLegacyDenomination,
-  mergeDeeply,
-  shuffleArray
-} from '../common/utils'
+import { getLegacyDenomination, mergeDeeply } from '../common/utils'
+import { fetchDrpc as fetchDrpcRequest } from './tonDrpc'
 import {
   asTonInitOptions,
   asTonPrivateKeys,
@@ -46,7 +44,6 @@ export class TonTools implements EdgeCurrencyTools {
 
   fetchAdaptor: ReturnType<typeof createFetchAdapter>
   getTonCenterClients: () => TonClient[]
-  getOrbsClients: () => TonClient[]
 
   constructor(env: PluginEnvironment<TonNetworkInfo>) {
     const { builtinTokens, currencyInfo, initOptions, io } = env
@@ -100,15 +97,23 @@ export class TonTools implements EdgeCurrencyTools {
       })
       return clients
     }
-    this.getOrbsClients = () => {
-      const clients = [...env.networkInfo.tonOrbsServers].map(url => {
-        return new TonClient({
-          endpoint: url,
-          httpAdapter: this.fetchAdaptor
-        })
-      })
-      return shuffleArray(clients)
+  }
+
+  async fetchDrpc(path: string, body?: object): Promise<unknown> {
+    const funcs: Array<() => Promise<unknown>> = [
+      async () =>
+        await fetchDrpcRequest(this.io, this.networkInfo.drpcUrl, path, body)
+    ]
+
+    const { drpcApiKey } = this.initOptions
+    if (drpcApiKey != null) {
+      const paidBaseUrl = `https://lb.drpc.org/rest/${drpcApiKey}/ton`
+      funcs.push(
+        async () => await fetchDrpcRequest(this.io, paidBaseUrl, path, body)
+      )
     }
+
+    return await asyncStaggeredRace(funcs)
   }
 
   async getDisplayPrivateKey(

--- a/src/ton/TonTools.ts
+++ b/src/ton/TonTools.ts
@@ -21,6 +21,7 @@ import { base16 } from 'rfc4648'
 
 import { PluginEnvironment } from '../common/innerPlugin'
 import { asyncStaggeredRace } from '../common/promiseUtils'
+import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { asSafeCommonWalletInfo } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import { getLegacyDenomination, mergeDeeply } from '../common/utils'
@@ -224,7 +225,12 @@ export class TonTools implements EdgeCurrencyTools {
   }
 
   async getTokenId(token: EdgeToken): Promise<string> {
-    throw new Error('Method not implemented.')
+    validateToken(token)
+    const cleanLocation = asMaybeContractLocation(token.networkLocation)
+    if (cleanLocation == null) {
+      throw new Error('ErrorInvalidContractAddress')
+    }
+    return cleanLocation.contractAddress
   }
 }
 

--- a/src/ton/tonDrpc.ts
+++ b/src/ton/tonDrpc.ts
@@ -1,0 +1,124 @@
+import { asArray, asNumber, asObject, asString } from 'cleaners'
+import { EdgeIo } from 'edge-core-js/types'
+
+// ---------------------------------------------------------------------------
+// Low-level dRPC / Toncenter HTTP helper
+// ---------------------------------------------------------------------------
+
+export async function fetchDrpc(
+  io: EdgeIo,
+  baseUrl: string,
+  path: string,
+  body?: object
+): Promise<unknown> {
+  const url = `${baseUrl}${path}`
+  const opts =
+    body != null
+      ? {
+          method: 'POST' as const,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        }
+      : { method: 'GET' as const }
+
+  const res = await io.fetch(url, opts)
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`dRPC ${path}: ${res.status} ${text}`)
+  }
+  const json: any = await res.json()
+  if (json?.ok === false) {
+    throw new Error(`dRPC ${path}: ${String(json.error ?? 'request failed')}`)
+  }
+  return json
+}
+
+// ---------------------------------------------------------------------------
+// Response cleaners
+// ---------------------------------------------------------------------------
+
+const asPassthrough = (raw: unknown): unknown => raw
+
+export const asDrpcAddressInfo = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // @type: asString,
+    balance: asString,
+    // code: asString,
+    // data: asString,
+    // last_transaction_id: asObject({ lt: asString, hash: asString }),
+    // block_id: asObject({ ... }),
+    // frozen_hash: asString,
+    state: asString
+  })
+})
+
+export const asDrpcEstimateFee = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // @type: asString,
+    source_fees: asObject({
+      // @type: asString,
+      in_fwd_fee: asNumber,
+      storage_fee: asNumber,
+      gas_fee: asNumber,
+      fwd_fee: asNumber
+    })
+    // destination_fees: asArray(...)
+  })
+})
+
+export const asDrpcRunGetMethod = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // gas_used: asNumber,
+    stack: asArray(asPassthrough),
+    exit_code: asNumber
+  })
+})
+
+export const asDrpcSendBoc = asObject({
+  // ok: asBoolean,
+  result: asPassthrough
+})
+
+const asDrpcTransactionId = asObject({
+  // @type: asString,
+  lt: asString,
+  hash: asString
+})
+
+export const asDrpcGetTransactions = asObject({
+  // ok: asBoolean,
+  result: asArray(
+    asObject({
+      transaction_id: asDrpcTransactionId
+      // utime: asNumber,
+      // data: asString,
+      // fee: asString,
+      // storage_fee: asString,
+      // other_fee: asString,
+      // in_msg: asObject({ ... }),
+      // out_msgs: asArray(...)
+    })
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Stack helpers for runGetMethod responses
+// ---------------------------------------------------------------------------
+
+export function parseSeqnoFromStack(stack: unknown[]): number {
+  if (stack.length === 0) {
+    throw new Error('Empty stack for seqno')
+  }
+  const entry = stack[0]
+  if (!Array.isArray(entry) || entry.length < 2) {
+    throw new Error('Unexpected seqno stack format')
+  }
+  const [type, value] = entry
+  if (type !== 'num') {
+    throw new Error(`Unexpected seqno stack type: ${String(type)}`)
+  }
+  return Number(value)
+}

--- a/src/ton/tonDrpc.ts
+++ b/src/ton/tonDrpc.ts
@@ -1,5 +1,7 @@
+import { Address, Cell } from '@ton/ton'
 import { asArray, asNumber, asObject, asString } from 'cleaners'
 import { EdgeIo } from 'edge-core-js/types'
+import { base64 } from 'rfc4648'
 
 // ---------------------------------------------------------------------------
 // Low-level dRPC / Toncenter HTTP helper
@@ -108,17 +110,65 @@ export const asDrpcGetTransactions = asObject({
 // Stack helpers for runGetMethod responses
 // ---------------------------------------------------------------------------
 
-export function parseSeqnoFromStack(stack: unknown[]): number {
-  if (stack.length === 0) {
-    throw new Error('Empty stack for seqno')
+function extractCellBytes(val: unknown): string {
+  if (typeof val === 'string') return val
+  if (typeof val === 'object' && val != null && 'bytes' in val) {
+    return (val as any).bytes
   }
-  const entry = stack[0]
-  if (!Array.isArray(entry) || entry.length < 2) {
-    throw new Error('Unexpected seqno stack format')
+  throw new Error('Cannot extract cell bytes')
+}
+
+function parseStackEntry(entry: unknown): { type: string; value: any } {
+  if (Array.isArray(entry)) {
+    const [entryType, val] = entry
+    if (entryType === 'num') return { type: 'num', value: val }
+    if (entryType === 'cell' || entryType === 'tvm.Cell') {
+      return { type: 'cell', value: extractCellBytes(val) }
+    }
+    if (entryType === 'tvm.Slice') {
+      return { type: 'slice', value: extractCellBytes(val) }
+    }
+    return { type: String(entryType), value: val }
   }
-  const [type, value] = entry
+  if (typeof entry === 'object' && entry != null) {
+    const obj = entry as any
+    if (obj['@type'] === 'tvm.stackEntryNumber') {
+      return { type: 'num', value: obj.number?.value ?? obj.number }
+    }
+    if (obj['@type'] === 'tvm.stackEntryCell') {
+      return {
+        type: 'cell',
+        value: extractCellBytes(obj.cell?.bytes ?? obj.cell)
+      }
+    }
+  }
+  throw new Error(`Unknown stack entry format: ${JSON.stringify(entry)}`)
+}
+
+export function parseStackNumber(stack: unknown[], index: number): string {
+  if (index >= stack.length) {
+    throw new Error(`Index ${index} out of bounds (len=${stack.length})`)
+  }
+  const { type, value } = parseStackEntry(stack[index])
   if (type !== 'num') {
-    throw new Error(`Unexpected seqno stack type: ${String(type)}`)
+    throw new Error(`Expected num at index ${index}, got ${type}`)
   }
-  return Number(value)
+  return BigInt(value).toString()
+}
+
+export function parseStackAddress(stack: unknown[], index: number): Address {
+  if (index >= stack.length) {
+    throw new Error(`Index ${index} out of bounds (len=${stack.length})`)
+  }
+  const { type, value } = parseStackEntry(stack[index])
+  if (type !== 'cell' && type !== 'slice') {
+    throw new Error(`Expected cell/slice at index ${index}, got ${type}`)
+  }
+  const cellBoc = base64.parse(value)
+  const cell = Cell.fromBoc(Buffer.from(cellBoc))[0]
+  return cell.beginParse().loadAddress()
+}
+
+export function parseSeqnoFromStack(stack: unknown[]): number {
+  return Number(parseStackNumber(stack, 0))
 }

--- a/src/ton/tonInfo.ts
+++ b/src/ton/tonInfo.ts
@@ -1,12 +1,24 @@
-import { EdgeCurrencyInfo } from 'edge-core-js/types'
+import { EdgeCurrencyInfo, EdgeTokenMap } from 'edge-core-js/types'
 
 import { makeOuterPlugin } from '../common/innerPlugin'
 import type { TonTools } from './TonTools'
 import { asTonInfoPayload, TonInfoPayload, TonNetworkInfo } from './tonTypes'
 
+const builtinTokens: EdgeTokenMap = {
+  EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs: {
+    currencyCode: 'USDT',
+    displayName: 'Tether USD',
+    denominations: [{ name: 'USDT', multiplier: '1000000' }],
+    networkLocation: {
+      contractAddress: 'EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs'
+    }
+  }
+}
+
 const networkInfo: TonNetworkInfo = {
   defaultWalletContract: 'v5r1',
   drpcUrl: 'https://toncenter.com/api/v2',
+  jettonTransferGas: '100000000',
   minimumAddressBalance: '50000000', // 0.5 TON There isn't a hardcoded minimum but the user needs to keep something left
   pluginMnemonicKeyName: 'tonMnemonic',
   tonCenterUrl: 'https://toncenter.com/api/v2/jsonRPC'
@@ -38,6 +50,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 }
 
 export const ton = makeOuterPlugin<TonNetworkInfo, TonTools, TonInfoPayload>({
+  builtinTokens,
   currencyInfo,
   asInfoPayload: asTonInfoPayload,
   networkInfo,

--- a/src/ton/tonInfo.ts
+++ b/src/ton/tonInfo.ts
@@ -6,17 +6,10 @@ import { asTonInfoPayload, TonInfoPayload, TonNetworkInfo } from './tonTypes'
 
 const networkInfo: TonNetworkInfo = {
   defaultWalletContract: 'v5r1',
+  drpcUrl: 'https://toncenter.com/api/v2',
   minimumAddressBalance: '50000000', // 0.5 TON There isn't a hardcoded minimum but the user needs to keep something left
   pluginMnemonicKeyName: 'tonMnemonic',
-  tonCenterUrl: 'https://toncenter.com/api/v2/jsonRPC',
-  tonOrbsServers: [
-    'https://ton.access.orbs.network/4410c0ff5Bd3F8B62C092Ab4D238bEE463E64410/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/4411c0ff5Bd3F8B62C092Ab4D238bEE463E64411/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/4412c0ff5Bd3F8B62C092Ab4D238bEE463E64412/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55013c0ff5Bd3F8B62C092Ab4D238bEE463E5501/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55023c0ff5Bd3F8B62C092Ab4D238bEE463E5502/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55033c0ff5Bd3F8B62C092Ab4D238bEE463E5503/1/mainnet/toncenter-api-v2/jsonRPC'
-  ]
+  tonCenterUrl: 'https://toncenter.com/api/v2/jsonRPC'
 }
 
 const currencyInfo: EdgeCurrencyInfo = {

--- a/src/ton/tonTypes.ts
+++ b/src/ton/tonTypes.ts
@@ -11,10 +11,10 @@ import {
 
 export interface TonNetworkInfo {
   defaultWalletContract: string
+  drpcUrl: string
   minimumAddressBalance: string
   pluginMnemonicKeyName: string
   tonCenterUrl: string
-  tonOrbsServers: string[]
 }
 
 //
@@ -22,7 +22,7 @@ export interface TonNetworkInfo {
 //
 
 export const asTonInfoPayload = asObject({
-  tonOrbsServers: asOptional(asArray(asString))
+  drpcUrl: asOptional(asString)
 })
 export type TonInfoPayload = ReturnType<typeof asTonInfoPayload>
 
@@ -99,6 +99,7 @@ export const asTonTxOtherParams = asObject({
 })
 
 export const asTonInitOptions = asObject({
+  drpcApiKey: asOptional(asString),
   tonCenterApiKeys: asOptional(asArray(asString), () => [])
 })
 export type TonInitOptions = ReturnType<typeof asTonInitOptions>

--- a/src/ton/tonTypes.ts
+++ b/src/ton/tonTypes.ts
@@ -12,6 +12,7 @@ import {
 export interface TonNetworkInfo {
   defaultWalletContract: string
   drpcUrl: string
+  jettonTransferGas: string
   minimumAddressBalance: string
   pluginMnemonicKeyName: string
   tonCenterUrl: string
@@ -26,8 +27,23 @@ export const asTonInfoPayload = asObject({
 })
 export type TonInfoPayload = ReturnType<typeof asTonInfoPayload>
 
+const asStringRecord: Cleaner<Record<string, string>> = (
+  raw: unknown
+): Record<string, string> => {
+  if (raw == null || typeof raw !== 'object') return {}
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k] = v
+  }
+  return out
+}
+
 export const asTonWalletOtherData = asObject({
   contractState: asOptional(asString, 'uninitialized'), //  "active" | "uninitialized" | "frozen";
+  jettonWalletAddresses: asOptional(
+    asStringRecord,
+    (): Record<string, string> => ({})
+  ),
   mostRecentLogicalTime: asOptional(asString),
   mostRecentHash: asOptional(asString)
 })
@@ -73,10 +89,25 @@ const asBigInt = (val: any): BigInt => {
   return val
 }
 
+const asNullableString = (raw: unknown): string | null => {
+  if (raw == null) return null
+  if (typeof raw !== 'string') throw new Error('Expected string or null')
+  return raw
+}
+
+export const asJettonTransferInfo = asObject({
+  jettonAmount: asBigInt,
+  message: asNullableString
+})
+export type JettonTransferInfo = ReturnType<typeof asJettonTransferInfo>
+
 const asMessage = asObject({
+  jetton_notify: asOptional(asJettonTransferInfo),
+  jetton_req: asOptional(asJettonTransferInfo),
   message: asOptional(asString),
   recipient: asString,
   sender: asOptional(asString),
+  txType: asOptional(asString),
   value: asOptional(asBigInt)
 })
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes TON transaction construction/fee estimation/broadcast flows and adds Jetton token balance + transfer handling, which can directly impact funds movement and history accuracy.
> 
> **Overview**
> Adds TON Jetton (token) support by resolving per-token Jetton wallet addresses, polling Jetton balances, and parsing Jetton transfer notifications/requests into token `EdgeTransaction`s (including memo support and parent-fee attribution).
> 
> Replaces prior Orbs-based network calls with a new dRPC HTTP layer (`tonDrpc`) used for address info, fee estimation, seqno lookup, and broadcasting (plus txid discovery for first-send wallets), and updates TON plugin config/init options to include dRPC settings and a builtin TON USDT token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6ab6c6f171ad077304d0ffb46c6fe96da47542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208623303322573