### PR TITLE
Add ETHx BNBx DAIx and BCHx tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (Zano) Add ETHx BNBx DAIx and BCHx tokens
 - fixed: (ZEC) Fix missing incoming transaction notifications
 
 ## 4.78.1 (2026-04-08)

--- a/src/zano/zanoInfo.ts
+++ b/src/zano/zanoInfo.ts
@@ -38,6 +38,62 @@ const builtinTokens: EdgeTokenMap = {
       contractAddress:
         '040a180aca4194a158c17945dd115db42086f6f074c1f77838621a4927fffa91'
     }
+  },
+  '93da681503353509367e241cda3234299dedbbad9ec851de31e900490807bf0c': {
+    currencyCode: 'ETHx',
+    displayName: 'Ethereum',
+    denominations: [
+      {
+        name: 'ETHx',
+        multiplier: '1000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '93da681503353509367e241cda3234299dedbbad9ec851de31e900490807bf0c'
+    }
+  },
+  '6ca3fa07f1b6a75b6e195d2918c32228765968b54ea691c75958affa1c4073fb': {
+    currencyCode: 'BNBx',
+    displayName: 'Binance Coin',
+    denominations: [
+      {
+        name: 'BNBx',
+        multiplier: '1000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '6ca3fa07f1b6a75b6e195d2918c32228765968b54ea691c75958affa1c4073fb'
+    }
+  },
+  '24819c4b65786c3ac424e05d9ef4ab212de6222cc73bc5c4b012df5a3107eea4': {
+    currencyCode: 'DAIx',
+    displayName: 'Dai Stablecoin',
+    denominations: [
+      {
+        name: 'DAIx',
+        multiplier: '1000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '24819c4b65786c3ac424e05d9ef4ab212de6222cc73bc5c4b012df5a3107eea4'
+    }
+  },
+  '3de9ad7243afa49e0ade6839e97a9f10a527c4958ece2fc9cb1b87a44032167d': {
+    currencyCode: 'BCHx',
+    displayName: 'Bitcoin Cash',
+    denominations: [
+      {
+        name: 'BCHx',
+        multiplier: '100000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '3de9ad7243afa49e0ade6839e97a9f10a527c4958ece2fc9cb1b87a44032167d'
+    }
   }
 }
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new Zano builtin token definitions and a changelog entry, with no changes to transaction or network logic.
> 
> **Overview**
> **Adds new Zano builtin tokens.** Extends `src/zano/zanoInfo.ts` `builtinTokens` to include `ETHx`, `BNBx`, `DAIx`, and `BCHx` with their asset IDs, display names, and denomination multipliers.
> 
> Updates `CHANGELOG.md` under *Unreleased* to document the new Zano tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98990291bb3337b011fbb1bb22489902315fc02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213595182356658