### PR TITLE
Fix DOT and TON syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (DOT) Add Subscan API key support
 - changed: (TON) Replace Orbs servers with dRPC
 
 ## 4.78.0 (2026-04-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (TON) Replace Orbs servers with dRPC
+
 ## 4.78.0 (2026-04-06)
 
 - added: (Zano) Add makeMaxSpend otherMethod to build single-transaction multi-asset max spends.

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -44,7 +44,6 @@ import {
   asSafePolkadotWalletInfo,
   asSubscanResponse,
   asTransactions,
-  asTransfer,
   LiberlandTransfer,
   PolkadotNetworkInfo,
   PolkadotWalletOtherData,
@@ -536,15 +535,9 @@ export class PolkadotEngine extends CurrencyEngine<
 
       // Process txs (newest first)
       transfers.forEach(tx => {
-        try {
-          this.processPolkadotTransaction(asTransfer(tx), isActiveChain)
-        } catch (e: any) {
-          const hash = tx != null && typeof tx.hash === 'string' ? tx.hash : ''
-          this.warn(`Ignoring invalid transfer ${hash}`)
-        }
+        if (tx == null) return
+        this.processPolkadotTransaction(tx, isActiveChain)
       })
-
-      if (count === this.otherData.subscanUrlMap[subscanBaseUrl].txCount) break
 
       // If we haven't reached the end, Update local txCount and progress and then query the next page
       this.otherData.subscanUrlMap[subscanBaseUrl].txCount =

--- a/src/polkadot/PolkadotEngine.ts
+++ b/src/polkadot/PolkadotEngine.ts
@@ -39,12 +39,14 @@ import { PolkadotTools } from './PolkadotTools'
 import {
   asLiberlandMeritsResponse,
   asLiberlandTransfersResponse,
+  asPolkadotInitOptions,
   asPolkadotWalletOtherData,
   asPolkapolkadotPrivateKeys,
   asSafePolkadotWalletInfo,
   asSubscanResponse,
   asTransactions,
   LiberlandTransfer,
+  PolkadotInitOptions,
   PolkadotNetworkInfo,
   PolkadotWalletOtherData,
   SafePolkadotWalletInfo,
@@ -64,6 +66,7 @@ export class PolkadotEngine extends CurrencyEngine<
   TokenSyncTracker
 > {
   engineFetch: EdgeFetchFunction
+  initOptions: PolkadotInitOptions
   networkInfo: PolkadotNetworkInfo
   otherData!: PolkadotWalletOtherData
   api!: ApiPromise
@@ -78,6 +81,7 @@ export class PolkadotEngine extends CurrencyEngine<
   ) {
     super(env, tools, walletInfo, opts, makeTokenSyncTracker)
     this.engineFetch = makeEngineFetch(env.io)
+    this.initOptions = asPolkadotInitOptions(env.initOptions)
     this.networkInfo = env.networkInfo
     this.nonce = 0
   }
@@ -130,16 +134,20 @@ export class PolkadotEngine extends CurrencyEngine<
     endpoint: string,
     body: JsonObject
   ): Promise<SubscanResponse> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+    if (this.initOptions.subscanApiKey !== '') {
+      headers['X-API-Key'] = this.initOptions.subscanApiKey
+    }
     const options = {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
+      headers,
       body: JSON.stringify(body)
     }
     const response = await this.engineFetch(baseSubscanUrl + endpoint, options)
-    if (!response.ok || response.status === 429) {
+    if (!response.ok) {
       throw new Error(`Subscan ${endpoint} failed with ${response.status}`)
     }
     const out = await response.json()
@@ -577,10 +585,13 @@ export class PolkadotEngine extends CurrencyEngine<
         TRANSACTION_POLL_MILLISECONDS
       )
     }
-    if (this.networkInfo.subscanBaseUrls.length > 0) {
+    if (
+      this.networkInfo.subscanBaseUrls.length > 0 &&
+      this.initOptions.subscanApiKey !== ''
+    ) {
       this.addToLoop('queryTransactions', TRANSACTION_POLL_MILLISECONDS)
     } else {
-      this.syncTracker.setHistoryRatios(this.enabledTokenIds, 1)
+      this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 1)
     }
     await super.startEngine()
   }

--- a/src/polkadot/polkadotTypes.ts
+++ b/src/polkadot/polkadotTypes.ts
@@ -54,7 +54,7 @@ export const asSubscanResponse = asObject({
 export type SubscanResponse = ReturnType<typeof asSubscanResponse>
 
 // https://docs.api.subscan.io/#transfers
-export const asTransfer = asObject({
+const asTransfer = asObject({
   from: asString,
   to: asString,
   success: asBoolean,
@@ -70,7 +70,7 @@ export type SubscanTx = ReturnType<typeof asTransfer>
 
 export const asTransactions = asObject({
   count: asNumber,
-  transfers: asMaybe(asArray(asTransfer), () => [])
+  transfers: asMaybe(asArray(asMaybe(asTransfer)), () => [])
 })
 
 export type SafePolkadotWalletInfo = ReturnType<typeof asSafePolkadotWalletInfo>

--- a/src/polkadot/polkadotTypes.ts
+++ b/src/polkadot/polkadotTypes.ts
@@ -13,6 +13,11 @@ import {
 
 import { asSafeCommonWalletInfo } from '../common/types'
 
+export const asPolkadotInitOptions = asObject({
+  subscanApiKey: asOptional(asString, '')
+})
+export type PolkadotInitOptions = ReturnType<typeof asPolkadotInitOptions>
+
 export interface PolkadotNetworkInfo {
   rpcNodes: string[]
   ss58Format: number

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -34,14 +34,18 @@ import { parse_tx } from 'ton-watcher/build/modules/txs/Transaction'
 import { CurrencyEngine } from '../common/CurrencyEngine'
 import { PluginEnvironment } from '../common/innerPlugin'
 import { getRandomDelayMs } from '../common/network'
-import {
-  asyncWaterfall,
-  formatAggregateError,
-  promiseAny
-} from '../common/promiseUtils'
+import { asyncWaterfall } from '../common/promiseUtils'
 import { makeTokenSyncTracker, TokenSyncTracker } from '../common/SyncTracker'
 import { asSafeCommonWalletInfo, SafeCommonWalletInfo } from '../common/types'
 import { snooze } from '../common/utils'
+import {
+  asDrpcAddressInfo,
+  asDrpcEstimateFee,
+  asDrpcGetTransactions,
+  asDrpcRunGetMethod,
+  asDrpcSendBoc,
+  parseSeqnoFromStack
+} from './tonDrpc'
 import { TonTools } from './TonTools'
 import {
   asParsedTx,
@@ -91,17 +95,16 @@ export class TonEngine extends CurrencyEngine<
 
   async queryBalance(): Promise<void> {
     try {
-      const clients = this.tools.getOrbsClients()
-      const funcs = clients.map(async client => {
-        return await client.getContractState(this.wallet.address)
-      })
-      const contractState: Awaited<ReturnType<TonClient['getContractState']>> =
-        await promiseAny(funcs)
+      const addr = encodeURIComponent(this.wallet.address.toRawString())
+      const raw = await this.tools.fetchDrpc(
+        `/getAddressInformation?address=${addr}`
+      )
+      const { result } = asDrpcAddressInfo(raw)
 
-      this.updateBalance(null, contractState.balance.toString())
+      this.updateBalance(null, String(result.balance))
 
-      if (contractState.state !== this.otherData.contractState) {
-        this.otherData.contractState = contractState.state
+      if (result.state !== this.otherData.contractState) {
+        this.otherData.contractState = result.state
         this.walletLocalDataDirty = true
       }
     } catch (e) {
@@ -288,7 +291,6 @@ export class TonEngine extends CurrencyEngine<
       value: fromNano(nativeAmount),
       to: Address.parse(publicAddress),
       body: memoCell,
-      init: needsInit ? this.wallet.init : null,
       bounce: false
     })
 
@@ -304,24 +306,27 @@ export class TonEngine extends CurrencyEngine<
 
     let networkFee = '0'
     if (nativeAmount !== '0') {
-      // Only estimate fee if we're sending something
-      const clients = this.tools.getOrbsClients()
-      const feeFuncs = clients.map(async client => {
-        return await client.estimateExternalMessageFee(this.wallet.address, {
-          body: transfer,
-          initCode: needsInit ? this.wallet.init.code : null,
-          initData: needsInit ? this.wallet.init.data : null,
-          ignoreSignature: false
-        })
-      })
-      const fees: Awaited<ReturnType<TonClient['estimateExternalMessageFee']>> =
-        await promiseAny(feeFuncs)
+      const addr = this.wallet.address.toRawString()
+      const bodyBoc = base64.stringify(transfer.toBoc())
+      const initCodeBoc = needsInit
+        ? base64.stringify(this.wallet.init.code.toBoc())
+        : ''
+      const initDataBoc = needsInit
+        ? base64.stringify(this.wallet.init.data.toBoc())
+        : ''
 
+      const feeRaw = await this.tools.fetchDrpc('/estimateFee', {
+        address: addr,
+        body: bodyBoc,
+        init_code: initCodeBoc,
+        init_data: initDataBoc
+      })
+      const { result: feeResult } = asDrpcEstimateFee(feeRaw)
       const totalFee =
-        fees.source_fees.fwd_fee +
-        fees.source_fees.gas_fee +
-        fees.source_fees.in_fwd_fee +
-        fees.source_fees.storage_fee
+        feeResult.source_fees.fwd_fee +
+        feeResult.source_fees.gas_fee +
+        feeResult.source_fees.in_fwd_fee +
+        feeResult.source_fees.storage_fee
       networkFee = totalFee.toString()
     }
 
@@ -376,13 +381,24 @@ export class TonEngine extends CurrencyEngine<
     )[0].asSlice()
     const transferMessage = loadMessageRelaxed(messageSlice)
 
-    const clients = this.tools.getOrbsClients()
-    const seqnoFuncs = clients.map(async client => {
-      const contract = client.open(this.wallet)
-      return await contract.getSeqno()
+    const addr = this.wallet.address.toRawString()
+    const seqnoRaw = await this.tools.fetchDrpc('/runGetMethod', {
+      address: addr,
+      method: 'seqno',
+      stack: []
     })
-    const seqno: Awaited<ReturnType<typeof this.wallet['getSeqno']>> =
-      await promiseAny(seqnoFuncs)
+    const { result: seqnoResult } = asDrpcRunGetMethod(seqnoRaw)
+    let seqno: number
+    if (seqnoResult.exit_code === -13) {
+      // Account not initialized — first outgoing tx deploys the contract
+      seqno = 0
+    } else if (seqnoResult.exit_code !== 0) {
+      throw new Error(
+        `seqno query failed with exit_code ${seqnoResult.exit_code}`
+      )
+    } else {
+      seqno = parseSeqnoFromStack(seqnoResult.stack)
+    }
 
     const transferArgs: Parameters<WalletContractV5R1['createTransfer']>[0] = {
       sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
@@ -404,53 +420,53 @@ export class TonEngine extends CurrencyEngine<
       const txBoc = base64.parse(edgeTransaction.signedTx)
       const txCell = Cell.fromBoc(Buffer.from(txBoc))[0]
 
-      const clients = this.tools.getOrbsClients()
-      const broadcastFuncs = clients.map(async client => {
-        const contract = client.open(this.wallet)
-        return await contract.send(txCell)
+      const needsInit = this.otherData.contractState === 'uninitialized'
+      const externalMessage = external({
+        to: this.wallet.address,
+        body: txCell,
+        init: needsInit ? this.wallet.init : undefined
       })
-      await formatAggregateError(
-        promiseAny(broadcastFuncs),
-        'Broadcast failed:'
-      )
+      const externalBoc = beginCell()
+        .store(storeMessage(externalMessage))
+        .endCell()
+      const bocBase64 = base64.stringify(externalBoc.toBoc())
+
+      const sendRaw = await this.tools.fetchDrpc('/sendBoc', {
+        boc: bocBase64
+      })
+      asDrpcSendBoc(sendRaw)
 
       if (this.otherData.contractState === 'uninitialized') {
-        // It's not possible to calculate the txid for a wallet's first send so we need to look for it once it's confirmed
+        // The txid for a wallet's deploy tx can't be calculated locally,
+        // so poll for the transaction whose inbound external message
+        // carries a StateInit (init_state) — that's the deploy.
+        const addr = encodeURIComponent(this.wallet.address.toRawString())
         let attempts = 0
         do {
           attempts++
           await snooze(1000)
-          const txidFuncs = clients.map(async client => {
-            return await client.getTransactions(this.wallet.address, {
-              limit: 50
-            })
-          })
-          const transactions: Awaited<
-            ReturnType<TonClient['getTransactions']>
-          > = await promiseAny(txidFuncs)
-
-          const tx = transactions.find(tx => {
-            return tx.oldStatus === 'uninitialized' && tx.endStatus === 'active'
-          })
-          if (tx != null) {
-            const txid = base16.stringify(tx.hash()).toLowerCase()
-            edgeTransaction.txid = txid
-            edgeTransaction.date = Date.now() / 1000
-            this.otherData.contractState = 'active'
-            this.walletLocalDataDirty = true
-            return edgeTransaction
+          try {
+            const raw = await this.tools.fetchDrpc(
+              `/getTransactions?address=${addr}&limit=100`
+            )
+            const { result: txs } = asDrpcGetTransactions(raw)
+            for (const tx of txs) {
+              const { in_msg: inMsg } = tx
+              if (inMsg.source === '' && inMsg.msg_data.init_state != null) {
+                const hashBytes = base64.parse(tx.transaction_id.hash)
+                edgeTransaction.txid = base16.stringify(hashBytes).toLowerCase()
+                edgeTransaction.date = Date.now() / 1000
+                this.otherData.contractState = 'active'
+                this.walletLocalDataDirty = true
+                return edgeTransaction
+              }
+            }
+          } catch (e) {
+            // retry
           }
         } while (attempts <= 30) // In testing, the tx was found after ~10 seconds
         throw new Error('Transaction broadcast but unable to find txid')
       } else {
-        // We can calculate the txid from the signedTx
-        const externalMessage = external({
-          to: this.wallet.address,
-          body: txCell
-        })
-        const externalBoc = beginCell()
-          .store(storeMessage(externalMessage))
-          .endCell()
         const txid = base16.stringify(externalBoc.hash()).toLowerCase()
         edgeTransaction.txid = txid
         edgeTransaction.date = Date.now() / 1000

--- a/src/ton/TonTools.ts
+++ b/src/ton/TonTools.ts
@@ -20,13 +20,11 @@ import {
 import { base16 } from 'rfc4648'
 
 import { PluginEnvironment } from '../common/innerPlugin'
+import { asyncStaggeredRace } from '../common/promiseUtils'
 import { asSafeCommonWalletInfo } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
-import {
-  getLegacyDenomination,
-  mergeDeeply,
-  shuffleArray
-} from '../common/utils'
+import { getLegacyDenomination, mergeDeeply } from '../common/utils'
+import { fetchDrpc as fetchDrpcRequest } from './tonDrpc'
 import {
   asTonInitOptions,
   asTonPrivateKeys,
@@ -46,7 +44,6 @@ export class TonTools implements EdgeCurrencyTools {
 
   fetchAdaptor: ReturnType<typeof createFetchAdapter>
   getTonCenterClients: () => TonClient[]
-  getOrbsClients: () => TonClient[]
 
   constructor(env: PluginEnvironment<TonNetworkInfo>) {
     const { builtinTokens, currencyInfo, initOptions, io } = env
@@ -100,15 +97,23 @@ export class TonTools implements EdgeCurrencyTools {
       })
       return clients
     }
-    this.getOrbsClients = () => {
-      const clients = [...env.networkInfo.tonOrbsServers].map(url => {
-        return new TonClient({
-          endpoint: url,
-          httpAdapter: this.fetchAdaptor
-        })
-      })
-      return shuffleArray(clients)
+  }
+
+  async fetchDrpc(path: string, body?: object): Promise<unknown> {
+    const funcs: Array<() => Promise<unknown>> = [
+      async () =>
+        await fetchDrpcRequest(this.io, this.networkInfo.drpcUrl, path, body)
+    ]
+
+    const { drpcApiKey } = this.initOptions
+    if (drpcApiKey != null && drpcApiKey !== '') {
+      const paidBaseUrl = `https://lb.drpc.org/rest/${drpcApiKey}/ton`
+      funcs.push(
+        async () => await fetchDrpcRequest(this.io, paidBaseUrl, path, body)
+      )
     }
+
+    return await asyncStaggeredRace(funcs)
   }
 
   async getDisplayPrivateKey(

--- a/src/ton/tonDrpc.ts
+++ b/src/ton/tonDrpc.ts
@@ -1,0 +1,143 @@
+import {
+  asArray,
+  asEither,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asUnknown
+} from 'cleaners'
+import { EdgeIo } from 'edge-core-js/types'
+
+// ---------------------------------------------------------------------------
+// Low-level dRPC / Toncenter HTTP helper
+// ---------------------------------------------------------------------------
+
+export async function fetchDrpc(
+  io: EdgeIo,
+  baseUrl: string,
+  path: string,
+  body?: object
+): Promise<unknown> {
+  const url = `${baseUrl}${path}`
+  const opts =
+    body != null
+      ? {
+          method: 'POST' as const,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        }
+      : { method: 'GET' as const }
+
+  const res = await io.fetch(url, opts)
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`dRPC ${path}: ${res.status} ${text}`)
+  }
+  const json: any = await res.json()
+  if (json?.ok === false) {
+    throw new Error(`dRPC ${path}: ${String(json.error ?? 'request failed')}`)
+  }
+  return json
+}
+
+// ---------------------------------------------------------------------------
+// Response cleaners
+// ---------------------------------------------------------------------------
+
+export const asDrpcAddressInfo = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // @type: asString,
+    balance: asEither(asString, asNumber),
+    // code: asString,
+    // data: asString,
+    // last_transaction_id: asObject({ lt: asString, hash: asString }),
+    // block_id: asObject({ ... }),
+    // frozen_hash: asString,
+    state: asString
+  })
+})
+
+export const asDrpcEstimateFee = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // @type: asString,
+    source_fees: asObject({
+      // @type: asString,
+      in_fwd_fee: asNumber,
+      storage_fee: asNumber,
+      gas_fee: asNumber,
+      fwd_fee: asNumber
+    })
+    // destination_fees: asArray(...)
+  })
+})
+
+export const asDrpcRunGetMethod = asObject({
+  // ok: asBoolean,
+  result: asObject({
+    // gas_used: asNumber,
+    stack: asArray(asUnknown),
+    exit_code: asNumber
+  })
+})
+
+export const asDrpcSendBoc = asObject({
+  // ok: asBoolean,
+  result: asUnknown
+})
+
+const asDrpcTransactionId = asObject({
+  // @type: asString,
+  lt: asString,
+  hash: asString
+})
+
+const asDrpcMsgData = asObject({
+  init_state: asOptional(asString)
+})
+
+const asDrpcInMsg = asObject({
+  source: asString,
+  msg_data: asDrpcMsgData
+})
+
+export const asDrpcGetTransactions = asObject({
+  // ok: asBoolean,
+  result: asArray(
+    asObject({
+      transaction_id: asDrpcTransactionId,
+      // utime: asNumber,
+      // data: asString,
+      // fee: asString,
+      // storage_fee: asString,
+      // other_fee: asString,
+      in_msg: asDrpcInMsg
+      // out_msgs: asArray(...)
+    })
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Stack helpers for runGetMethod responses
+// ---------------------------------------------------------------------------
+
+export function parseSeqnoFromStack(stack: unknown[]): number {
+  if (stack.length === 0) {
+    throw new Error('Empty stack for seqno')
+  }
+  const entry = stack[0]
+  if (!Array.isArray(entry) || entry.length < 2) {
+    throw new Error('Unexpected seqno stack format')
+  }
+  const [type, value] = entry
+  if (type !== 'num') {
+    throw new Error(`Unexpected seqno stack type: ${String(type)}`)
+  }
+  const n = Number(value)
+  if (!Number.isFinite(n)) {
+    throw new Error(`Invalid seqno value: ${String(value)}`)
+  }
+  return n
+}

--- a/src/ton/tonInfo.ts
+++ b/src/ton/tonInfo.ts
@@ -6,17 +6,10 @@ import { asTonInfoPayload, TonInfoPayload, TonNetworkInfo } from './tonTypes'
 
 const networkInfo: TonNetworkInfo = {
   defaultWalletContract: 'v5r1',
+  drpcUrl: 'https://toncenter.com/api/v2',
   minimumAddressBalance: '50000000', // 0.5 TON There isn't a hardcoded minimum but the user needs to keep something left
   pluginMnemonicKeyName: 'tonMnemonic',
-  tonCenterUrl: 'https://toncenter.com/api/v2/jsonRPC',
-  tonOrbsServers: [
-    'https://ton.access.orbs.network/4410c0ff5Bd3F8B62C092Ab4D238bEE463E64410/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/4411c0ff5Bd3F8B62C092Ab4D238bEE463E64411/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/4412c0ff5Bd3F8B62C092Ab4D238bEE463E64412/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55013c0ff5Bd3F8B62C092Ab4D238bEE463E5501/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55023c0ff5Bd3F8B62C092Ab4D238bEE463E5502/1/mainnet/toncenter-api-v2/jsonRPC',
-    'https://ton.access.orbs.network/55033c0ff5Bd3F8B62C092Ab4D238bEE463E5503/1/mainnet/toncenter-api-v2/jsonRPC'
-  ]
+  tonCenterUrl: 'https://toncenter.com/api/v2/jsonRPC'
 }
 
 const currencyInfo: EdgeCurrencyInfo = {

--- a/src/ton/tonTypes.ts
+++ b/src/ton/tonTypes.ts
@@ -11,10 +11,10 @@ import {
 
 export interface TonNetworkInfo {
   defaultWalletContract: string
+  drpcUrl: string
   minimumAddressBalance: string
   pluginMnemonicKeyName: string
   tonCenterUrl: string
-  tonOrbsServers: string[]
 }
 
 //
@@ -22,7 +22,7 @@ export interface TonNetworkInfo {
 //
 
 export const asTonInfoPayload = asObject({
-  tonOrbsServers: asOptional(asArray(asString))
+  drpcUrl: asOptional(asString)
 })
 export type TonInfoPayload = ReturnType<typeof asTonInfoPayload>
 
@@ -99,6 +99,7 @@ export const asTonTxOtherParams = asObject({
 })
 
 export const asTonInitOptions = asObject({
+  drpcApiKey: asOptional(asString),
   tonCenterApiKeys: asOptional(asArray(asString), () => [])
 })
 export type TonInitOptions = ReturnType<typeof asTonInitOptions>


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes TON’s balance/fee/seqno/broadcast network paths to a new dRPC REST client and gates Polkadot tx syncing on a new Subscan API key, which could affect syncing/broadcast behavior if the new endpoints or keys are misconfigured.
> 
> **Overview**
> **DOT:** Adds `initOptions.subscanApiKey` and sends it as `X-API-Key` on Subscan requests; transaction syncing is now only scheduled when a key is provided, and Subscan `transfers` parsing tolerates `null` entries.
> 
> **TON:** Replaces Orbs-server usage with a new dRPC REST wrapper (`tonDrpc.ts`) and updates balance lookup, fee estimation, seqno fetching, and broadcasting to use dRPC endpoints; adds `TonNetworkInfo.drpcUrl` plus optional `initOptions.drpcApiKey` with staggered fallback between free and paid dRPC URLs, and updates deploy-txid detection by polling dRPC transaction results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7680d601635bbb90df27f4fc1394bc7fd24be790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213882158399672