### PR TITLE
feat(zano): add makeMaxSpend wallet other method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (Zano) Add makeMaxSpend otherMethod to build single-transaction multi-asset max spends.
+
 ## 4.77.2 (2026-03-24)
 
 - changed: Update chain-registry package

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -415,3 +415,11 @@ export async function exponentialBackoff<T>(
     }
   }
 }
+
+export const safeParseInt = (value: string): number => {
+  const num = Number(value)
+  if (!Number.isSafeInteger(num)) {
+    throw new Error(`Amount exceeds safe integer precision: ${value}`)
+  }
+  return num
+}

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -15,8 +15,11 @@ import {
   JsonObject,
   NoAmountSpecifiedError
 } from 'edge-core-js/types'
-import type { RecentTransaction, TransferParams } from 'react-native-zano'
-import { CppBridge } from 'react-native-zano'
+import type {
+  CppBridge,
+  RecentTransaction,
+  TransferParams
+} from 'react-native-zano'
 
 import { CurrencyEngine } from '../common/CurrencyEngine'
 import { PluginEnvironment } from '../common/innerPlugin'
@@ -35,6 +38,7 @@ import {
   asZanoPrivateKeys,
   asZanoTransferParams,
   asZanoWalletOtherData,
+  MakeMaxSpendParams,
   SafeZanoWalletInfo,
   ZanoNetworkInfo,
   ZanoOtherMethods,
@@ -597,6 +601,85 @@ export class ZanoEngine extends CurrencyEngine<
 
   otherMethods: ZanoOtherMethods = {
     resolveName: this.resolveName.bind(this),
+    makeMaxSpend: async (
+      params: MakeMaxSpendParams
+    ): Promise<EdgeTransaction> => {
+      const { metadata } = params
+      const publicAddress = params.spendTargets[0]?.publicAddress
+      if (publicAddress == null) throw new Error('Missing publicAddress')
+
+      const tokenIdsSet = new Set<EdgeTokenId>(
+        params.tokenIds.map(tokenId =>
+          tokenId === this.networkInfo.nativeAssetId ? null : tokenId
+        )
+      )
+      const tokenIds = Array.from(tokenIdsSet)
+      if (tokenIds.length === 0) {
+        throw new Error('No tokenIds provided')
+      }
+
+      const feeNumber = await this.tools.zano.getCurrentTxFee(2)
+      const networkFee = feeNumber.toFixed()
+      const zanoBalance = this.unlockedBalanceMap.get(null) ?? '0'
+      if (lt(zanoBalance, networkFee)) {
+        throw new InsufficientFundsError({ tokenId: null })
+      }
+
+      const transfers: TransferParams['transfers'] = []
+      const includesNative = tokenIds.includes(null)
+      if (includesNative) {
+        const zanoSendAmount = sub(zanoBalance, networkFee)
+        if (!gt(zanoSendAmount, '0')) {
+          throw new InsufficientFundsError({ tokenId: null })
+        }
+        transfers.push({
+          assetId: this.networkInfo.nativeAssetId,
+          nativeAmount: parseInt(zanoSendAmount),
+          recipient: publicAddress
+        })
+      }
+
+      for (const tokenId of tokenIds) {
+        if (tokenId == null) continue
+        const tokenBalance = this.unlockedBalanceMap.get(tokenId) ?? '0'
+        if (eq(tokenBalance, '0')) {
+          throw new InsufficientFundsError({ tokenId })
+        }
+        transfers.push({
+          assetId: tokenId,
+          nativeAmount: parseInt(tokenBalance),
+          recipient: publicAddress
+        })
+      }
+
+      if (transfers.length === 0) {
+        throw new InsufficientFundsError({ tokenId: null })
+      }
+
+      const out: EdgeTransaction = {
+        blockHeight: 0,
+        currencyCode: this.currencyInfo.currencyCode,
+        date: Date.now() / 1000,
+        isSend: true,
+        memos: [],
+        metadata,
+        nativeAmount: includesNative
+          ? mul(zanoBalance, '-1')
+          : mul(networkFee, '-1'),
+        networkFee,
+        networkFees: [{ tokenId: null, nativeAmount: networkFee }],
+        otherParams: {
+          transfers,
+          fee: feeNumber
+        },
+        ourReceiveAddresses: [],
+        signedTx: '',
+        tokenId: null,
+        txid: '',
+        walletId: this.walletId
+      }
+      return out
+    },
     makeTx: async (makeTxParams: MakeTxParams): Promise<EdgeTransaction> => {
       if (makeTxParams.type === 'MakeTx') {
         const { unsignedTx, metadata } = makeTxParams

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -28,7 +28,7 @@ import {
   makeLifecycleManager
 } from '../common/lifecycleManager'
 import { MakeTxParams } from '../common/types'
-import { cleanTxLogs } from '../common/utils'
+import { cleanTxLogs, safeParseInt } from '../common/utils'
 import { makeZanoSyncTracker, ZanoSyncTracker } from './ZanoSyncTracker'
 import { ZanoTools } from './ZanoTools'
 import {
@@ -494,7 +494,7 @@ export class ZanoEngine extends CurrencyEngine<
     const otherParams: TransferParams = {
       transfers: cleanTargets.map(st => ({
         assetId,
-        nativeAmount: parseInt(abs(st.nativeAmount)),
+        nativeAmount: safeParseInt(abs(st.nativeAmount)),
         recipient: st.publicAddress
       })),
 
@@ -634,7 +634,7 @@ export class ZanoEngine extends CurrencyEngine<
         }
         transfers.push({
           assetId: this.networkInfo.nativeAssetId,
-          nativeAmount: parseInt(zanoSendAmount),
+          nativeAmount: safeParseInt(zanoSendAmount),
           recipient: publicAddress
         })
       }
@@ -647,7 +647,7 @@ export class ZanoEngine extends CurrencyEngine<
         }
         transfers.push({
           assetId: tokenId,
-          nativeAmount: parseInt(tokenBalance),
+          nativeAmount: safeParseInt(tokenBalance),
           recipient: publicAddress
         })
       }

--- a/src/zano/zanoTypes.ts
+++ b/src/zano/zanoTypes.ts
@@ -7,7 +7,12 @@ import {
   asString,
   Cleaner
 } from 'cleaners'
-import { EdgeToken, EdgeTransaction } from 'edge-core-js/types'
+import {
+  EdgeMetadata,
+  EdgeToken,
+  EdgeTokenId,
+  EdgeTransaction
+} from 'edge-core-js/types'
 import type { BurnAssetParams, TransferParams } from 'react-native-zano'
 
 import { createTokenIdFromContractAddress } from '../common/tokenHelpers'
@@ -123,6 +128,13 @@ export const asGetAliasDetailsResponse = asObject({
 export interface ZanoOtherMethods {
   resolveName: (alias: string) => Promise<string>
   makeTx: (makeTxParams: MakeTxParams) => Promise<EdgeTransaction>
+  makeMaxSpend: (params: MakeMaxSpendParams) => Promise<EdgeTransaction>
+}
+
+export interface MakeMaxSpendParams {
+  tokenIds: EdgeTokenId[]
+  spendTargets: Array<{ publicAddress: string }>
+  metadata?: EdgeMetadata
 }
 
 export const asZanoBurnAssetParams = asObject<BurnAssetParams>({


### PR DESCRIPTION
Motivation: allow GUI migration to request one max-spend transaction across selected Zano assets instead of composing multiple spends. The method accepts selected token IDs and defaults to all assets when none are provided, so callers can opt into explicit asset control.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Zano transaction-construction path that builds multi-asset max-spend transfers and changes amount parsing to enforce JS safe-integer limits, which could surface new runtime errors or edge-case balance/fee behavior.
> 
> **Overview**
> Adds a new Zano `otherMethods.makeMaxSpend` that constructs a **single multi-asset max-spend** `EdgeTransaction` by sweeping selected token balances (and optionally native ZANO minus fee) into one transfer list.
> 
> Introduces `safeParseInt` and switches Zano transfer amount conversion to use it, throwing if a string amount cannot be represented as a JS safe integer (affecting both `makeSpend` and the new max-spend path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130735f19254c9882de50356928570531ea028c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213968564434713