### PR TITLE
Fix missing incoming ZEC transaction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (ZEC) Fix missing incoming transaction notifications
+
 ## 4.78.1 (2026-04-08)
 
 - added: (DOT) Add Subscan API key support

--- a/src/common/CurrencyEngine.ts
+++ b/src/common/CurrencyEngine.ts
@@ -289,7 +289,8 @@ export class CurrencyEngine<
     return out
   }
 
-  private isTransactionNew(edgeTransaction: EdgeTransaction): boolean {
+  // This method is protected because it's used in the ZcashEngine to handle unconfirmed txs. It should revert to private once unconfirmed txs are properly handled in the seenTxCheckpoint API
+  protected isTransactionNew(edgeTransaction: EdgeTransaction): boolean {
     const txCheckpoint = this.getTxCheckpoint(edgeTransaction)
     if (
       // Undefined seenTxCheckpoint means we're syncing for the very first time

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -171,6 +171,19 @@ export class ZcashEngine extends CurrencyEngine<
     })
   }
 
+  // This is a partial fix for handling unconfirmed txs in the seenTxCheckpoint API. It solves the problem for a single device, but multi-devices syncing the same account may still see incorrect notifications.
+  isTransactionNew(edgeTransaction: EdgeTransaction): boolean {
+    if (
+      edgeTransaction.blockHeight === 0 &&
+      edgeTransaction.confirmations === 'unconfirmed' &&
+      this.seenTxCheckpoint != null &&
+      !edgeTransaction.isSend
+    ) {
+      return true
+    }
+    return super.isTransactionNew(edgeTransaction)
+  }
+
   isSynced(): boolean {
     // Synchronizer status is updated regularly and should be checked before accessing the db to avoid errors
     return this.synchronizerStatus === 'SYNCED'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts new-transaction detection/notification logic for Zcash by special-casing unconfirmed incoming transactions, which could change when/if users see notifications (including potential false positives or duplicates, especially across devices).
> 
> **Overview**
> Fixes missing incoming ZEC transaction notifications by treating unconfirmed incoming transactions (`blockHeight === 0`, `confirmations === 'unconfirmed'`) as *new* even when a `seenTxCheckpoint` already exists.
> 
> To support this override, `CurrencyEngine.isTransactionNew` is loosened from `private` to `protected`, and Zcash adds an engine-specific `isTransactionNew` implementation that falls back to the base checkpoint logic for all other cases. Also adds a corresponding Unreleased changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aab354d37d012ad28753f2eb8e790d6e6b06f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213629974235942