### PR TITLE
feat(zano): decode base58 mnemonic keys in parseUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (Zano) Support base58-encoded raw seed imports in `parseUri`, with and without a `zano:` prefix
+
 ## 4.79.1 (2026-04-10)
 
 - changed: Update chain-registry

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
     "@ton/ton": "^15.1.0",
+    "@zano-project/zano-utils-js": "https://github.com/EdgeApp/zano-utils-js/releases/download/v0.0.4-edge.1/zano-project-zano-utils-js-0.0.4.tgz",
     "@zondax/izari-filecoin": "^1.2.6",
     "algosdk": "^2.1.0",
     "assert-log": "^0.2.2",

--- a/src/zano/ZanoTools.ts
+++ b/src/zano/ZanoTools.ts
@@ -1,4 +1,6 @@
+import { seedToMnemonic } from '@zano-project/zano-utils-js'
 import { div, mul, toFixed } from 'biggystring'
+import bs58 from 'bs58'
 import { asMaybe, asString } from 'cleaners'
 import {
   EdgeCurrencyInfo,
@@ -166,46 +168,52 @@ export class ZanoTools implements EdgeCurrencyTools {
 
     // Handle Zano Deeplink URIs:
     if (uri.startsWith('zano:')) {
-      const zanoDeeplink = parseZanoDeeplink(uri)
-      if (zanoDeeplink.action !== 'send') {
-        throw new Error('Invalid Zano URI: only send action is supported')
-      }
-      if (!(await this.isValidAddress(zanoDeeplink.address))) {
-        throw new Error('InvalidPublicAddressError')
-      }
-      const edgeParsedUri: EdgeParsedUri = {
-        publicAddress: zanoDeeplink.address
-      }
-      const amountStr = zanoDeeplink.amount
-      if (amountStr != null && typeof amountStr === 'string') {
-        // Validate that the currency in the deeplink matches the requested
-        // currency code:
-        let deeplinkCurrencyCode: string
-        if (zanoDeeplink.asset_id == null) {
-          deeplinkCurrencyCode = this.currencyInfo.currencyCode
-        } else {
-          deeplinkCurrencyCode =
-            this.builtinTokens[zanoDeeplink.asset_id]?.currencyCode
-        }
-        if (currencyCode != null && currencyCode !== deeplinkCurrencyCode) {
-          throw new Error('InvalidCurrencyCodeError')
-        }
-        const denom = getLegacyDenomination(
-          deeplinkCurrencyCode,
-          this.currencyInfo,
-          customTokens ?? [],
-          this.builtinTokens
-        )
-        if (denom == null) {
-          throw new Error('InternalErrorInvalidCurrencyCode')
-        }
-        let nativeAmount = mul(amountStr, denom.multiplier)
-        nativeAmount = toFixed(nativeAmount, 0, 0)
+      let zanoDeeplink: ReturnType<typeof parseZanoDeeplink> | undefined
+      try {
+        zanoDeeplink = parseZanoDeeplink(uri)
+      } catch {}
 
-        edgeParsedUri.nativeAmount = nativeAmount
-        edgeParsedUri.currencyCode = deeplinkCurrencyCode
+      if (zanoDeeplink != null) {
+        if (zanoDeeplink.action !== 'send') {
+          throw new Error('Invalid Zano URI: only send action is supported')
+        }
+        if (!(await this.isValidAddress(zanoDeeplink.address))) {
+          throw new Error('InvalidPublicAddressError')
+        }
+        const edgeParsedUri: EdgeParsedUri = {
+          publicAddress: zanoDeeplink.address
+        }
+        const amountStr = zanoDeeplink.amount
+        if (amountStr != null && typeof amountStr === 'string') {
+          // Validate that the currency in the deeplink matches the requested
+          // currency code:
+          let deeplinkCurrencyCode: string
+          if (zanoDeeplink.asset_id == null) {
+            deeplinkCurrencyCode = this.currencyInfo.currencyCode
+          } else {
+            deeplinkCurrencyCode =
+              this.builtinTokens[zanoDeeplink.asset_id]?.currencyCode
+          }
+          if (currencyCode != null && currencyCode !== deeplinkCurrencyCode) {
+            throw new Error('InvalidCurrencyCodeError')
+          }
+          const denom = getLegacyDenomination(
+            deeplinkCurrencyCode,
+            this.currencyInfo,
+            customTokens ?? [],
+            this.builtinTokens
+          )
+          if (denom == null) {
+            throw new Error('InternalErrorInvalidCurrencyCode')
+          }
+          let nativeAmount = mul(amountStr, denom.multiplier)
+          nativeAmount = toFixed(nativeAmount, 0, 0)
+
+          edgeParsedUri.nativeAmount = nativeAmount
+          edgeParsedUri.currencyCode = deeplinkCurrencyCode
+        }
+        return edgeParsedUri
       }
-      return edgeParsedUri
     }
 
     // Handle standard URIs:
@@ -221,6 +229,25 @@ export class ZanoTools implements EdgeCurrencyTools {
 
     if (edgeParsedUri.privateKeys != null) {
       return edgeParsedUri
+    }
+
+    // Some scanners provide the mnemonic as base58-encoded raw seed bytes,
+    // with or without a `zano:` prefix. The bytes are either a 32-byte seed
+    // or a full seed with appended timestamp/checksum word indices.
+    const base58Candidates = [uri]
+    if (uri.startsWith('zano:')) {
+      base58Candidates.push(uri.slice('zano:'.length).replace(/^\/\//, ''))
+    }
+    for (const candidate of base58Candidates) {
+      if (candidate === '') continue
+      try {
+        const seedHex = base16.stringify(bs58.decode(candidate))
+        const decodedMnemonic = seedToMnemonic(seedHex)
+        await this.importPrivateKey(decodedMnemonic)
+        edgeParsedUri.privateKeys = [decodedMnemonic]
+        edgeParsedUri.publicAddress = undefined
+        return edgeParsedUri
+      } catch {}
     }
 
     let address = ''

--- a/test/plugin/zanoTools.parseUri.test.ts
+++ b/test/plugin/zanoTools.parseUri.test.ts
@@ -1,0 +1,58 @@
+import { assert } from 'chai'
+
+import { ZanoTools } from '../../src/zano/ZanoTools'
+
+// Deterministic full-seed (v2) test vector. The 36-byte seed below is
+// base58-encoded as `encodedKey` and decodes via `seedToMnemonic` into
+// `expectedMnemonic`.
+const encodedKey = '16qJFWMMHFy3xDdLmvUeyc2S6FrWRhJP51HsvDYdz9boMC8Z'
+const expectedMnemonic =
+  'before bring today bleed process melody cruel devil nowhere frozen bit month fur suffocate thigh against volume effort hill worse thick shove world different just love'
+
+const makeTools = (
+  importCalls: string[]
+): { tools: ZanoTools; importCalls: string[] } => {
+  const tools = Object.assign(Object.create(ZanoTools.prototype), {
+    currencyInfo: { pluginId: 'zano' },
+    builtinTokens: {}
+  }) as ZanoTools
+
+  tools.importPrivateKey = async (input: string) => {
+    importCalls.push(input)
+    if (input !== expectedMnemonic) {
+      throw new Error('Unable to validate mnemonic')
+    }
+    return { zanoMnemonic: input }
+  }
+
+  tools.isValidAddress = async () => {
+    throw new Error('Address validation should not run for private keys')
+  }
+
+  return { tools, importCalls }
+}
+
+describe('ZanoTools.parseUri', () => {
+  it('decodes a base58-encoded raw-seed private key', async () => {
+    const importCalls: string[] = []
+    const { tools } = makeTools(importCalls)
+
+    const parsedUri = await tools.parseUri(encodedKey)
+
+    assert.deepEqual(parsedUri.privateKeys, [expectedMnemonic])
+    assert.isUndefined(parsedUri.publicAddress)
+    assert.deepEqual(importCalls, [encodedKey, expectedMnemonic])
+  })
+
+  it('decodes a base58-encoded raw-seed private key with zano: prefix', async () => {
+    const prefixedKey = `zano:${encodedKey}`
+    const importCalls: string[] = []
+    const { tools } = makeTools(importCalls)
+
+    const parsedUri = await tools.parseUri(prefixedKey)
+
+    assert.deepEqual(parsedUri.privateKeys, [expectedMnemonic])
+    assert.isUndefined(parsedUri.publicAddress)
+    assert.deepEqual(importCalls, [prefixedKey, expectedMnemonic])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,6 +2703,18 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+"@zano-project/zano-utils-js@https://github.com/EdgeApp/zano-utils-js/releases/download/v0.0.4-edge.1/zano-project-zano-utils-js-0.0.4.tgz":
+  version "0.0.4"
+  resolved "https://github.com/EdgeApp/zano-utils-js/releases/download/v0.0.4-edge.1/zano-project-zano-utils-js-0.0.4.tgz#e688c5c3fc2c228dd045298d40cbb50877c6b513"
+  dependencies:
+    axios "^0.21.1"
+    big.js "^6.1.1"
+    bn.js "^5.2.1"
+    elliptic "^6.5.4"
+    js-sha3 "^0.9.3"
+    keccak "^3.0.3"
+    rimraf "^3.0.2"
+
 "@zondax/izari-filecoin@^1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@zondax/izari-filecoin/-/izari-filecoin-1.2.6.tgz#7b6243b30ec25d154a027fca107734e9442e3704"
@@ -3098,6 +3110,13 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
@@ -3200,6 +3219,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+big.js@^6.1.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.2.tgz#be3bb9ac834558b53b099deef2a1d06ac6368e1a"
+  integrity sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==
 
 biggystring@^4.2.3:
   version "4.2.3"
@@ -5386,6 +5410,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.14.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 follow-redirects@^1.14.8, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
@@ -6438,6 +6467,11 @@ js-sha3@0.8.0, js-sha3@^0.8.0:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
+js-sha3@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.9.3.tgz#f0209432b23a66a0f6c7af592c26802291a75c2a"
+  integrity sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==
+
 js-sha512@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha512/-/js-sha512-0.8.0.tgz#dd22db8d02756faccf19f218e3ed61ec8249f7d4"
@@ -6566,6 +6600,15 @@ keccak@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.3.tgz#4bc35ad917be1ef54ff246f904c2bbbf9ac61276"
   integrity sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+    readable-stream "^3.6.0"
+
+keccak@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.4.tgz#edc09b89e633c0549da444432ecf062ffadee86d"
+  integrity sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==
   dependencies:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"


### PR DESCRIPTION
Scanner imports can provide Zano recovery keys as base58 payloads rather than plain mnemonic text, including optional zano-prefixed forms.

Handle these formats during URI parsing so valid recovery imports succeed without requiring users to manually reformat the key first.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Zano URI/private-key parsing and adds a new external dependency, so malformed inputs or library behavior changes could affect import flows; changes are localized and covered by a new unit test.
> 
> **Overview**
> Zano `parseUri` now recognizes base58-encoded raw-seed payloads (with or without a `zano:` prefix), converts them to a mnemonic via `seedToMnemonic`, validates via `importPrivateKey`, and returns them as `privateKeys` instead of attempting address validation.
> 
> Deeplink parsing was made more defensive by treating malformed `zano:` URIs as non-deeplinks rather than immediately throwing. Adds `@zano-project/zano-utils-js` dependency, a focused unit test for the new base58 import behavior, and updates the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af6b74d7d9de47ac3a6ee2b47f1ee77659e6421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214086170126881