### PR TITLE
accb: Migrate THORChain mainnet endpoints off NineRealms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Migrate THORChain mainnet endpoints (RPC, thornode, Midgard, archive) off NineRealms to gateway.liquify.com.
+
 ## 4.80.0 (2026-04-16)
 
 - added: (Zano) Support base58-encoded raw seed imports in `parseUri`, with and without a `zano:` prefix

--- a/src/cosmos/info/thorchainruneInfo.ts
+++ b/src/cosmos/info/thorchainruneInfo.ts
@@ -26,19 +26,19 @@ const networkInfo: MidgardNetworkInfo = {
     url: 'https://raw.githubusercontent.com/cosmos/chain-registry/master/thorchain/chain.json'
   },
   defaultChainId: 'thorchain-mainnet-v1',
-  chainIdUpdateUrl: 'https://rpc.ninerealms.com/status',
+  chainIdUpdateUrl: 'https://gateway.liquify.com/chain/thorchain_rpc/status',
   transactionFeeConnectionInfo: {
-    url: 'https://thornode.ninerealms.com/thorchain/network',
+    url: 'https://gateway.liquify.com/chain/thorchain_api/thorchain/network',
     headers: { 'x-client-id': '{{ninerealmsClientId}}' }
   },
   midgardConnectionInfo: {
-    url: 'https://midgard.ninerealms.com',
+    url: 'https://gateway.liquify.com/chain/thorchain_midgard',
     headers: { 'x-client-id': '{{ninerealmsClientId}}' }
   },
   nativeDenom: 'rune',
   pluginMnemonicKeyName: 'thorchainruneMnemonic',
   rpcNode: {
-    url: 'https://rpc.ninerealms.com',
+    url: 'https://gateway.liquify.com/chain/thorchain_rpc',
     headers: { 'x-client-id': '{{ninerealmsClientId}}' }
   },
   archiveNodes: [
@@ -48,7 +48,7 @@ const networkInfo: MidgardNetworkInfo = {
         // end: TBD
       },
       endpoint: {
-        url: 'https://rpc-v1.ninerealms.com',
+        url: 'https://gateway.liquify.com/chain/thorchain_v1_rpc',
         headers: { 'x-client-id': '{{ninerealmsClientId}}' }
       }
     }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1214112351777430/f)

Migrates the `thorchainrune` mainnet currency plugin off `*.ninerealms.com`. Those hosts are being retired on 2026-04-20 (already returning 301). Without this change RUNE wallet sync, fee estimation, Midgard lookups, and archive-node queries all break.

Edits in `src/cosmos/info/thorchainruneInfo.ts`:
- `chainIdUpdateUrl`: `rpc.ninerealms.com/status` → `gateway.liquify.com/chain/thorchain_rpc/status`
- `transactionFeeConnectionInfo.url`: `thornode.ninerealms.com/thorchain/network` → `gateway.liquify.com/chain/thorchain_api/thorchain/network`
- `midgardConnectionInfo.url`: `midgard.ninerealms.com` → `gateway.liquify.com/chain/thorchain_midgard`
- `rpcNode.url`: `rpc.ninerealms.com` → `gateway.liquify.com/chain/thorchain_rpc`
- `archiveNodes[0].endpoint.url`: `rpc-v1.ninerealms.com` → `gateway.liquify.com/chain/thorchain_v1_rpc`

Kept intact (intentional):
- `x-client-id: {{ninerealmsClientId}}` header on every connection — Liquify accepts it without issue; stripping it is a larger-surface config change for a later PR.
- `thorchainruneStagenetInfo.ts` — Maya team hasn't published stagenet replacement URLs yet; follow-up when they do.
- Commented-out `rpc-v2.ninerealms.com` archive node — stays inert.

Sibling PRs handle edge-exchange-plugins (swap + tx tracker) and edge-react-gui (Savers / Yield).

Asana parent: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1214109247963126

### Testing

Curl-verified new endpoints with existing `ninerealmsClientId`:
- `gateway.liquify.com/chain/thorchain_api/thorchain/network` → 200 OK
- `gateway.liquify.com/chain/thorchain_midgard/v2/health` → 200 OK
- `gateway.liquify.com/chain/thorchain_rpc/status` → 200 OK
- `gateway.liquify.com/chain/thorchain_v1_rpc/status` → 200 (rate-limited daily, endpoint exists)

Reviewer should confirm a RUNE wallet syncs + shows balances and that send-tx fee estimation works on mainnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Endpoint-only change, but it affects core THORChain wallet sync, fee estimation, and transaction/history queries; incorrect URLs or gateway behavior would break mainnet RUNE functionality.
> 
> **Overview**
> Migrates the `thorchainrune` mainnet plugin’s network endpoints away from `*.ninerealms.com` to `gateway.liquify.com`, updating the URLs used for chain-id polling, thornode fee/network data, Midgard queries, the primary RPC node, and the v1 archive RPC.
> 
> Adds a `CHANGELOG.md` Unreleased entry documenting the THORChain endpoint migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec35c95243f424e2813aa34a469b19ecd37390fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->