### PR TITLE
zcash: ZIP-321 memo parsing + populate spendTargets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: zcash - Honor the ZIP-321 `memo` query parameter when parsing payment URIs (base64url decoded), unblocking ZNS claim flows.
+
 ## 4.81.2 (2026-04-24)
 
 - changed: Update chain-registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: zcash - Populate `EdgeTransaction.spendTargets` with the recipient address for outgoing transactions, enabling reverse address lookups (e.g. ZNS) in the GUI.
 - fixed: zcash - Honor the ZIP-321 `memo` query parameter when parsing payment URIs (base64url decoded), unblocking ZNS claim flows.
 
 ## 4.81.2 (2026-04-24)

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -237,6 +237,22 @@ export class ZcashEngine extends CurrencyEngine<
         ? Math.max(blockTimeInSeconds, Date.now() / 1000)
         : blockTimeInSeconds
 
+    // For outgoing transactions, carry the recipient address onto
+    // `spendTargets` so the GUI can drive reverse address lookups (e.g. ZNS).
+    // Shielded receives leave `toAddress` null, so no spendTargets there.
+    const spendTargets =
+      toAddress != null
+        ? [
+            {
+              currencyCode: this.currencyInfo.currencyCode,
+              nativeAmount: value,
+              publicAddress: toAddress,
+              memo: undefined,
+              uniqueIdentifier: undefined
+            }
+          ]
+        : undefined
+
     const edgeTransaction: EdgeTransaction = {
       blockHeight: minedHeight,
       confirmations,
@@ -251,6 +267,7 @@ export class ZcashEngine extends CurrencyEngine<
       otherParams: {},
       ourReceiveAddresses: [], // Not accessible from SDK and unified addresses are deterministic
       signedTx: raw ?? '',
+      spendTargets,
       tokenId: null,
       txid: rawTransactionId,
       walletId: this.walletId

--- a/src/zcash/ZcashTools.ts
+++ b/src/zcash/ZcashTools.ts
@@ -13,6 +13,7 @@ import {
   JsonObject
 } from 'edge-core-js/types'
 import { Tools as ToolsType } from 'react-native-zcash'
+import { base64url } from 'rfc4648'
 
 import { PluginEnvironment } from '../common/innerPlugin'
 import { asIntegerString } from '../common/types'
@@ -26,6 +27,15 @@ import {
   ZcashInfoPayload,
   ZcashNetworkInfo
 } from './zcashTypes'
+
+/**
+ * Decode a ZIP-321 base64url memo string (no `=` padding) into raw bytes.
+ * Per https://zips.z.cash/zip-0321: memo uses base64url alphabet, no padding,
+ * decoded ≤ 512 bytes. `loose: true` permits the missing `=` padding.
+ */
+export function decodeZip321Memo(b64url: string): Buffer {
+  return Buffer.from(base64url.parse(b64url, { loose: true }))
+}
 
 export class ZcashTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
@@ -160,7 +170,8 @@ export class ZcashTools implements EdgeCurrencyTools {
 
     const {
       edgeParsedUri,
-      edgeParsedUri: { publicAddress }
+      edgeParsedUri: { publicAddress },
+      parsedUri
     } = await parseUriCommon({
       currencyInfo: this.currencyInfo,
       uri,
@@ -172,6 +183,26 @@ export class ZcashTools implements EdgeCurrencyTools {
 
     if (publicAddress == null || !(await this.isValidAddress(publicAddress))) {
       throw new Error('InvalidPublicAddressError')
+    }
+
+    // ZIP-321 `memo` query parameter — base64url without padding, ≤ 512 bytes
+    // decoded. https://zips.z.cash/zip-0321
+    // Surface as `uniqueIdentifier`, which the GUI threads through to
+    // EdgeSpendInfo.memos (and the legacy `spendTarget.memo`).
+    const memoB64Url = parsedUri.query.memo
+    if (memoB64Url != null && memoB64Url !== '') {
+      const memoBytes = decodeZip321Memo(memoB64Url)
+      const memoOption = this.currencyInfo.memoOptions?.[0]
+      if (
+        memoOption?.type === 'text' &&
+        memoOption.maxLength != null &&
+        memoBytes.length > memoOption.maxLength
+      ) {
+        throw new Error(
+          `ZIP-321 memo exceeds ${memoOption.maxLength} byte limit`
+        )
+      }
+      edgeParsedUri.uniqueIdentifier = memoBytes.toString('utf8')
     }
 
     return edgeParsedUri

--- a/test/zcash/zip321.test.ts
+++ b/test/zcash/zip321.test.ts
@@ -1,0 +1,53 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { decodeZip321Memo } from '../../src/zcash/ZcashTools'
+
+// ZIP-321 memo encoding: base64url, no `=` padding, ≤ 512 decoded bytes.
+// https://zips.z.cash/zip-0321
+describe('decodeZip321Memo', function () {
+  it('decodes a ZNS:CLAIM ASCII payload', function () {
+    // base64url of "ZNS:CLAIM:edge:test"
+    const encoded = 'Wk5TOkNMQUlNOmVkZ2U6dGVzdA'
+    assert.equal(
+      decodeZip321Memo(encoded).toString('utf8'),
+      'ZNS:CLAIM:edge:test'
+    )
+  })
+
+  it('handles base64url-specific characters (- and _)', function () {
+    // base64 of "subjects?_d>" is "c3ViamVjdHM/X2Q+" (uses + and /)
+    // base64url of the same is "c3ViamVjdHM_X2Q-" (- and _)
+    const encoded = 'c3ViamVjdHM_X2Q-'
+    assert.equal(decodeZip321Memo(encoded).toString('utf8'), 'subjects?_d>')
+  })
+
+  it('handles input that needs no padding', function () {
+    // base64url of "abcd" — exactly 4 char output, no padding needed
+    const encoded = 'YWJjZA'
+    assert.equal(decodeZip321Memo(encoded).toString('utf8'), 'abcd')
+  })
+
+  it('handles input that needs 1-byte padding', function () {
+    // base64url of "abc" → 4 chars with 1 missing pad
+    const encoded = 'YWJj'
+    assert.equal(decodeZip321Memo(encoded).toString('utf8'), 'abc')
+  })
+
+  it('handles input that needs 2-byte padding', function () {
+    // base64url of "ab" → 3 chars with 2 missing pads
+    const encoded = 'YWI'
+    assert.equal(decodeZip321Memo(encoded).toString('utf8'), 'ab')
+  })
+
+  it('decodes binary bytes correctly', function () {
+    // base64url of bytes [0x01, 0x02, 0x03, 0xff]
+    const encoded = 'AQID_w'
+    const decoded = decodeZip321Memo(encoded)
+    assert.deepEqual(Array.from(decoded), [0x01, 0x02, 0x03, 0xff])
+  })
+
+  it('returns empty buffer for empty input', function () {
+    assert.equal(decodeZip321Memo('').length, 0)
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

Asana: https://app.asana.com/0/1214252040192565/1214281428820963
Blocks gui work: [EdgeApp/edge-react-gui#6000](https://github.com/EdgeApp/edge-react-gui/pull/6000)

Two zcash changes, both unblocking ZNS flows in the GUI:

**1. Honor ZIP-321 `memo` query param in `parseUri`** ([zip-0321 spec](https://zips.z.cash/zip-0321))

`ZcashTools.parseUri` was delegating to the generic `parseUriCommon`, which only extracts `label`/`message`/`category`/`amount` and silently drops the ZIP-321 `memo` query parameter. Scanning a zcashnames.com claim QR — e.g. `zcash:u1k0…?amount=0.015&memo=<base64url of "ZNS:CLAIM:edge:u1fm0cctk8xycu7a5…">` — produced a transaction with an empty shielded memo, breaking ZNS claim flows. Now base64url-decoded and surfaced as `EdgeParsedUri.uniqueIdentifier`, which the GUI already threads through to `EdgeSpendInfo.memos` / `spendTarget.memo`. Validated ≤ 512 decoded bytes per spec.

**2. Populate `EdgeTransaction.spendTargets` for outgoing txs**

`ZcashEngine.processTransaction` was building `EdgeTransaction` without `spendTargets`, even though the native sync event provides `toAddress` for outgoing transactions. Anything in the GUI that reads `transaction.spendTargets?.[0]?.publicAddress` — recipient display, reverse address lookups (e.g. the ZNS reverse lookup on #6000), etc. — was seeing `undefined` for every zcash tx and silently bailing. Now populated with `[{ publicAddress: toAddress, nativeAmount: value, ... }]` whenever `toAddress != null`. Receives (shielded, `toAddress == null`) are untouched.

**Out of scope** (follow-ups if needed):
- `paramindex` / multi-recipient ZIP-321 URIs
- `req-asset` validation (unknown `req-*` should reject per spec)
- Broader refactor to thread the raw URI to the native SDK via `otherParams.zip321Uri` (would cover all ZIP-321 features for free but is a bigger change).

**Tests:** new `test/zcash/zip321.test.ts` exercises the `decodeZip321Memo` helper — ASCII payload, base64url-specific characters (`-` / `_`), 0/1/2-byte padding, binary bytes, empty input. All 451 existing tests still pass. Verified locally with `yarn prepare`, `yarn lint`, `yarn test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Zcash URI parsing and transaction processing, which can affect how memos/recipients are surfaced to the GUI and could cause edge-case decoding or display regressions if memo inputs are malformed.
> 
> **Overview**
> **Zcash payment URI parsing now honors ZIP-321 `memo` query parameters.** `parseUri` decodes base64url (no padding) memos, enforces the configured memo byte limit, and surfaces the decoded text via `EdgeParsedUri.uniqueIdentifier`.
> 
> **Outgoing Zcash transactions now include recipient info in `EdgeTransaction.spendTargets`.** When the SDK provides `toAddress`, the engine populates a single spend target so the GUI can reliably show recipients and perform reverse address lookups.
> 
> Adds unit tests for ZIP-321 memo decoding and updates the changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34b4e492d3559da5cebe0d1bdcfe92c9c3dab24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->