### PR TITLE
Use `promisesAgree` on public address resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: zcash - Populate `EdgeTransaction.spendTargets` with the recipient address for outgoing transactions, enabling reverse address lookups (e.g. ZNS) in the GUI.
+- changed: (FIO) Use `promisesAgree` on public address resolution
 - fixed: zcash - Honor the ZIP-321 `memo` query parameter when parsing payment URIs (base64url decoded), unblocking ZNS claim flows.
 
 ## 4.81.2 (2026-04-24)

--- a/src/fio/FioEngine.ts
+++ b/src/fio/FioEngine.ts
@@ -105,6 +105,7 @@ import {
   comparisonFioBalanceString,
   comparisonFioNameString,
   FioActionFees,
+  FioGetPubAddressesResponse,
   FioNetworkInfo,
   FioRefBlock,
   FioRequestTypes,
@@ -904,6 +905,30 @@ export class FioEngine extends CurrencyEngine<
           return comparisonFioBalanceString(result)
         },
         2
+      )
+    } else if (actionName === 'getPublicAddresses') {
+      res = await promisesAgree(
+        this.networkInfo.apiUrls.map(async apiUrl => {
+          const apiRes = await timeout(
+            this.fioApiRequest(apiUrl, actionName, params),
+            10000
+          )
+          if (apiRes.isError != null) {
+            const error = new FioError(apiRes.data.message)
+            error.json = apiRes.data.json
+            error.list = apiRes.data.list
+            error.errorCode = apiRes.data.code
+            throw error
+          }
+          return apiRes
+        }),
+        (result: FioGetPubAddressesResponse) => {
+          return result.public_addresses
+            .map(r => `${r.chain_code}${r.token_code}${r.public_address}`)
+            .sort((a, b) => a.localeCompare(b))
+            .join()
+        },
+        3
       )
     } else if (actionName === 'getFees') {
       res = await asyncWaterfall(

--- a/src/fio/FioTools.ts
+++ b/src/fio/FioTools.ts
@@ -1,5 +1,6 @@
 import { FIOSDK } from '@fioprotocol/fiosdk'
 import { AvailabilityResponse } from '@fioprotocol/fiosdk/lib/entities/AvailabilityResponse'
+import type { PublicAddressResponse } from '@fioprotocol/fiosdk/lib/entities/PublicAddressResponse'
 import { PrivateKey } from '@greymass/eosio'
 import { div } from 'biggystring'
 import { validateMnemonic } from 'bip39'
@@ -16,7 +17,7 @@ import {
 } from 'edge-core-js/types'
 
 import { PluginEnvironment } from '../common/innerPlugin'
-import { asyncWaterfall } from '../common/promiseUtils'
+import { asyncWaterfall, promisesAgree, timeout } from '../common/promiseUtils'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
 import {
   getLegacyDenomination,
@@ -530,43 +531,66 @@ export class FioTools implements EdgeCurrencyTools {
     actionName: string,
     params?: any
   ): Promise<any> {
-    const res = await asyncWaterfall(
-      shuffleArray(
-        this.networkInfo.apiUrls.map(apiUrl => async () => {
-          let out
+    const requestServer = async (apiUrl: string): Promise<any> => {
+      let out
 
-          const connection = new FIOSDK(
-            '',
-            '',
-            apiUrl,
-            this.engineFetch,
-            undefined,
-            this.tpid
-          )
+      const connection = new FIOSDK(
+        '',
+        '',
+        apiUrl,
+        this.engineFetch,
+        undefined,
+        this.tpid
+      )
 
-          try {
-            out = await connection.genericAction(actionName, params)
-          } catch (e: any) {
-            // handle FIO API error
-            if (e.errorCode != null && fioApiErrorCodes.includes(e.errorCode)) {
-              out = {
-                isError: true,
-                data: {
-                  code: e.errorCode,
-                  message: safeErrorMessage(e),
-                  json: e.json,
-                  list: e.list
-                }
-              }
-            } else {
-              throw e
+      try {
+        out = await connection.genericAction(actionName, params)
+      } catch (e: any) {
+        // handle FIO API error
+        if (e.errorCode != null && fioApiErrorCodes.includes(e.errorCode)) {
+          out = {
+            isError: true,
+            data: {
+              code: e.errorCode,
+              message: safeErrorMessage(e),
+              json: e.json,
+              list: e.list
             }
           }
+        } else {
+          throw e
+        }
+      }
 
-          return out
-        })
-      )
-    )
+      return out
+    }
+
+    const res =
+      actionName === 'getPublicAddress'
+        ? await promisesAgree(
+            this.networkInfo.apiUrls.map(async apiUrl => {
+              const out = await timeout(requestServer(apiUrl), 10000)
+              if (out.isError != null) {
+                const error = new FioError(out.data.message)
+                error.json = out.data.json
+                error.list = out.data.list
+                error.errorCode = out.data.code
+                throw error
+              }
+              return out
+            }),
+            (result: PublicAddressResponse) => {
+              return result.public_address
+            },
+            3
+          )
+        : await asyncWaterfall(
+            shuffleArray(
+              this.networkInfo.apiUrls.map(apiUrl => async () => {
+                return await requestServer(apiUrl)
+              })
+            )
+          )
 
     if (res.isError != null) {
       const error = new FioError(res.errorMessage)

--- a/src/fio/fioTypes.ts
+++ b/src/fio/fioTypes.ts
@@ -1,5 +1,6 @@
 import type { BalanceResponse } from '@fioprotocol/fiosdk/lib/entities/BalanceResponse'
 import type { FioNamesResponse } from '@fioprotocol/fiosdk/lib/entities/FioNamesResponse'
+import type { PublicAddress } from '@fioprotocol/fiosdk/lib/entities/PublicAddress'
 import {
   asArray,
   asBoolean,
@@ -44,6 +45,14 @@ export interface FioNetworkInfo {
 }
 
 export type FioRequestTypes = 'PENDING' | 'SENT'
+
+// The FIO chain/get_pub_addresses endpoint returns `public_addresses`, but
+// the SDK's `PublicAddressesResponse` type incorrectly names the field
+// `requests`. Define a local interface that matches the actual API response.
+export interface FioGetPubAddressesResponse {
+  public_addresses: PublicAddress[]
+  more: boolean
+}
 
 export interface FioRefBlock {
   expiration: string


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FIO public-address resolution from first-success to quorum-based agreement across multiple API nodes, which may impact reliability/latency and surface new error paths if nodes disagree or time out.
> 
> **Overview**
> **Improves FIO public address resolution robustness** by switching `getPublicAddress` (in `FioTools`) and `getPublicAddresses` (in `FioEngine`) to use `promisesAgree` with timeouts, requiring multiple nodes to return matching results before accepting a response.
> 
> Adds explicit error propagation for per-node FIO API error payloads during these quorum calls, and introduces a local `FioGetPubAddressesResponse` type to match the actual `get_pub_addresses` API response shape (working around an SDK typing mismatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd852f1df29e56b82c2e0df6bbcc263b094d72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214373920757188