### PR TITLE
fix: HyperEVM transaction sync via Etherscan V2 and longer lookback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (HyperEVM) Use Etherscan V2 (api.etherscan.io) as the primary transaction-history source and increase the query lookback to 5 minutes, fixing slow/missing transaction list syncing.
+
 ## 4.83.0 (2026-06-12)
 
 - changed: Convert the build tooling from Yarn to npm.

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -118,7 +118,7 @@ const networkFees: EthereumFees = {
 }
 
 const networkInfo: EthereumNetworkInfo = {
-  addressQueryLookbackBlocks: 120, // 2 minutes
+  addressQueryLookbackBlocks: 300, // 5 minutes
   networkAdapterConfigs: [
     {
       type: 'rpc',
@@ -132,7 +132,10 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: ['https://api.routescan.io/v2/network/mainnet/evm/999/etherscan']
+      servers: [
+        'https://api.etherscan.io',
+        'https://api.routescan.io/v2/network/mainnet/evm/999/etherscan'
+      ]
     }
   ],
   uriNetworks: [],


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Hardens HyperEVM (HYPE) transaction-list syncing, which gets stuck (balance updates, but the tx list shows "Loading Transactions... 50%" indefinitely until a manual resync).

**Root cause (verified in-app and at the data/config layer)**

HyperEVM (chainId 999) has exactly one working transaction source: Etherscan V2 (`https://api.etherscan.io/v2/api?chainid=999`), and only WITH the shared Etherscan V2 key. Every other option fails for chain 999: the old `routescan` evmscan server now returns `{"status":"0","message":"chain not supported"}`, `hyperevmscan.io` has no working V2 endpoint, and Etherscan V2 without a key returns `Missing/Invalid API Key`.

The `evmscan` adapter resolves its key in `getEvmScanApiKey`: for an `etherscan.io` server it requires the `etherscanApiKey` init option and THROWS `Missing etherscanApiKey for etherscan.io` when it is absent. HyperEVM's plugin init never carried that key, so the etherscan.io call throws before any request goes out, `asyncWaterfall` falls through to the dead routescan server, that throws too, `fetchTxs` throws, and `setHistoryRatios` is never reached. The wallet sync ratio is `(balanceRatio + historyRatio) / 2`; balance reaches 1 via the RPC adapter while history stays 0, so the wallet sits at the "50%" loader forever.

**Why it was still stuck after the info-server change**

The controlling server list is the info server, not this file: at runtime `updateInfoPayload` merges the info-server `coreRollup` payload over the built-in `networkInfo`. The info server already serves `api.etherscan.io` for HyperEVM (`coreRollup` `networkAdapterConfigs.evmscan.servers = [api.etherscan.io, routescan]`). But that payload carries no API key, and keys come only from plugin init options. So adding the server did nothing on its own: HyperEVM still had no `etherscanApiKey`, so etherscan.io could not authenticate.

**The live fix (not in this repo)**

Provision the shared Etherscan V2 key to the HyperEVM plugin init (`HYPEREVM_INIT.etherscanApiKey`), the same key 19 other etherscan.io chains already carry. That is an app build-secrets change, not a code change. Verified in-app on the iOS sim (edge-funds HYPE wallet) with the key provisioned and the production info-server config: the HYPE transaction list syncs fully and shows real send/receive history (no "50%" loader). Confirmed with the published `edge-currency-accountbased` (no code from this branch linked), so the key is the only change needed.

**What this PR changes (supporting hardening, not the live unstick)**

1. `addressQueryLookbackBlocks` 120 -> 300 (~2 min -> ~5 min at the measured ~1 s/block). The info payload does NOT override this field, so it is effective in production and makes incremental sync more resilient to indexer lag (mirrors the avalanche precedent for the same symptom).
2. Add `https://api.etherscan.io` as the primary evmscan server, kept as the correct built-in default and fallback for when the info server is unavailable or omits the override. The live fix still requires the key provisioning above.

Screenshots: synced HYPE transaction list (after the key is provisioned).

---
Asana: https://app.asana.com/0/1215088146871429/1211390103547275
