### PR TITLE
Derive Avalanche C-Chain addresses at coin type 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Avalanche) Derive C-Chain addresses at coin type 60 so seeds imported from EVM wallets (Exodus, MetaMask, Trust) produce a matching receive address. Existing wallets keep their cached address and are unaffected.
+
 ## 4.82.1 (2026-05-27)
 
 - changed: (FIO) Replace forked `@fioprotocol/fiosdk` with official npm 1.10.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- fixed: (Avalanche) Derive C-Chain addresses at coin type 60 so seeds imported from EVM wallets (Exodus, MetaMask, Trust) produce a matching receive address. Existing wallets keep their cached address and are unaffected.
+- added: (EVM) Save the BIP-44 derivation path in wallet keys, so wallets created before a coin type correction keep deriving at the path their stored private key was built from.
+- fixed: (Avalanche) Derive C-Chain addresses at coin type 60 so seeds imported from EVM wallets (Exodus, MetaMask, Trust) produce a matching receive address. Existing wallets are unaffected.
 
 ## 4.82.1 (2026-05-27)
 

--- a/src/ethereum/EthereumTools.ts
+++ b/src/ethereum/EthereumTools.ts
@@ -37,6 +37,12 @@ import {
 } from './ethereumTypes'
 import { RpcAdapterConfig } from './networkAdapters/RpcAdapter'
 
+/**
+ * The BIP-44 path an EVM wallet's first account lives at.
+ */
+const makeHdPath = (hdPathCoinType: number): string =>
+  `m/44'/${hdPathCoinType}'/0'/0/0`
+
 export class EthereumTools implements EdgeCurrencyTools {
   builtinTokens: EdgeTokenMap
   currencyInfo: EdgeCurrencyInfo
@@ -94,10 +100,12 @@ export class EthereumTools implements EdgeCurrencyTools {
         // was just the wrong length
         throw new Error('Invalid input')
       }
-      const hexKey = await this._mnemonicToHex(userInput)
+      const derivationPath = makeHdPath(this.networkInfo.hdPathCoinType)
+      const hexKey = await this._mnemonicToHex(userInput, derivationPath)
       return {
         [pluginMnemonicKeyName]: userInput,
-        [pluginRegularKeyName]: hexKey
+        [pluginRegularKeyName]: hexKey,
+        derivationPath
       }
     }
   }
@@ -113,17 +121,24 @@ export class EthereumTools implements EdgeCurrencyTools {
     const entropy = Buffer.from(this.io.random(32))
     const mnemonicKey = entropyToMnemonic(entropy)
 
-    const hexKey = await this._mnemonicToHex(mnemonicKey) // will not have 0x in it
+    const derivationPath = makeHdPath(this.networkInfo.hdPathCoinType)
+    // will not have 0x in it:
+    const hexKey = await this._mnemonicToHex(mnemonicKey, derivationPath)
     return {
       [pluginMnemonicKeyName]: mnemonicKey,
-      [pluginRegularKeyName]: hexKey
+      [pluginRegularKeyName]: hexKey,
+      derivationPath
     }
   }
 
   async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<Object> {
     const { pluginId } = this.currencyInfo
-    const { hdPathCoinType, pluginMnemonicKeyName, pluginRegularKeyName } =
-      this.networkInfo
+    const {
+      hdPathCoinType,
+      legacyHdPathCoinType,
+      pluginMnemonicKeyName,
+      pluginRegularKeyName
+    } = this.networkInfo
     if (walletInfo.type !== `wallet:${pluginId}`) {
       throw new Error('Invalid wallet type')
     }
@@ -134,8 +149,17 @@ export class EthereumTools implements EdgeCurrencyTools {
         walletInfo.keys[pluginMnemonicKeyName]
       )
       const hdwallet = hdKey.fromMasterSeed(seedBuffer)
-      const walletHdpath = `m/44'/${hdPathCoinType}'/0'/0`
-      const walletPathDerivation = hdwallet.derivePath(`${walletHdpath}/0`)
+      // Wallets created since the plugin started saving `derivationPath` carry
+      // the path they were built from. Older ones do not, and their stored
+      // private key was derived from the coin type of that era, so they must
+      // keep deriving from it or the address would stop matching the key that
+      // signs for it.
+      const savedPath = walletInfo.keys.derivationPath
+      const walletHdpath =
+        typeof savedPath === 'string'
+          ? savedPath
+          : makeHdPath(legacyHdPathCoinType ?? hdPathCoinType)
+      const walletPathDerivation = hdwallet.derivePath(walletHdpath)
       const wallet = walletPathDerivation.getWallet()
       const publicKey = wallet.getPublicKey()
       const addressHex = EthereumUtil.pubToAddress(publicKey).toString('hex')
@@ -158,11 +182,9 @@ export class EthereumTools implements EdgeCurrencyTools {
     return { publicKey: address }
   }
 
-  async _mnemonicToHex(mnemonic: string): Promise<string> {
-    const { hdPathCoinType } = this.networkInfo
+  async _mnemonicToHex(mnemonic: string, path: string): Promise<string> {
     const hdwallet = hdKey.fromMasterSeed(mnemonicToSeedSync(mnemonic))
-    const walletHdpath = `m/44'/${hdPathCoinType}'/0'/0`
-    const walletPathDerivation = hdwallet.derivePath(`${walletHdpath}/0`)
+    const walletPathDerivation = hdwallet.derivePath(path)
     const wallet = walletPathDerivation.getWallet()
     const privKey = wallet.getPrivateKeyString().replace(/^0x/, '')
     return privKey

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -110,6 +110,10 @@ export interface EthereumNetworkInfo {
   ercTokenStandard: string
   evmGasStationUrl: string | null
   hdPathCoinType: number
+  // Coin type wallets used before `hdPathCoinType` was corrected. Wallets
+  // created back then have no `derivationPath` in their keys, so they derive
+  // from this instead and keep the address their stored private key signs for.
+  legacyHdPathCoinType?: number
   networkFees: EthereumFees
   pluginMnemonicKeyName: string
   pluginRegularKeyName: string
@@ -461,6 +465,7 @@ export const asSafeEthWalletInfo = asSafeCommonWalletInfo
 export interface EthereumPrivateKeys {
   mnemonic?: string
   privateKey: string
+  derivationPath?: string
 }
 export const asEthereumPrivateKeys = (
   pluginId: string
@@ -472,12 +477,13 @@ export const asEthereumPrivateKeys = (
   } &
     {
       [key in `${PluginId}Mnemonic`]?: string
-    }
+    } & { derivationPath?: string }
   const _pluginId = pluginId as PluginId
   // Derived cleaners from the generic parameter:
   const asFromKeys: Cleaner<FromKeys> = asObject({
     [`${_pluginId}Mnemonic`]: asOptional(asString),
-    [`${_pluginId}Key`]: asString
+    [`${_pluginId}Key`]: asString,
+    derivationPath: asOptional(asString)
   }) as Cleaner<any>
   const asFromJackedKeys = asObject({ keys: asFromKeys })
 
@@ -488,7 +494,8 @@ export const asEthereumPrivateKeys = (
       if (fromJacked != null) {
         const to: EthereumPrivateKeys = {
           mnemonic: fromJacked.keys[`${_pluginId}Mnemonic`],
-          privateKey: fromJacked.keys[`${_pluginId}Key`]
+          privateKey: fromJacked.keys[`${_pluginId}Key`],
+          derivationPath: fromJacked.keys.derivationPath
         }
         return to
       }
@@ -497,14 +504,16 @@ export const asEthereumPrivateKeys = (
       const from = asFromKeys(value)
       const to: EthereumPrivateKeys = {
         mnemonic: from[`${_pluginId}Mnemonic`],
-        privateKey: from[`${_pluginId}Key`]
+        privateKey: from[`${_pluginId}Key`],
+        derivationPath: from.derivationPath
       }
       return to
     },
     ethPrivateKey => {
       return {
         [`${_pluginId}Mnemonic`]: ethPrivateKey.mnemonic,
-        [`${_pluginId}Key`]: ethPrivateKey.privateKey
+        [`${_pluginId}Key`]: ethPrivateKey.privateKey,
+        derivationPath: ethPrivateKey.derivationPath
       }
     }
   )

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -212,7 +212,9 @@ const networkInfo: EthereumNetworkInfo = {
     name: 'AVAX Mainnet'
   },
   supportsEIP1559: true,
-  hdPathCoinType: 9000,
+  // AVAX C-Chain is EVM and standard wallets (Exodus, MetaMask, Trust) derive it
+  // at Ethereum's coin type so imported seeds yield a matching receive address.
+  hdPathCoinType: 60,
   pluginMnemonicKeyName: 'avalancheMnemonic',
   pluginRegularKeyName: 'avalancheKey',
   evmGasStationUrl: null,

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -215,6 +215,7 @@ const networkInfo: EthereumNetworkInfo = {
   // AVAX C-Chain is EVM and standard wallets (Exodus, MetaMask, Trust) derive it
   // at Ethereum's coin type so imported seeds yield a matching receive address.
   hdPathCoinType: 60,
+  legacyHdPathCoinType: 9000,
   pluginMnemonicKeyName: 'avalancheMnemonic',
   pluginRegularKeyName: 'avalancheKey',
   evmGasStationUrl: null,

--- a/test/ethereum/avalancheDerivation.test.ts
+++ b/test/ethereum/avalancheDerivation.test.ts
@@ -1,0 +1,63 @@
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyPlugin,
+  EdgeCurrencyTools,
+  makeFakeIo
+} from 'edge-core-js'
+import { before, describe, it } from 'mocha'
+import fetch from 'node-fetch'
+
+import edgeCorePlugins from '../../src/index'
+import { fakeLog } from '../fake/fakeLog'
+
+// A 12-word seed and the receive address it yields on EVM wallets (Exodus,
+// MetaMask, Trust) which all derive at coin type 60. Ethereum, Polygon and
+// Avalanche C-Chain are all EVM, so importing this seed into Edge must produce
+// the same address on each. Avalanche was the regression (it derived at coin
+// type 9000); Ethereum and Polygon are the chains the report flagged as most
+// important, so they are locked here too.
+const MNEMONIC =
+  'room soda device label bicycle hill fork nest lion knee purpose hen'
+const EXPECTED_EVM_ADDRESS = '0x21D45Fd06e291C49AbFa135460DE827b6579Cef5'
+
+const makeOpts = (): EdgeCorePluginOptions => {
+  const fakeIo = makeFakeIo()
+  return {
+    infoPayload: {},
+    initOptions: {},
+    io: { ...fakeIo, fetch, fetchCors: fetch },
+    log: fakeLog,
+    nativeIo: {},
+    pluginDisklet: fakeIo.disklet
+  }
+}
+
+const CASES = [
+  { pluginId: 'ethereum', mnemonicKey: 'ethereumMnemonic' },
+  { pluginId: 'polygon', mnemonicKey: 'polygonMnemonic' },
+  { pluginId: 'avalanche', mnemonicKey: 'avalancheMnemonic' }
+] as const
+
+describe('EVM derivation parity (coin type 60)', function () {
+  for (const { pluginId, mnemonicKey } of CASES) {
+    describe(pluginId, function () {
+      let tools: EdgeCurrencyTools
+
+      before('Tools', async function () {
+        const factory = edgeCorePlugins[pluginId]
+        const plugin: EdgeCurrencyPlugin = factory(makeOpts())
+        tools = await plugin.makeCurrencyTools()
+      })
+
+      it('derives the Exodus-matching EVM address from an imported seed', async function () {
+        const keys = await tools.derivePublicKey({
+          id: 'id',
+          keys: { [mnemonicKey]: MNEMONIC },
+          type: `wallet:${pluginId}`
+        })
+        assert.equal(keys.publicKey, EXPECTED_EVM_ADDRESS)
+      })
+    })
+  }
+})

--- a/test/ethereum/avalancheDerivation.test.ts
+++ b/test/ethereum/avalancheDerivation.test.ts
@@ -1,0 +1,47 @@
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyPlugin,
+  EdgeCurrencyTools,
+  makeFakeIo
+} from 'edge-core-js'
+import { before, describe, it } from 'mocha'
+import fetch from 'node-fetch'
+
+import edgeCorePlugins from '../../src/index'
+import { fakeLog } from '../fake/fakeLog'
+
+// A 12-word seed and the receive address it yields on EVM wallets (Exodus,
+// MetaMask, Trust) which all derive at coin type 60. Avalanche C-Chain is EVM,
+// so importing this seed into Edge must produce the same address.
+const MNEMONIC =
+  'room soda device label bicycle hill fork nest lion knee purpose hen'
+const EXPECTED_EVM_ADDRESS = '0x21D45Fd06e291C49AbFa135460DE827b6579Cef5'
+
+describe('Avalanche derivation parity', function () {
+  let tools: EdgeCurrencyTools
+
+  before('Tools', async function () {
+    const fakeIo = makeFakeIo()
+    const opts: EdgeCorePluginOptions = {
+      infoPayload: {},
+      initOptions: {},
+      io: { ...fakeIo, fetch, fetchCors: fetch },
+      log: fakeLog,
+      nativeIo: {},
+      pluginDisklet: fakeIo.disklet
+    }
+    const factory = edgeCorePlugins.avalanche
+    const plugin: EdgeCurrencyPlugin = factory(opts)
+    tools = await plugin.makeCurrencyTools()
+  })
+
+  it('derives the EVM (coin type 60) address from an imported seed', async function () {
+    const keys = await tools.derivePublicKey({
+      id: 'id',
+      keys: { avalancheMnemonic: MNEMONIC },
+      type: 'wallet:avalanche'
+    })
+    assert.equal(keys.publicKey, EXPECTED_EVM_ADDRESS)
+  })
+})

--- a/test/ethereum/avalancheDerivation.test.ts
+++ b/test/ethereum/avalancheDerivation.test.ts
@@ -12,36 +12,52 @@ import edgeCorePlugins from '../../src/index'
 import { fakeLog } from '../fake/fakeLog'
 
 // A 12-word seed and the receive address it yields on EVM wallets (Exodus,
-// MetaMask, Trust) which all derive at coin type 60. Avalanche C-Chain is EVM,
-// so importing this seed into Edge must produce the same address.
+// MetaMask, Trust) which all derive at coin type 60. Ethereum, Polygon and
+// Avalanche C-Chain are all EVM, so importing this seed into Edge must produce
+// the same address on each. Avalanche was the regression (it derived at coin
+// type 9000); Ethereum and Polygon are the chains the report flagged as most
+// important, so they are locked here too.
 const MNEMONIC =
   'room soda device label bicycle hill fork nest lion knee purpose hen'
 const EXPECTED_EVM_ADDRESS = '0x21D45Fd06e291C49AbFa135460DE827b6579Cef5'
 
-describe('Avalanche derivation parity', function () {
-  let tools: EdgeCurrencyTools
+const makeOpts = (): EdgeCorePluginOptions => {
+  const fakeIo = makeFakeIo()
+  return {
+    infoPayload: {},
+    initOptions: {},
+    io: { ...fakeIo, fetch, fetchCors: fetch },
+    log: fakeLog,
+    nativeIo: {},
+    pluginDisklet: fakeIo.disklet
+  }
+}
 
-  before('Tools', async function () {
-    const fakeIo = makeFakeIo()
-    const opts: EdgeCorePluginOptions = {
-      infoPayload: {},
-      initOptions: {},
-      io: { ...fakeIo, fetch, fetchCors: fetch },
-      log: fakeLog,
-      nativeIo: {},
-      pluginDisklet: fakeIo.disklet
-    }
-    const factory = edgeCorePlugins.avalanche
-    const plugin: EdgeCurrencyPlugin = factory(opts)
-    tools = await plugin.makeCurrencyTools()
-  })
+const CASES = [
+  { pluginId: 'ethereum', mnemonicKey: 'ethereumMnemonic' },
+  { pluginId: 'polygon', mnemonicKey: 'polygonMnemonic' },
+  { pluginId: 'avalanche', mnemonicKey: 'avalancheMnemonic' }
+] as const
 
-  it('derives the EVM (coin type 60) address from an imported seed', async function () {
-    const keys = await tools.derivePublicKey({
-      id: 'id',
-      keys: { avalancheMnemonic: MNEMONIC },
-      type: 'wallet:avalanche'
+describe('EVM derivation parity (coin type 60)', function () {
+  for (const { pluginId, mnemonicKey } of CASES) {
+    describe(pluginId, function () {
+      let tools: EdgeCurrencyTools
+
+      before('Tools', async function () {
+        const factory = edgeCorePlugins[pluginId]
+        const plugin: EdgeCurrencyPlugin = factory(makeOpts())
+        tools = await plugin.makeCurrencyTools()
+      })
+
+      it('derives the Exodus-matching EVM address from an imported seed', async function () {
+        const keys = await tools.derivePublicKey({
+          id: 'id',
+          keys: { [mnemonicKey]: MNEMONIC },
+          type: `wallet:${pluginId}`
+        })
+        assert.equal(keys.publicKey, EXPECTED_EVM_ADDRESS)
+      })
     })
-    assert.equal(keys.publicKey, EXPECTED_EVM_ADDRESS)
-  })
+  }
 })

--- a/test/ethereum/avalancheDerivation.test.ts
+++ b/test/ethereum/avalancheDerivation.test.ts
@@ -3,6 +3,7 @@ import {
   EdgeCorePluginOptions,
   EdgeCurrencyPlugin,
   EdgeCurrencyTools,
+  JsonObject,
   makeFakeIo
 } from 'edge-core-js'
 import { before, describe, it } from 'mocha'
@@ -21,6 +22,11 @@ const MNEMONIC =
   'room soda device label bicycle hill fork nest lion knee purpose hen'
 const EXPECTED_EVM_ADDRESS = '0x21D45Fd06e291C49AbFa135460DE827b6579Cef5'
 
+// What the same seed yields at Avalanche's old coin type 9000. Wallets created
+// before the correction hold a private key derived at that path, so they must
+// keep resolving to this address.
+const LEGACY_AVAX_ADDRESS = '0xc0Ee5411B61513Bea1853692463e28D6c32A0b50'
+
 const makeOpts = (): EdgeCorePluginOptions => {
   const fakeIo = makeFakeIo()
   return {
@@ -31,6 +37,25 @@ const makeOpts = (): EdgeCorePluginOptions => {
     nativeIo: {},
     pluginDisklet: fakeIo.disklet
   }
+}
+
+const makeTools = async (
+  pluginId: keyof typeof edgeCorePlugins
+): Promise<EdgeCurrencyTools> => {
+  const factory = edgeCorePlugins[pluginId]
+  const plugin: EdgeCurrencyPlugin = factory(makeOpts())
+  return await plugin.makeCurrencyTools()
+}
+
+/** `EdgeCurrencyTools.importPrivateKey` is optional, but EVM plugins have it. */
+const importPrivateKey = async (
+  tools: EdgeCurrencyTools,
+  userInput: string
+): Promise<JsonObject> => {
+  if (tools.importPrivateKey == null) {
+    throw new Error('Plugin does not support importPrivateKey')
+  }
+  return await tools.importPrivateKey(userInput)
 }
 
 const CASES = [
@@ -45,19 +70,55 @@ describe('EVM derivation parity (coin type 60)', function () {
       let tools: EdgeCurrencyTools
 
       before('Tools', async function () {
-        const factory = edgeCorePlugins[pluginId]
-        const plugin: EdgeCurrencyPlugin = factory(makeOpts())
-        tools = await plugin.makeCurrencyTools()
+        tools = await makeTools(pluginId)
       })
 
       it('derives the Exodus-matching EVM address from an imported seed', async function () {
+        const importedKeys = await importPrivateKey(tools, MNEMONIC)
+        assert.equal(importedKeys[mnemonicKey], MNEMONIC)
+        assert.equal(importedKeys.derivationPath, "m/44'/60'/0'/0/0")
+
         const keys = await tools.derivePublicKey({
           id: 'id',
-          keys: { [mnemonicKey]: MNEMONIC },
+          keys: importedKeys,
           type: `wallet:${pluginId}`
         })
         assert.equal(keys.publicKey, EXPECTED_EVM_ADDRESS)
       })
     })
   }
+})
+
+describe('Avalanche legacy wallets', function () {
+  let tools: EdgeCurrencyTools
+
+  before('Tools', async function () {
+    tools = await makeTools('avalanche')
+  })
+
+  it('keeps the coin type 9000 address when no path was saved', async function () {
+    // The shape of a wallet created before the plugin saved `derivationPath`:
+    // its stored private key was derived at coin type 9000, so re-deriving the
+    // public key on a new device has to land on the same address.
+    const keys = await tools.derivePublicKey({
+      id: 'id',
+      keys: { avalancheMnemonic: MNEMONIC },
+      type: 'wallet:avalanche'
+    })
+    assert.equal(keys.publicKey, LEGACY_AVAX_ADDRESS)
+  })
+
+  it('derives the private key at the saved path', async function () {
+    const importedKeys = await importPrivateKey(tools, MNEMONIC)
+    const publicKeys = await tools.derivePublicKey({
+      id: 'id',
+      // Only the private key, as if the mnemonic were never saved:
+      keys: { avalancheKey: importedKeys.avalancheKey },
+      type: 'wallet:avalanche'
+    })
+    assert.equal(
+      publicKeys.publicKey.toLowerCase(),
+      EXPECTED_EVM_ADDRESS.toLowerCase()
+    )
+  })
 })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Avalanche C-Chain is EVM-compatible, and standard wallets (Exodus, MetaMask, Trust) derive its address at Ethereum's BIP-44 coin type `60`. Edge derived Avalanche at coin type `9000` (the SLIP-44 X/P-Chain type), so a 12-word seed imported from one of those wallets produced an AVAX receive address that did **not** match the source wallet, the bug reported on the Asana task (ETH/POL matched, AVAX did not).

This switches `avalancheInfo.hdPathCoinType` from `9000` to `60`, bringing AVAX in line with every other EVM network in this repo.

**Existing wallets keep their old address.** The plugin now saves the BIP-44 path it derived from into the wallet keys (`derivationPath`, the same shape `TronTools` already uses), and `derivePublicKey` derives from that saved path when it is present. Keys with no saved path predate the correction, so they fall back to the new `EthereumNetworkInfo.legacyHdPathCoinType`, set to `9000` on avalanche only. Without that fallback an existing wallet re-derived on a new device would have displayed a coin-type-60 address while its stored `avalancheKey` still signed for the coin-type-9000 one, leaving anything sent to the displayed address unspendable in the app. This is the incomplete-fix case raised in review.

**Verification**

- `test/ethereum/avalancheDerivation.test.ts` covers three things: ethereum, polygon and avalanche all derive `0x21D45Fd06e291C49AbFa135460DE827b6579Cef5` from one imported seed (driven through `importPrivateKey`, so the saved path is what gets exercised); a path-less avalanche keys object still derives the legacy `0xc0Ee5411B61513Bea1853692463e28D6c32A0b50`; and a keys object holding only the private key resolves to the coin-type-60 address.
- `tsc`, eslint and the full test suite pass (`verify-repo.sh`).
- The coin-type-60 fix was driven end to end in the iOS simulator on an earlier segment: importing the affected seed into a fresh AVAX wallet showed `0x21D4...Cef5` on the receive scene, against `0xc0Ee...0b50` on a pre-fix build.

Asana: https://app.asana.com/0/1215088146871429/1209918996092096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HD derivation for new/imported Avalanche wallets; existing wallets keep cached keys per PR description, but any code path that re-derives without cache could diverge from old 9000 addresses.
> 
> **Overview**
> Fixes **Avalanche C-Chain** receive addresses for **new/imported** wallets by changing BIP-44 derivation from coin type **9000** to **60** in `avalancheInfo`, matching Exodus, MetaMask, Trust and other EVM wallets.
> 
> Documents the fix in **CHANGELOG** and adds **`test/ethereum/avalancheDerivation.test.ts`**, which asserts `derivePublicKey` for **ethereum**, **polygon**, and **avalanche** all yield the same known coin-type-60 address from a fixed 12-word seed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a67d28bec84433c66e04eae459a3c972731a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-currency-accountbased/pull/1057/commits/7119116216d2785ea77ede4aac54e3aaadc7bff7"><code>7119116</code></a><br><sub>Derive Avalanche C-Chain addresses at coin type 60</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260609-232539-01-AVAX-receive-PRE-FIX-derives-coinType-9000-address-does-not-match-Exodus.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260609-232539-01-AVAX-receive-PRE-FIX-derives-coinType-9000-address-does-not-match-Exodus.png" width="200"></a><br><sub>AVAX receive PRE FIX derives coinType 9000 address does not match Exodus</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260612-150734-01-imported-seed-fixed-coin-type-60-0x21D45Fd06e291C49AbFa135460DE827b6579Cef5.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260612-150734-01-imported-seed-fixed-coin-type-60-0x21D45Fd06e291C49AbFa135460DE827b6579Cef5.png" width="200"></a><br><sub>imported seed fixed coin type 60 0x21D45Fd06e291C49AbFa135460DE827b6579Cef5</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260612-150734-02-same-seed-pre-fix-coin-type-9000-0xc0Ee5411B61513Bea1853692463e28D6c32A0b50.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1057/20260612-150734-02-same-seed-pre-fix-coin-type-9000-0xc0Ee5411B61513Bea1853692463e28D6c32A0b50.png" width="200"></a><br><sub>same seed pre fix coin type 9000 0xc0Ee5411B61513Bea1853692463e28D6c32A0b50</sub></td>
</tr>
</table>
<!-- agent-test-evidence:end -->