### PR TITLE
ton: fix duplicate transactions by reconciling broadcast txid with chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: ton - Resolve duplicate transactions by reading the broadcast tx's real on-chain hash back from the chain, so the pending tx reconciles into the confirmed one instead of being orphaned.
+
 ## 4.83.0 (2026-06-12)
 
 - changed: Convert the build tooling from Yarn to npm.

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -436,42 +436,42 @@ export class TonEngine extends CurrencyEngine<
       })
       asDrpcSendBoc(sendRaw)
 
-      if (this.otherData.contractState === 'uninitialized') {
-        // The txid for a wallet's deploy tx can't be calculated locally,
-        // so poll for the transaction whose inbound external message
-        // carries a StateInit (init_state) — that's the deploy.
-        const addr = encodeURIComponent(this.wallet.address.toRawString())
-        let attempts = 0
-        do {
-          attempts++
-          await snooze(1000)
-          try {
-            const raw = await this.tools.fetchDrpc(
-              `/getTransactions?address=${addr}&limit=100`
-            )
-            const { result: txs } = asDrpcGetTransactions(raw)
-            for (const tx of txs) {
-              const { in_msg: inMsg } = tx
-              if (inMsg.source === '' && inMsg.msg_data.init_state != null) {
-                const hashBytes = base64.parse(tx.transaction_id.hash)
-                edgeTransaction.txid = base16.stringify(hashBytes).toLowerCase()
-                edgeTransaction.date = Date.now() / 1000
-                this.otherData.contractState = 'active'
-                this.walletLocalDataDirty = true
-                return edgeTransaction
-              }
+      // The on-chain transaction hash is unrelated to any locally-computable
+      // hash (e.g. the external-message BOC hash), so the txid must be read
+      // back from the chain — otherwise the pending tx is keyed by a hash the
+      // chain never reports and queryTransactions records the confirmed tx as
+      // a separate duplicate. Poll for the transaction whose inbound message
+      // body matches the signed transfer we broadcast, then adopt its on-chain
+      // transaction hash — the same hash processTonTransaction records, so the
+      // pending tx reconciles into the confirmed one.
+      const bodyHash = base64.stringify(txCell.hash())
+      const addr = encodeURIComponent(this.wallet.address.toRawString())
+      let attempts = 0
+      do {
+        attempts++
+        await snooze(1000)
+        try {
+          const raw = await this.tools.fetchDrpc(
+            `/getTransactions?address=${addr}&limit=100`
+          )
+          const { result: txs } = asDrpcGetTransactions(raw)
+          for (const tx of txs) {
+            if (tx.in_msg.body_hash !== bodyHash) continue
+            const hashBytes = base64.parse(tx.transaction_id.hash)
+            edgeTransaction.txid = base16.stringify(hashBytes).toLowerCase()
+            edgeTransaction.date = Date.now() / 1000
+            if (needsInit) {
+              // The first outgoing tx deploys the wallet contract.
+              this.otherData.contractState = 'active'
+              this.walletLocalDataDirty = true
             }
-          } catch (e) {
-            // retry
+            return edgeTransaction
           }
-        } while (attempts <= 30) // In testing, the tx was found after ~10 seconds
-        throw new Error('Transaction broadcast but unable to find txid')
-      } else {
-        const txid = base16.stringify(externalBoc.hash()).toLowerCase()
-        edgeTransaction.txid = txid
-        edgeTransaction.date = Date.now() / 1000
-        return edgeTransaction
-      }
+        } catch (e) {
+          // retry
+        }
+      } while (attempts <= 30) // In testing, the tx was found after ~10 seconds
+      throw new Error('Transaction broadcast but unable to find txid')
     } catch (e) {
       this.log.warn('FAILURE broadcastTx failed: ', e)
       throw e

--- a/src/ton/tonDrpc.ts
+++ b/src/ton/tonDrpc.ts
@@ -3,7 +3,6 @@ import {
   asEither,
   asNumber,
   asObject,
-  asOptional,
   asString,
   asUnknown
 } from 'cleaners'
@@ -94,13 +93,11 @@ const asDrpcTransactionId = asObject({
   hash: asString
 })
 
-const asDrpcMsgData = asObject({
-  init_state: asOptional(asString)
-})
-
 const asDrpcInMsg = asObject({
-  source: asString,
-  msg_data: asDrpcMsgData
+  // base64 hash of the inbound message body. For an outgoing tx this is the
+  // hash of the signed transfer cell we broadcast, letting us match the
+  // on-chain transaction back to the one we sent.
+  body_hash: asString
 })
 
 export const asDrpcGetTransactions = asObject({


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/0/1215088146871429/1208857053925054

Fixes TON duplicate transactions. After sending a TON tx, the sent tx stayed stuck on `Pending` forever while a second, separately-confirmed `Sent` tx appeared — a duplicate (reproducible even on a wallet's first transaction).

**Root cause.** The pending tx and the confirmed tx were keyed by two unrelated hashes, so the engine never reconciled them:

- `broadcastTx` (active-contract path) recorded the txid as the **external-message BOC hash** (`externalBoc.hash()`).
- `queryTransactions` → `processTonTransaction` records the txid as the **on-chain transaction hash** (`parse_tx` returns `tx.hash()`).

The external-message hash is never echoed by the chain query, so when the poll discovered the same transaction on-chain it was treated as brand-new (duplicate) and the pending entry was orphaned. The deploy path already handled this correctly by polling `/getTransactions` and reading back the real on-chain `transaction_id.hash`.

**Fix.** `broadcastTx` now reads the txid back from the chain for both the deploy and active-contract paths: after `/sendBoc`, it polls `/getTransactions` and adopts the on-chain `transaction_id.hash` of the transaction whose inbound message `body_hash` matches the signed transfer we broadcast (`base64(txCell.hash())`). This is exactly the hash `queryTransactions` records, so the pending tx reconciles into the confirmed one instead of duplicating. The previous `init_state`-based deploy match is subsumed by the precise `body_hash` match.

**Files**
- `src/ton/TonEngine.ts` — unify `broadcastTx` to read the on-chain txid back via a `body_hash` match (replaces the local `externalBoc.hash()` txid and the `init_state` deploy branch).
- `src/ton/tonDrpc.ts` — expose `in_msg.body_hash` on the `getTransactions` cleaner.

**Testing**
- `tsc --noEmit`, eslint (changed files), and `yarn test` pass; CHANGELOG updated.
- Full on-device e2e (send TON, observe single confirmed tx with no orphaned pending) was **not** run: it requires a funded TON wallet to send from, and the test-account roster holds no TON (real on-chain TON funds the slot can't provide). The fix mirrors the already-proven deploy-path logic in the same function, verified statically against `processTonTransaction`'s txid source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how outgoing TON transactions are keyed immediately after broadcast; wrong matching could delay or fail txid assignment, but scope is limited to TON send reconciliation.
> 
> **Overview**
> Fixes **duplicate TON sends** where a pending outgoing tx never merged with the confirmed one because `broadcastTx` used a **local external-message BOC hash** as `txid` while history sync uses the **on-chain transaction hash**.
> 
> After `/sendBoc`, **`broadcastTx` always polls** `/getTransactions`, finds the tx whose `in_msg.body_hash` matches the signed transfer (`base64(txCell.hash())`), and sets **`txid` from `transaction_id.hash`**—the same id `processTonTransaction` uses. Deploy and already-active wallets share this path; the old `init_state` deploy branch and instant `externalBoc.hash()` return are removed.
> 
> **`tonDrpc`** now parses `in_msg.body_hash` instead of `source` / `msg_data.init_state`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc585d64369e795d7b544116e4411fe46494403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->