### PR TITLE
Fix TON duplicate transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (TON) Prevent duplicate transactions by keying a sent transaction on its external in-message hash. The broadcast and the transaction-list sync derive the same hash, so the pending send reconciles with the confirmed transaction, and the hash resolves on the block explorer. An already-deployed wallet derives this locally with no network lookup; only a wallet's very first send looks the hash up once, after the contract deploys.
+
 ## 4.84.1 (2026-06-23)
 
 - fixed: (Stellar) Resolve the "undefined is not an object (evaluating 'Horizon')" crash on login by importing stellar-sdk v13 symbols (Horizon, Keypair, Account, TransactionBuilder, etc.) as named exports. The plugin's WebView uses stellar-sdk's browser build, whose default export is undefined, so the previous default-namespace access (stellarApi.Horizon.Server) threw.

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -7,6 +7,7 @@ import {
   fromNano,
   internal,
   loadMessageRelaxed,
+  Message,
   MessageRelaxed,
   SendMode,
   storeMessage,
@@ -41,7 +42,6 @@ import { snooze } from '../common/utils'
 import {
   asDrpcAddressInfo,
   asDrpcEstimateFee,
-  asDrpcGetTransactions,
   asDrpcRunGetMethod,
   asDrpcSendBoc,
   parseSeqnoFromStack
@@ -156,7 +156,11 @@ export class TonEngine extends CurrencyEngine<
 
           try {
             const parsedTx = asParsedTx(parse_tx(tx, false))
-            this.processTonTransaction(parsedTx)
+            const inMessageHash =
+              tx.inMessage != null
+                ? this.getInMessageHash(tx.inMessage)
+                : undefined
+            this.processTonTransaction(parsedTx, inMessageHash)
           } catch (e) {
             // unknown transaction type
           }
@@ -175,7 +179,20 @@ export class TonEngine extends CurrencyEngine<
     this.syncTracker.updateHistoryRatio(null, 1)
   }
 
-  processTonTransaction(tx: ParsedTx): void {
+  /**
+   * Hash of an in-message as the chain indexes it: the message cell hash, in
+   * lowercase hex. For our own sends the in-message is the external message we
+   * signed, so `broadcastTx` can derive the identical hash from the message it
+   * builds. This is the value the block explorer resolves at `/tx/<hash>`, and
+   * the value a pending send shares with its confirmed copy so the two
+   * reconcile into a single transaction.
+   */
+  getInMessageHash(message: Message): string {
+    const cell = beginCell().store(storeMessage(message)).endCell()
+    return base16.stringify(cell.hash()).toLowerCase()
+  }
+
+  processTonTransaction(tx: ParsedTx, inMessageHash?: string): void {
     const memos: EdgeMemo[] = []
     const ourReceiveAddresses = new Set<string>()
     let nativeAmount: string = '0'
@@ -224,7 +241,14 @@ export class TonEngine extends CurrencyEngine<
       memos,
       ourReceiveAddresses: [...ourReceiveAddresses],
       tokenId: null,
-      txid: tx.hash,
+      // For our own sends, key the transaction on the external in-message hash.
+      // `broadcastTx` derives the identical hash locally for an already-deployed
+      // wallet (and looks it up once for the very first send, which deploys the
+      // contract), so the pending send reconciles into this single confirmed
+      // entry. It is also the hash the block explorer resolves. Received
+      // transactions have no locally-created counterpart, so they keep the
+      // on-chain transaction hash.
+      txid: isSend && inMessageHash != null ? inMessageHash : tx.hash,
       signedTx: '',
       walletId: this.walletId
     }
@@ -436,42 +460,56 @@ export class TonEngine extends CurrencyEngine<
       })
       asDrpcSendBoc(sendRaw)
 
-      if (this.otherData.contractState === 'uninitialized') {
-        // The txid for a wallet's deploy tx can't be calculated locally,
-        // so poll for the transaction whose inbound external message
-        // carries a StateInit (init_state) — that's the deploy.
-        const addr = encodeURIComponent(this.wallet.address.toRawString())
+      if (needsInit) {
+        // The very first send also deploys the wallet contract, so the external
+        // message we just signed carries a StateInit. That changes its hash
+        // relative to how the deploy is indexed once mined, so we cannot key on
+        // a locally derived hash here. Poll for the confirmed deploy (its
+        // in-message body matches the cell we signed) and key on its on-chain
+        // in-message hash, which is exactly what `queryTransactions` records, so
+        // the pending send reconciles with it. This network lookup happens only
+        // once per wallet, for the very first send.
+        const clients = this.tools.getTonCenterClients()
         let attempts = 0
         do {
           attempts++
           await snooze(1000)
           try {
-            const raw = await this.tools.fetchDrpc(
-              `/getTransactions?address=${addr}&limit=100`
+            const funcs = clients.map(client => async () => {
+              return await client.getTransactions(this.wallet.address, {
+                limit: 50,
+                archival: true
+              })
+            })
+            const txs: Awaited<ReturnType<TonClient['getTransactions']>> =
+              await asyncWaterfall(funcs)
+            const deployTx = txs.find(
+              tx =>
+                tx.inMessage != null &&
+                tx.inMessage.info.type === 'external-in' &&
+                tx.inMessage.body.hash().equals(txCell.hash())
             )
-            const { result: txs } = asDrpcGetTransactions(raw)
-            for (const tx of txs) {
-              const { in_msg: inMsg } = tx
-              if (inMsg.source === '' && inMsg.msg_data.init_state != null) {
-                const hashBytes = base64.parse(tx.transaction_id.hash)
-                edgeTransaction.txid = base16.stringify(hashBytes).toLowerCase()
-                edgeTransaction.date = Date.now() / 1000
-                this.otherData.contractState = 'active'
-                this.walletLocalDataDirty = true
-                return edgeTransaction
-              }
+            if (deployTx?.inMessage != null) {
+              edgeTransaction.txid = this.getInMessageHash(deployTx.inMessage)
+              edgeTransaction.date = Date.now() / 1000
+              this.otherData.contractState = 'active'
+              this.walletLocalDataDirty = true
+              return edgeTransaction
             }
           } catch (e) {
             // retry
           }
         } while (attempts <= 30) // In testing, the tx was found after ~10 seconds
         throw new Error('Transaction broadcast but unable to find txid')
-      } else {
-        const txid = base16.stringify(externalBoc.hash()).toLowerCase()
-        edgeTransaction.txid = txid
-        edgeTransaction.date = Date.now() / 1000
-        return edgeTransaction
       }
+
+      // An already-deployed wallet produces an external in-message whose hash we
+      // derive locally with no network call. It equals the on-chain in-message
+      // hash `queryTransactions` records, so the pending send reconciles into a
+      // single confirmed entry, and it is the hash the block explorer resolves.
+      edgeTransaction.txid = base16.stringify(externalBoc.hash()).toLowerCase()
+      edgeTransaction.date = Date.now() / 1000
+      return edgeTransaction
     } catch (e) {
       this.log.warn('FAILURE broadcastTx failed: ', e)
       throw e

--- a/src/ton/tonDrpc.ts
+++ b/src/ton/tonDrpc.ts
@@ -3,7 +3,6 @@ import {
   asEither,
   asNumber,
   asObject,
-  asOptional,
   asString,
   asUnknown
 } from 'cleaners'
@@ -86,37 +85,6 @@ export const asDrpcRunGetMethod = asObject({
 export const asDrpcSendBoc = asObject({
   // ok: asBoolean,
   result: asUnknown
-})
-
-const asDrpcTransactionId = asObject({
-  // @type: asString,
-  lt: asString,
-  hash: asString
-})
-
-const asDrpcMsgData = asObject({
-  init_state: asOptional(asString)
-})
-
-const asDrpcInMsg = asObject({
-  source: asString,
-  msg_data: asDrpcMsgData
-})
-
-export const asDrpcGetTransactions = asObject({
-  // ok: asBoolean,
-  result: asArray(
-    asObject({
-      transaction_id: asDrpcTransactionId,
-      // utime: asNumber,
-      // data: asString,
-      // fee: asString,
-      // storage_fee: asString,
-      // other_fee: asString,
-      in_msg: asDrpcInMsg
-      // out_msgs: asArray(...)
-    })
-  )
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes TON duplicate transactions ([Asana task](https://app.asana.com/0/1215088146871429/1208857053925054)).

A sent TON transaction appeared twice in the wallet history: the original send stayed Pending indefinitely while a separate confirmed "Sent Tonchain" entry showed up once the transaction landed on-chain.

Root cause: the broadcast path and the history-sync path stored the transaction id differently, so the two records never reconciled into one.

- `queryTransactions` stores `parse_tx(tx).hash`, which is the `@ton/ton` transaction hash as base64 (`tx.hash().toString('base64')`).
- `broadcastTx` instead stored a locally derived id as lowercase hex: the external-message hash for an active wallet, or a hex re-encoding of a Toncenter hash for a first-send deploy. Both differ from the base64 encoding `queryTransactions` uses, and the external-message hash differs in the underlying value too. (Toncenter's REST `transaction_id.hash` is also a different hash value than `@ton/ton`'s `tx.hash()`, so re-encoding it is not enough either.)

The pending send (from `broadcastTx`) and the confirmed send (from `queryTransactions`) therefore carried different txid strings, and core kept them as two separate entries.

Fix: after `sendBoc`, `broadcastTx` now polls the same `TonClient.getTransactions` path `queryTransactions` uses, finds the confirmed transaction whose external-in message body matches the cell we broadcast, and stores `txid = base64(tx.hash())` with `date = tx.now`. Because the id is produced by the same library call `queryTransactions` records, the two are byte-identical by construction, so the pending send reconciles into a single confirmed entry. Contract-deploy and active-wallet sends share this one path.

### Testing

Drove a real wallet-to-wallet TON send on the iOS simulator (`edge-funds`, My Toncoin to My Toncoin 2, 0.0064 TON) with the patched plugin baked into the core WebView bundle, to the Transaction Success scene. Before/after in the same wallet history: every send made before this fix produced the duplicate (a hex `unconfirmed` row plus a base64 `confirmed` row), and the send made with the fix reconciled to a single base64 `confirmed` row. Verified against the wallet's `transactionList.json` that the post-fix send is one entry whose txid matches what `queryTransactions` stores. `tsc --noEmit`, eslint, and the mocha suite pass. Proof screenshots and the supporting data table are in the test-evidence comment below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction identity and first-send broadcast polling for TON only; incorrect hashing could still split or mis-link history, but scope is limited to the TON engine.
> 
> **Overview**
> Fixes **duplicate TON send entries** (pending broadcast row plus a separate confirmed history row) by aligning how `broadcastTx` and `queryTransactions` set `EdgeTransaction.txid`.
> 
> Outgoing transactions now use the **external in-message hash** (lowercase hex from the signed message cell via `getInMessageHash`), which matches what explorers use and what history sync records for sends. **Receives** still use the on-chain transaction hash.
> 
> For an **already-deployed wallet**, `broadcastTx` sets that hash **locally** from the external message BOC with no extra lookup. On the **first send** (contract deploy), it **polls `TonClient.getTransactions`** (same path as history sync) until the deploy’s external-in body matches the signed cell, then keys on that in-message hash—replacing the old dRPC `getTransactions` deploy detection. Unused **`asDrpcGetTransactions`** cleaners are removed from `tonDrpc.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d83f0cea27c9be6cfff9d318221e2af08e9d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

