### PR TITLE
Fix Stellar login crash from stellar-sdk v13 default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Stellar) Resolve the "undefined is not an object (evaluating 'Horizon')" crash on login by importing stellar-sdk v13 symbols (Horizon, Keypair, Account, TransactionBuilder, etc.) as named exports. The plugin's WebView uses stellar-sdk's browser build, whose default export is undefined, so the previous default-namespace access (stellarApi.Horizon.Server) threw.
+
 ## 4.84.0 (2026-06-18)
 
 - added: Add monero plugin

--- a/src/stellar/StellarEngine.ts
+++ b/src/stellar/StellarEngine.ts
@@ -12,7 +12,17 @@ import {
   NoAmountSpecifiedError
 } from 'edge-core-js/types'
 import { base16, base64 } from 'rfc4648'
-import stellarApi, { Transaction } from 'stellar-sdk'
+import {
+  Account,
+  Asset,
+  Keypair,
+  Memo,
+  Networks,
+  Operation,
+  TimeoutInfinite,
+  Transaction,
+  TransactionBuilder
+} from 'stellar-sdk'
 
 import { CurrencyEngine } from '../common/CurrencyEngine'
 import { PluginEnvironment } from '../common/innerPlugin'
@@ -526,7 +536,7 @@ export class StellarEngine extends CurrencyEngine<
 
     const exchangeAmount = div(nativeAmount, denom.multiplier, 7)
 
-    const account = new stellarApi.Account(
+    const account = new Account(
       this.walletLocalData.publicKey,
       this.otherData.accountSequence
     )
@@ -540,23 +550,23 @@ export class StellarEngine extends CurrencyEngine<
     // stellar-sdk v13: the network passphrase moved from the removed global
     // Network singleton into per-transaction options, and transactions must
     // declare timebounds (TimeoutInfinite preserves the old no-bounds behavior).
-    let txBuilder = new stellarApi.TransactionBuilder(account, {
+    let txBuilder = new TransactionBuilder(account, {
       fee: String(feeSetting),
-      networkPassphrase: stellarApi.Networks.PUBLIC
-    }).setTimeout(stellarApi.TimeoutInfinite)
+      networkPassphrase: Networks.PUBLIC
+    }).setTimeout(TimeoutInfinite)
 
     if (mustCreateAccount) {
       txBuilder = txBuilder.addOperation(
-        stellarApi.Operation.createAccount({
+        Operation.createAccount({
           destination: publicAddress,
           startingBalance: exchangeAmount
         })
       )
     } else {
       txBuilder = txBuilder.addOperation(
-        stellarApi.Operation.payment({
+        Operation.payment({
           destination: publicAddress,
-          asset: stellarApi.Asset.native(),
+          asset: Asset.native(),
           amount: exchangeAmount
         })
       )
@@ -564,13 +574,13 @@ export class StellarEngine extends CurrencyEngine<
     for (const memo of memos) {
       switch (memo.type) {
         case 'hex':
-          txBuilder = txBuilder.addMemo(stellarApi.Memo.hash(memo.value))
+          txBuilder = txBuilder.addMemo(Memo.hash(memo.value))
           break
         case 'number':
-          txBuilder = txBuilder.addMemo(stellarApi.Memo.id(memo.value))
+          txBuilder = txBuilder.addMemo(Memo.id(memo.value))
           break
         case 'text':
-          txBuilder = txBuilder.addMemo(stellarApi.Memo.text(memo.value))
+          txBuilder = txBuilder.addMemo(Memo.text(memo.value))
           break
       }
     }
@@ -648,9 +658,7 @@ export class StellarEngine extends CurrencyEngine<
         throw new Error('ErrorInvalidTransaction')
       }
       this.warn('Signing...')
-      const keypair = stellarApi.Keypair.fromSecret(
-        stellarPrivateKeys.stellarKey
-      )
+      const keypair = Keypair.fromSecret(stellarPrivateKeys.stellarKey)
       await transaction.sign(keypair)
     } catch (e: any) {
       this.error(

--- a/src/stellar/StellarTools.ts
+++ b/src/stellar/StellarTools.ts
@@ -11,7 +11,7 @@ import {
   EdgeTokenMap,
   EdgeWalletInfo
 } from 'edge-core-js/types'
-import stellarApi, { Horizon } from 'stellar-sdk'
+import { Horizon, Keypair } from 'stellar-sdk'
 import { serialize } from 'uri-js'
 import parse from 'url-parse'
 
@@ -50,7 +50,7 @@ export class StellarTools implements EdgeCurrencyTools {
     // TransactionBuilder options.
     this.stellarApiServers = []
     for (const server of this.networkInfo.stellarServers) {
-      const stellarServer = new stellarApi.Horizon.Server(server)
+      const stellarServer = new Horizon.Server(server)
       stellarServer.serverName = server
       this.stellarApiServers.push(stellarServer)
     }
@@ -73,7 +73,7 @@ export class StellarTools implements EdgeCurrencyTools {
   checkAddress(address: string): boolean {
     // TODO: check address
     try {
-      stellarApi.Keypair.fromPublicKey(address)
+      Keypair.fromPublicKey(address)
       return true
     } catch (e: any) {
       return false
@@ -97,7 +97,7 @@ export class StellarTools implements EdgeCurrencyTools {
         "m/44'/148'/0'",
         seed.toString('hex')
       ).key
-      const keypair = stellarApi.Keypair.fromRawEd25519Seed(
+      const keypair = Keypair.fromRawEd25519Seed(
         Uint8Array.from(derivedSeed) as unknown as number[]
       )
 
@@ -107,7 +107,7 @@ export class StellarTools implements EdgeCurrencyTools {
       }
     } else {
       userInput = userInput.replace(/ /g, '')
-      stellarApi.Keypair.fromSecret(userInput)
+      Keypair.fromSecret(userInput)
       if (userInput.length !== 56) throw new Error('Private key wrong length')
 
       return {
@@ -122,7 +122,7 @@ export class StellarTools implements EdgeCurrencyTools {
       throw new Error('InvalidWalletType')
     }
 
-    const keypair = stellarApi.Keypair.fromSecret(walletInfo.keys.stellarKey)
+    const keypair = Keypair.fromSecret(walletInfo.keys.stellarKey)
     return { publicKey: keypair.publicKey() }
   }
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1215849737061914/f)

Fixes a crash on login for any account holding a Stellar (XLM) wallet: `undefined is not an object (evaluating 'new(C()).Horizon')`.

Root cause: `4.83.0` migrated the Stellar plugin to stellar-sdk v13. The plugin runs inside edge-core-js's plugin WebView, which loads stellar-sdk's browser build (`dist/stellar-sdk.min.js`). That build exposes no usable `default` export, so the plugin's default-namespace accesses read properties off `undefined`:

- `new stellarApi.Horizon.Server(server)` threw first, in the `StellarTools` constructor that runs on login when an XLM wallet's tools/engine load.
- Every other `stellarApi.X` access (`Keypair`, `Account`, `TransactionBuilder`, `Networks`, `Operation`, `Asset`, `Memo`, `TimeoutInfinite`) was equally broken and would have failed during key derivation, address validation, and sending.

Fix: import the v13 symbols as named exports (`Horizon`, `Keypair`, `Account`, `TransactionBuilder`, `Networks`, `Operation`, `Asset`, `Memo`, `TimeoutInfinite`) instead of off the default export. Named exports resolve in both the Node (`lib`) and browser (`dist`) builds.

Verification:
- Confirmed against the actual browser build: the old `default.Horizon` access throws the exact production error; the named-import path constructs `Horizon.Server`, a `Keypair`, and a full `TransactionBuilder` transaction successfully.
- iOS simulator: built the gui with the rebuilt plugin bundle loaded via `DEBUG_ACCOUNTBASED`, logged into an account holding four XLM wallets. All loaded on login with live balances and rates (no Horizon crash). Screenshots attached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted import refactor with no new logic; restores expected stellar-sdk v13 usage in the browser build and affects only the Stellar plugin.
> 
> **Overview**
> Fixes **login crashes for accounts with Stellar (XLM) wallets** introduced after the stellar-sdk v13 migration: the plugin WebView loads the browser bundle, where the default export is undefined, so `stellarApi.Horizon.Server` and similar calls threw immediately when tools/engine initialized.
> 
> **`StellarTools`** and **`StellarEngine`** now import **`Horizon`**, **`Keypair`**, **`Account`**, **`TransactionBuilder`**, **`Networks`**, **`Operation`**, **`Asset`**, **`Memo`**, and **`TimeoutInfinite`** as named exports and call them directly (e.g. `new Horizon.Server(server)`, `Keypair.fromSecret(...)`). Behavior is unchanged aside from fixing module resolution in the WebView; transaction building still uses v13’s per-transaction `networkPassphrase` and `TimeoutInfinite` timebounds.
> 
> CHANGELOG **Unreleased** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba2157b0d13a9bfb4dbe1856e4d2dbe5926bfec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->