### PR TITLE
Add makeMaxSpend to ethereum and ton engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (ethereum, ton) Implement the `makeMaxSpend` engine method, which atomically builds a transaction that spends the maximum amount.
+
 ## 4.84.1 (2026-06-23)
 
 - fixed: (Stellar) Resolve the "undefined is not an object (evaluating 'Horizon')" crash on login by importing stellar-sdk v13 symbols (Horizon, Keypair, Account, TransactionBuilder, etc.) as named exports. The plugin's WebView uses stellar-sdk's browser build, whose default export is undefined, so the previous default-namespace access (stellarApi.Horizon.Server) threw.

--- a/src/ethereum/EthereumEngine.ts
+++ b/src/ethereum/EthereumEngine.ts
@@ -1212,6 +1212,22 @@ export class EthereumEngine extends CurrencyEngine<
     }
   }
 
+  async makeMaxSpend(edgeSpendInfoIn: EdgeSpendInfo): Promise<EdgeTransaction> {
+    // Compute the max spendable amount and build the transaction back-to-back
+    // so the fee pricing stays consistent (getMaxSpendable caches L1 pricing
+    // for makeSpend) and network state cannot change between the two steps:
+    const maxNativeAmount = await this.getMaxSpendable(edgeSpendInfoIn)
+    const edgeSpendInfo: EdgeSpendInfo = {
+      ...edgeSpendInfoIn,
+      spendTargets: edgeSpendInfoIn.spendTargets.map((spendTarget, index) =>
+        index === 0
+          ? { ...spendTarget, nativeAmount: maxNativeAmount }
+          : spendTarget
+      )
+    }
+    return await this.makeSpend(edgeSpendInfo)
+  }
+
   getTxParameterInformation(
     edgeSpendInfo: EdgeSpendInfo,
     tokenId: EdgeTokenId,

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -266,6 +266,21 @@ export class TonEngine extends CurrencyEngine<
     )
   }
 
+  async makeMaxSpend(edgeSpendInfoIn: EdgeSpendInfo): Promise<EdgeTransaction> {
+    // Compute the max spendable amount and build the transaction back-to-back
+    // so network state cannot change between the two steps:
+    const maxNativeAmount = await this.getMaxSpendable(edgeSpendInfoIn)
+    const edgeSpendInfo: EdgeSpendInfo = {
+      ...edgeSpendInfoIn,
+      spendTargets: edgeSpendInfoIn.spendTargets.map((spendTarget, index) =>
+        index === 0
+          ? { ...spendTarget, nativeAmount: maxNativeAmount }
+          : spendTarget
+      )
+    }
+    return await this.makeSpend(edgeSpendInfo)
+  }
+
   async makeSpend(edgeSpendInfoIn: EdgeSpendInfo): Promise<EdgeTransaction> {
     const { edgeSpendInfo, currencyCode } = this.makeSpendCheck(edgeSpendInfoIn)
     const { memos = [], tokenId } = edgeSpendInfo


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Pairs with the new `EdgeCurrencyEngine.makeMaxSpend` engine method in edge-core-js (EdgeApp/edge-core-js#727). The engine method is optional, so this PR is independent: the core only calls it once that change ships; until then the core fallback shim handles max spends.

### Description

Implement the `makeMaxSpend` engine method on `EthereumEngine` and `TonEngine`. It computes the maximum spendable amount and builds the transaction back-to-back inside the engine, so network state and fee pricing stay consistent between the two steps. This avoids the race that affects separate `getMaxSpendable` and `makeSpend` calls (for Ethereum it also reuses the L1 fee pricing `getMaxSpendable` caches for `makeSpend`).

Asana: https://app.asana.com/0/1215088146871429/1207967192999590

### Testing

- `npm run types` (tsc): the change introduces no new type errors (verified by comparing error counts on the base branch vs this branch — both 15, all pre-existing and unrelated, from the locally-installed older `edge-core-js` and `react-native-monero` not being present; CI installs fresh dependencies).
- The max-spend flow was exercised end to end in the running app via the core `makeMaxSpend` wallet API (see EdgeApp/edge-core-js#727); the engine method here mirrors that already-tested `getMaxSpendable` + `makeSpend` logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core send paths for native max spends on Ethereum (fees, rollups, caching) and TON; behavior should match the prior two-step flow but any mismatch would affect full-balance sends.
> 
> **Overview**
> Adds optional **`makeMaxSpend`** on **`EthereumEngine`** and **`TonEngine`**, pairing with edge-core-js’s wallet API so max-send is one engine call instead of separate **`getMaxSpendable`** + **`makeSpend`**.
> 
> Each implementation calls **`getMaxSpendable`**, sets the first spend target’s **`nativeAmount`** to that value, then **`makeSpend`** immediately. On Ethereum the comment notes this keeps L1 fee pricing aligned via **`lastMaxSpendable`** caching between the two steps; on TON it avoids balance/fee drift between queries.
> 
> CHANGELOG **Unreleased** documents the addition for ethereum and ton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e400d4d511b89047136c2266ec5d24ce0dc317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->