### PR TITLE
Enable HyperEVM automatic token detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (HyperEVM) Enable automatic token detection by adding the ethBalCheckerContract address to the RPC adapter config, so tokens arriving in a HyperEVM wallet are auto-detected like other EVM chains.
+
 ## 4.84.1 (2026-06-23)
 
 - fixed: (Stellar) Resolve the "undefined is not an object (evaluating 'Horizon')" crash on login by importing stellar-sdk v13 symbols (Horizon, Keypair, Account, TransactionBuilder, etc.) as named exports. The plugin's WebView uses stellar-sdk's browser build, whose default export is undefined, so the previous default-namespace access (stellarApi.Horizon.Server) threw.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Robinhood Chain support (`robinhood`, EVM chain 4663), an Arbitrum Nitro L2 with ETH as its gas token. Transaction history comes from the chain's Blockscout instance, since Etherscan V2 does not cover this chain, and fees use the Arbitrum `NodeInterface` L1-component estimate. Built-in tokens are USDC, USDT, USDG, WBTC, WETH, CASHCAT and PONS.
 - fixed: (Avalanche) Remove unreachable avascan and snowscan evmscan servers
+- fixed: (HyperEVM) Tokens are detected automatically
 
 ## 4.90.1 (2026-08-28)
 

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -127,7 +127,8 @@ const networkInfo: EthereumNetworkInfo = {
         'https://rpc.hypurrscan.io',
         'https://hyperliquid-json-rpc.stakely.io',
         'https://hyperliquid-json-rpc.stakely.io'
-      ]
+      ],
+      ethBalCheckerContract: '0x75c246EaCe343aCe287c1A37B45D7BD4214C6f27'
     },
     {
       type: 'evmscan',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1211539505635265/f)

Fixes HyperEVM (chainId 999) not auto-detecting tokens that arrive in a wallet. Every other EVM chain auto-detects via a deployed on-chain balance-checker contract; HyperEVM's RPC adapter config was missing the `ethBalCheckerContract` address, so `RpcAdapter.fetchTokenBalances` stayed `null` and the engine only re-checked already-enabled tokens, never discovering new ones.

This adds the contract address to the HyperEVM `rpc` adapter config, matching Sonic/Monad/Celo/RSK/FilecoinFEVM/opBNB.

**Contract deployment.** The balance-checker is byte-identical to the one already live on the other chains (same `balances(address[],address[])` / `tokenBalance` contract). It is deployed on HyperEVM at `0x75c246EaCe343aCe287c1A37B45D7BD4214C6f27` (tx `0x6e811d894e8f6fac31a67e081c7f5f651c72ddba7b34dfea3570f40563563fbb`). Its deployed runtime bytecode is verified byte-for-byte equal to the contract on Sonic/Celo/opBNB. The contract is stateless and trustless (pure view functions, no owner, fallback reverts on payment).

Note: the canonical `0x726391B6cA41761c4c332aa556Cf804A50279b52` used on the other 6 chains was deployed by the Edge deployer EOA `0xbc291f404bde7e9e819da0ebe2eb06d400220520` (direct CREATE at nonce 0, not a CREATE2 factory), so reproducing that exact address on HyperEVM requires that deployer key. That EOA currently has nonce 0 on HyperEVM, so if chain-wide address consistency is preferred, the contract can instead be deployed from that deployer and this one line updated to `0x726391...`.

### Testing

- On-chain: the deployed contract's `balances([wallet],[tokens])` returns correct HyperEVM balances (verified via direct RPC call).
- In-app (iOS sim, edge-funds, modified plugin served via DEBUG_ACCOUNTBASED dev-server): a HyperEVM wallet auto-detected an HFUN token balance (0.0645 HFUN / $0.632) that the published build did not surface. Cross-checked on-chain: the wallet holds the token via the deployed checker. See attached screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single network-info field addition; behavior aligns with existing EVM chains and does not touch sends, auth, or fee logic.
> 
> **Overview**
> **HyperEVM** wallets can **auto-detect incoming ERC-20 tokens** again, matching other EVM chains.
> 
> The HyperEVM RPC network adapter config now includes **`ethBalCheckerContract`** (`0x75c246EaCe343aCe287c1A37B45D7BD4214C6f27`). Without it, `RpcAdapter` never exposes `fetchTokenBalances`, so sync only refreshed balances for tokens already enabled and never surfaced newly received assets.
> 
> The unreleased **CHANGELOG** notes the HyperEVM fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce89a5ce2d6945a675a8634673dfc9e610f0c039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->