### PR TITLE
Monero: immediate balance refresh, live max-spend, and steady sync progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: (Monero, Zano) Report sync progress at least once a second while it is still advancing, so a slow chain shows steady movement instead of appearing frozen between whole-percent updates.
 - fixed: (TON) Prevent duplicate transactions by keying a sent transaction on its external in-message hash. The broadcast and the transaction-list sync derive the same hash, so the pending send reconciles with the confirmed transaction, and the hash resolves on the block explorer. An already-deployed wallet derives this locally with no network lookup; only a wallet's very first send looks the hash up once, after the contract deploys.
 - fixed: (Monero) Update the wallet balance as soon as a pending transaction is received and on every sync poll, instead of only after a new block, so an incoming pending amount appears immediately.
 - fixed: (Monero) Calculate the max sendable amount from the wallet's live unlocked balance instead of a stale cached value, so tapping Max no longer intermittently returns 0 or an unsendable amount.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fixed: (TON) Prevent duplicate transactions by keying a sent transaction on its external in-message hash. The broadcast and the transaction-list sync derive the same hash, so the pending send reconciles with the confirmed transaction, and the hash resolves on the block explorer. An already-deployed wallet derives this locally with no network lookup; only a wallet's very first send looks the hash up once, after the contract deploys.
 - fixed: (Monero) Update the wallet balance as soon as a pending transaction is received and on every sync poll, instead of only after a new block, so an incoming pending amount appears immediately.
+- fixed: (Monero) Calculate the max sendable amount from the wallet's live unlocked balance instead of a stale cached value, so tapping Max no longer intermittently returns 0 or an unsendable amount.
 
 ## 4.84.1 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: (TON) Prevent duplicate transactions by keying a sent transaction on its external in-message hash. The broadcast and the transaction-list sync derive the same hash, so the pending send reconciles with the confirmed transaction, and the hash resolves on the block explorer. An already-deployed wallet derives this locally with no network lookup; only a wallet's very first send looks the hash up once, after the contract deploys.
+- fixed: (Monero) Update the wallet balance as soon as a pending transaction is received and on every sync poll, instead of only after a new block, so an incoming pending amount appears immediately.
 
 ## 4.84.1 (2026-06-23)
 

--- a/src/common/WeightedSyncTracker.ts
+++ b/src/common/WeightedSyncTracker.ts
@@ -6,6 +6,12 @@ const SYNC_PROGRESS_WEIGHT = 0.85
 const BALANCE_PROGRESS_WEIGHT = 0.05
 const TRANSACTION_PROGRESS_WEIGHT = 0.1
 
+// Push a sync-status update at least this often while progress is still moving,
+// even within a single 1% step. Without this, a slow chain (e.g. monerod over
+// the Nym mixnet, where 1% can be many thousands of blocks) looks frozen for
+// minutes between whole-percent boundaries.
+const SYNC_STATUS_INTERVAL_MS = 1000
+
 /**
  * A sync status tracker that works block-by-block.
  */
@@ -31,6 +37,7 @@ export function makeWeightedSyncTracker(
   let blockRatioDetail: [number, number] = [0, 1]
   let historyRatio = 0
   let lastTotalRatio = 0
+  let lastSentTime = 0
 
   function calculateStatus(): EdgeSyncStatus {
     // Avoid rounding issues by treating 1 as special:
@@ -52,13 +59,22 @@ export function makeWeightedSyncTracker(
 
   function maybeSendUpdate(): void {
     const status = calculateStatus()
+    const now = Date.now()
 
-    // Update every 1% change
+    // Update on completion, on every 1% change, or — when progress is still
+    // moving — at least once per SYNC_STATUS_INTERVAL_MS so slow syncs show
+    // steady movement instead of appearing frozen between 1% boundaries.
     const flooredPrevProgress = Math.floor(lastTotalRatio * 100)
     const flooredNewProgress = Math.floor(status.totalRatio * 100)
+    const progressMoved = status.totalRatio > lastTotalRatio
 
-    if (status.totalRatio === 1 || flooredNewProgress > flooredPrevProgress) {
+    if (
+      status.totalRatio === 1 ||
+      flooredNewProgress > flooredPrevProgress ||
+      (progressMoved && now - lastSentTime >= SYNC_STATUS_INTERVAL_MS)
+    ) {
       engine.sendSyncStatus(status)
+      lastSentTime = now
     }
 
     lastTotalRatio = status.totalRatio

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -722,13 +722,23 @@ export class MoneroEngine extends CurrencyEngine<
     }
 
     try {
+      // Read the live unlocked balance instead of this.unlockedBalance, which
+      // starts at '0' and is reset to '0' on every engine restart (settings or
+      // daemon change, resync) and only repopulated on a fully-synced poll.
+      // That staleness made Max intermittently return 0 (sub('0', fee) < 0) or
+      // an amount that then failed to actually send.
+      const status = await this.tools.cppBridge.getWalletStatus(nativeWalletId)
+      // We fetched a fresh status, so keep the cached balances in sync with it.
+      this.unlockedBalance = status.unlockedBalance
+      this.updateBalance(null, status.balance)
+
       const result = await this.tools.cppBridge.createTransaction(
         nativeWalletId,
         [{ address: spendTarget.publicAddress, amount: '0' }],
         translateFee(edgeSpendInfo.networkFeeOption)
       )
 
-      const maxSpendable = sub(this.unlockedBalance, result.fee)
+      const maxSpendable = sub(status.unlockedBalance, result.fee)
       if (lt(maxSpendable, '0')) {
         return '0'
       }

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -197,11 +197,17 @@ export class MoneroEngine extends CurrencyEngine<
               if (event.walletId !== base64UrlWalletId) return
               if (event.eventName !== 'pendingTransactionReceived') return
 
-              this.queryTransactions(base64UrlWalletId).catch(err =>
-                this.log.error(
-                  `Event-triggered queryTransactions error: ${String(err)}`
+              this.queryTransactions(base64UrlWalletId)
+                .then(async () => {
+                  // Refresh the balance immediately so a pending incoming tx
+                  // shows up without waiting for the next synced poll.
+                  await this.refreshBalance(base64UrlWalletId)
+                })
+                .catch(err =>
+                  this.log.error(
+                    `Event-triggered refresh error: ${String(err)}`
+                  )
                 )
-              )
             }
           )
           this.unsubscribeWalletEvent = unsubscribeWalletEvent
@@ -386,6 +392,13 @@ export class MoneroEngine extends CurrencyEngine<
 
       this.updateBlockHeight(status.networkHeight)
 
+      // Refresh the balance on every poll, not only once fully synced, so a
+      // pending incoming tx or the pending change after a send is reflected
+      // promptly instead of lagging until a new block advances syncedHeight.
+      // updateBalance no-ops when the value is unchanged.
+      this.unlockedBalance = status.unlockedBalance
+      this.updateBalance(null, status.balance)
+
       // Capture the first reported synced height as our baseline for
       // progress tracking. This is reset when the wallet restarts
       // (settings change, resync, daemon change).
@@ -402,9 +415,6 @@ export class MoneroEngine extends CurrencyEngine<
           status.networkHeight
         )
 
-        const balance = status.balance
-        this.unlockedBalance = status.unlockedBalance
-        this.updateBalance(null, balance)
         this.syncTracker.updateBalanceRatio(1)
 
         await this.queryTransactions(nativeWalletId)
@@ -437,6 +447,15 @@ export class MoneroEngine extends CurrencyEngine<
       this.log.error(`syncNetwork error: ${String(error)}`)
       return ERROR_POLL_MS
     }
+  }
+
+  // Pull the latest balances from the native wallet and publish them. Used by
+  // the pending-tx event handler so a received/sent amount is reflected without
+  // waiting for the next syncNetwork poll. updateBalance no-ops when unchanged.
+  private async refreshBalance(nativeWalletId: string): Promise<void> {
+    const status = await this.tools.cppBridge.getWalletStatus(nativeWalletId)
+    this.unlockedBalance = status.unlockedBalance
+    this.updateBalance(null, status.balance)
   }
 
   private async queryTransactions(nativeWalletId: string): Promise<void> {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

EdgeApp/react-native-monero#1 — the balance/max-spend fixes here pair with that PR's native `getWalletStatus` live-balance fix, and its monerod-over-Nym fix is what makes the Max calculation reliable on the Full Node backend.

### Description

Three Monero engine changes (the last also benefits Zano).

**Update the balance on a pending tx and every sync poll** (`abde38e1`)
The displayed balance was only refreshed inside `syncNetwork`'s `isSynced` branch, and the `pendingTransactionReceived` handler only re-queried the transaction list. So an incoming pending receive (and the pending change after a send) stayed stale until a new block. Added a `refreshBalance()` call from the pending-tx event and moved the balance refresh out of the `isSynced`-only branch.

**Compute max spend from the live unlocked balance** (`98defe80`)
`getMaxSpendable` derived the max from `this.unlockedBalance`, which is `'0'` until the first fully-synced poll and is reset on every engine restart — so tapping Max intermittently returned 0 or an amount that then failed to send. Read a fresh `getWalletStatus()` instead.

**Report sync progress on a time interval, not only per 1%** (`11392622`, Monero + Zano)
`WeightedSyncTracker` only pushed a sync-status update when the floored whole-percent increased, so on a slow chain (e.g. monerod over the Nym mixnet, where 1% can be thousands of blocks) the displayed progress froze for minutes between boundaries even while blocks were downloading. Also push at least once per second while progress is still moving.

**Testing:** tsc + full mocha suite pass. Verified on the iOS simulator — pending balances appear immediately, Max returns the correct amount on a Full Node wallet, and the "Syncing blocks X/Y" count advances steadily under Nym instead of freezing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monero send/balance paths change polling and Max calculation behavior; `WeightedSyncTracker` affects all engines using it (Monero and Zano), though the logic is additive for UI updates only.
> 
> **Overview**
> Improves Monero wallet UX around **balances**, **Max send**, and **sync progress**, with sync UI fixes shared with Zano via `WeightedSyncTracker`.
> 
> **Monero engine:** Balance and unlocked balance now update on **every** `syncNetwork` poll and right after a `pendingTransactionReceived` event (via new `refreshBalance`), instead of only when the wallet is fully caught up—so pending receives and change show up without waiting for the next block. **`getMaxSpendable`** fetches a fresh `getWalletStatus` and uses live `unlockedBalance` rather than `this.unlockedBalance`, which stayed at `'0'` across restarts until a fully-synced poll and caused Max to return 0 or fail sends.
> 
> **Shared sync tracker:** `WeightedSyncTracker` still emits on completion and each whole-percent step, but also pushes status **at least once per second** while `totalRatio` is still increasing, so slow block sync (e.g. monerod over Nym) does not look frozen between 1% boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677d9095e76aa6fc69b9075fda162997f843d37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216124906422311