### PR TITLE
Monero: show pending transactions, mark dropped, fix bouncing confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (Monero) Mark transactions that leave the mempool without confirming as dropped, instead of leaving them displayed as unconfirmed forever. A tx must stay missing for 30 minutes before it is declared dropped, since a just-mined tx briefly disappears from both the mempool and confirmed history while the LWS server indexes its block.
 - fixed: (Hedera) HBAR sends failed with an "[object Object]" error. The npm conversion re-resolved `@hashgraph/sdk` to 2.81, whose account-ID serialization calls `Long.fromBigInt` — a method missing from the pinned `long@4.0.0` override. Bump the `long` override to the `5.3.1` the SDK declares so transactions serialize, sign, and broadcast.
 - fixed: (Monero) Pending (unconfirmed) transactions now appear in the transaction list as soon as the wallet sees them, instead of only after their first confirmation. Pending entries sort behind all confirmed history in the native transaction list, so the newest-known-txid history scan never reached them — on LWS the balance would move with no transaction row to explain it. Requires react-native-monero with `getPendingTransactions`.
 - fixed: (Monero) Repair transactions stuck displaying as unconfirmed because the history-scan cursor was recorded while they were still pending.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
-- added: (Monero) Mark transactions that leave the mempool without confirming as dropped, instead of leaving them displayed as unconfirmed forever. A tx must stay missing for 30 minutes before it is declared dropped, since a just-mined tx briefly disappears from both the mempool and confirmed history while the LWS server indexes its block.
+- added: (Monero) Mark transactions that leave the mempool without confirming as dropped, instead of leaving them displayed as unconfirmed forever. A tx must stay missing for 30 minutes before it is declared dropped, since a just-mined tx briefly disappears from both the mempool and confirmed history while the LWS server indexes its block. Time while the app is closed, and the initial backfill after a relaunch, do not count toward that grace.
 - fixed: (Hedera) HBAR sends failed with an "[object Object]" error. The npm conversion re-resolved `@hashgraph/sdk` to 2.81, whose account-ID serialization calls `Long.fromBigInt` — a method missing from the pinned `long@4.0.0` override. Bump the `long` override to the `5.3.1` the SDK declares so transactions serialize, sign, and broadcast.
-- fixed: (Monero) Pending (unconfirmed) transactions now appear in the transaction list as soon as the wallet sees them, instead of only after their first confirmation. Pending entries sort behind all confirmed history in the native transaction list, so the newest-known-txid history scan never reached them — on LWS the balance would move with no transaction row to explain it. Requires react-native-monero with `getPendingTransactions`.
-- fixed: (Monero) Repair transactions stuck displaying as unconfirmed because the history-scan cursor was recorded while they were still pending.
+- fixed: (Monero) Pending (unconfirmed) transactions now appear in the transaction list as soon as the wallet sees them, instead of only after their first confirmation. Pending entries sort behind all confirmed history in the native transaction list, so the newest-known-txid history scan never reached them; on LWS the balance would move with no transaction row to explain it. Requires react-native-monero with `getPendingTransactions`.
+- fixed: (Monero) First-sighted incoming transactions still emit the new-transaction notification even though they now enter the wallet while pending (the base checkpoint math treats a height-0 entry as already seen).
+- fixed: (Monero) Repair transactions stuck displaying as unconfirmed because the history-scan cursor was recorded while they were still pending, including ones sitting behind the repaired cursor.
+- fixed: (Monero) Confirmation counts no longer bounce up and down. The network height reported by the native layer can briefly regress (the LWS client reports the stored account scan height until its first refresh completes, and a load-balanced daemon can answer a block behind the previous poll), and every height change re-stamps every transaction's confirmation count. Small regressions are smoothed so counts only advance, while a large regression is accepted as a correction so one bad reading cannot stick until resync.
 
 ## 4.85.0 (2026-06-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - fixed: (Hedera) HBAR sends failed with an "[object Object]" error. The npm conversion re-resolved `@hashgraph/sdk` to 2.81, whose account-ID serialization calls `Long.fromBigInt` — a method missing from the pinned `long@4.0.0` override. Bump the `long` override to the `5.3.1` the SDK declares so transactions serialize, sign, and broadcast.
+- fixed: (Monero) Pending (unconfirmed) transactions now appear in the transaction list as soon as the wallet sees them, instead of only after their first confirmation. Pending entries sort behind all confirmed history in the native transaction list, so the newest-known-txid history scan never reached them — on LWS the balance would move with no transaction row to explain it. Requires react-native-monero with `getPendingTransactions`.
+- fixed: (Monero) Repair transactions stuck displaying as unconfirmed because the history-scan cursor was recorded while they were still pending.
 
 ## 4.85.0 (2026-06-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "prettier": "^2.2.0",
         "process": "^0.11.10",
         "querystring": "^0.2.1",
-        "react-native-monero": "0.1.0",
+        "react-native-monero": "0.3.0",
         "react-native-piratechain": "0.5.0",
         "react-native-zano": "^0.2.7",
         "react-native-zcash": "0.10.1",
@@ -130,7 +130,7 @@
         "webpack-dev-server": "^5.2.4"
       },
       "peerDependencies": {
-        "react-native-monero": "^0.1.0",
+        "react-native-monero": "^0.3.0",
         "react-native-piratechain": "v0.5.0",
         "react-native-zano": "^0.2.7",
         "react-native-zcash": "^0.10.1"
@@ -15623,9 +15623,9 @@
       }
     },
     "node_modules/react-native-monero": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-monero/-/react-native-monero-0.1.0.tgz",
-      "integrity": "sha512-lyKYOtN1tVkEXD3/gvfYj8bQ4d2ZYOQ8+hgiT6i4UroYNaPZjvs6yKXTrRbIXbJrApCYPxQgNyGgdkT/Rk46wQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-monero/-/react-native-monero-0.3.0.tgz",
+      "integrity": "sha512-AxAH8ltNhVRIbUausraCupmSnI7wiPdcemsRif/VcxxB22ioOf/wKTxadrtSBYmwHu7fUAwVgsn7Dosqqhgmtw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Paul Puey <paul@edge.app>",
     "William Swanson <william@edge.app>",
     "Eliran Zach <eliran@edge.app>",
-    "Matthew Piché <matthew@edge.app>",
+    "Matthew Pich\u00e9 <matthew@edge.app>",
     "Sam Holmes <sam@edge.app>",
     "Jonathan Tzeng <jon@edge.app>",
     "Austin Bonander <austin@launchbadge.com>"
@@ -168,7 +168,7 @@
     "prettier": "^2.2.0",
     "process": "^0.11.10",
     "querystring": "^0.2.1",
-    "react-native-monero": "0.1.0",
+    "react-native-monero": "0.3.0",
     "react-native-piratechain": "0.5.0",
     "react-native-zano": "^0.2.7",
     "react-native-zcash": "0.10.1",
@@ -186,7 +186,7 @@
     "webpack-dev-server": "^5.2.4"
   },
   "peerDependencies": {
-    "react-native-monero": "^0.1.0",
+    "react-native-monero": "^0.3.0",
     "react-native-piratechain": "v0.5.0",
     "react-native-zano": "^0.2.7",
     "react-native-zcash": "^0.10.1"

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -26,6 +26,7 @@ import {
 import {
   cleanTxLogs,
   makeEngineFetch,
+  makeMutex,
   matchJson,
   normalizeAddress
 } from '../common/utils'
@@ -64,6 +65,25 @@ const ERROR_POLL_MS = 5000 // back off after a sync error
 // and confirmed history) before it is considered evicted from the pool:
 export const DROPPED_TX_GRACE_MS = 30 * 60 * 1000
 
+// Accept a lower reported network height only when it regresses by more than
+// this many blocks. Small dips (a load-balanced daemon a block behind, lwsf
+// reporting the stored scan height until its first refresh) are smoothed so
+// confirmation counts do not bounce, while a large regression is taken as a
+// correction so one garbage reading cannot ratchet the stored height forever:
+const HEIGHT_REGRESSION_BOUND = 1000
+
+// How often to refresh the pool-watch stamp of a tx that is still in the pool.
+// Millisecond freshness buys nothing against a 30-minute grace, and a fresh
+// stamp every pass would rewrite walletLocalData on every save loop:
+const PENDING_SEEN_REFRESH_MS = 5 * 60 * 1000
+
+// How often to refresh a still-pending tx's otherParams.lastSeenTime (seconds).
+// The base engine independently drops an unconfirmed tx once that stamp is
+// older than 24 hours, and a pool residence can outlast that (monerod keeps
+// transactions for around three days), so it must be refreshed periodically;
+// hourly keeps the refresh-triggered change events negligible:
+const LAST_SEEN_REFRESH_S = 60 * 60
+
 /**
  * Converts an Edge walletId (standard base64) into the form the native monero
  * layer expects. The native code embeds the id in a filesystem path and rejects
@@ -89,8 +109,8 @@ export class MoneroEngine extends CurrencyEngine<
   private sendKeysToNative?: (keys: MoneroPrivateKeys) => void
   private syncStartHeight: number | undefined
   private txSortOrder: 'asc' | 'desc' = 'asc'
-  private queryTransactionsRun: Promise<void> | undefined
-  private queryTransactionsQueued = false
+  private readonly queryTxMutex = makeMutex()
+  private pendingSeenReset = false
   private unsubscribeWalletEvent?: () => void
   private unsubscribeNymFetch?: () => Promise<void>
   private abortKeysWait?: () => void
@@ -401,7 +421,20 @@ export class MoneroEngine extends CurrencyEngine<
         return SYNC_POLL_MS
       }
 
-      this.updateBlockHeight(status.networkHeight)
+      // Smooth small height regressions: lwsf reports the stored account scan
+      // height until its first refresh completes, a load-balanced daemon can
+      // answer a block behind the previous poll, and the base engine re-stamps
+      // every tx's confirmation count on ANY height change, so honoring those
+      // dips makes displayed confirmations bounce. A large regression is
+      // accepted as a correction, so one garbage or wrong-chain reading cannot
+      // ratchet the stored height forever.
+      const storedHeight = this.walletLocalData.blockHeight
+      const networkHeight =
+        status.networkHeight >= storedHeight ||
+        storedHeight - status.networkHeight > HEIGHT_REGRESSION_BOUND
+          ? status.networkHeight
+          : storedHeight
+      this.updateBlockHeight(networkHeight)
 
       // Refresh the balance on every poll, not only once fully synced, so a
       // pending incoming tx or the pending change after a send is reflected
@@ -470,55 +503,50 @@ export class MoneroEngine extends CurrencyEngine<
   }
 
   private async queryTransactions(nativeWalletId: string): Promise<void> {
-    const PAGE_SIZE = 50
+    // Serialize passes with the fleet-standard mutex (Tron, Polkadot, and
+    // Algorand guard queryTransactions the same way): the sync poll and the
+    // pendingTransactionReceived event can both call this, and interleaved
+    // passes would race the scan cursor and the pending diff. A caller queued
+    // behind an in-flight pass runs its own full pass afterwards, so every
+    // caller's promise covers a pass that started at or after its call, even
+    // when an earlier pass throws.
+    return await this.queryTxMutex(async () => {
+      const PAGE_SIZE = 50
 
-    // The sync poll and the pendingTransactionReceived event can both call
-    // this; interleaved passes would race the scan cursor and the pending
-    // diff. A call that arrives mid-pass flags one coalesced re-run and awaits
-    // the in-flight run, whose promise only settles once the re-run queue has
-    // drained — so every caller's promise covers a pass that started at or
-    // after its call, and chained work (the event handler's balance refresh,
-    // syncNetwork's backfill pacing) never runs against a half-finished pass.
-    if (this.queryTransactionsRun != null) {
-      this.queryTransactionsQueued = true
-      return await this.queryTransactionsRun
-    }
+      // A queued caller can land here after killEngine (a settings change or
+      // resync wipes the state next); do not write into the fresh state.
+      if (!this.engineOn) return
 
-    const run = (async () => {
       try {
-        do {
-          this.queryTransactionsQueued = false
+        // The pending diff, cursor healing, and lastSeenTime preservation all
+        // consult the in-memory transaction list, which loadEngine only loads
+        // eagerly on a first-ever sync. Load it on warm launches too
+        // (idempotent after the first call):
+        await this.loadTransactions()
 
-          try {
-            if (this.txSortOrder === 'asc') {
-              await this.queryTransactionsAsc(nativeWalletId, PAGE_SIZE)
-            } else {
-              await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
-            }
+        if (this.txSortOrder === 'asc') {
+          await this.queryTransactionsAsc(nativeWalletId, PAGE_SIZE)
+        } else {
+          await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
+        }
 
-            // Pending transactions live outside the cursor protocol above:
-            // they sort behind all confirmed history, so neither scan reaches
-            // them. Process them on every pass so they appear before their
-            // first confirmation.
-            await this.queryPendingTransactions(nativeWalletId, PAGE_SIZE)
+        // Bail between stages when the engine stopped mid-pass, to shorten
+        // the tail of writes killEngine's drain has to wait out:
+        if (!this.engineOn) return
 
-            this.sendTransactionEvents()
-          } catch (error: unknown) {
-            // Log and keep looping: if another call arrived mid-pass, the
-            // loop still owes it a full pass — exiting here would silently
-            // skip that caller's trigger until the next sync poll. The loop
-            // stays bounded: a re-run only happens when a new call arrived
-            // during the failing pass.
-            this.log.error(`queryTransactions error: ${String(error)}`)
-          }
-        } while (this.queryTransactionsQueued)
+        // Pending transactions live outside the cursor protocol above: they
+        // sort behind all confirmed history, so neither scan reaches them.
+        // Process them on every pass so they appear before their first
+        // confirmation.
+        await this.queryPendingTransactions(nativeWalletId, PAGE_SIZE)
+      } catch (error: unknown) {
+        this.log.error(`queryTransactions error: ${String(error)}`)
       } finally {
-        this.queryTransactionsRun = undefined
+        // Flush events even when a later stage failed, so confirmed txs the
+        // scans already processed are not buffered until the next block:
+        this.sendTransactionEvents()
       }
-    })()
-
-    this.queryTransactionsRun = run
-    return await run
+    })
   }
 
   /** Look up the engine's stored copy of a transaction, if any. */
@@ -542,6 +570,22 @@ export class MoneroEngine extends CurrencyEngine<
     pageSize: number
   ): Promise<void> {
     const now = Date.now()
+
+    // Time while the engine was not running must not count toward the
+    // eviction grace: a tx can confirm or leave the pool while the app is
+    // closed, and the relaunch backfill has not caught up yet. Restart each
+    // surviving watch entry's clock once per engine session.
+    if (!this.pendingSeenReset) {
+      this.pendingSeenReset = true
+      const txids = Object.keys(this.otherData.pendingTxSeen)
+      if (txids.length > 0) {
+        const reset: { [txid: string]: number } = {}
+        for (const txid of txids) reset[txid] = now
+        this.otherData.pendingTxSeen = reset
+        this.walletLocalDataDirty = true
+      }
+    }
+
     const seen = new Set<string>()
     let page = 0
     while (true) {
@@ -554,14 +598,28 @@ export class MoneroEngine extends CurrencyEngine<
         seen.add(tx.hash)
         this.processTransaction(tx)
       }
-      if ((page + 1) * pageSize >= txPage.totalCount) break
+      // The short/empty-page check is insurance against a native totalCount
+      // that disagrees with the page contents:
+      if (
+        txPage.transactions.length < pageSize ||
+        (page + 1) * pageSize >= txPage.totalCount
+      ) {
+        break
+      }
       page++
     }
 
     // Rebuild the watch map: entries seen right now, plus absent-but-graced
     // entries. Resolved (confirmed/dropped) entries are simply not carried.
     const pendingTxSeen: { [txid: string]: number } = {}
-    for (const txid of seen) pendingTxSeen[txid] = now
+    for (const txid of seen) {
+      // Refresh a still-pending entry's stamp only periodically, so
+      // steady-state passes leave otherData byte-identical instead of
+      // rewriting walletLocalData on every save loop:
+      const prev = this.otherData.pendingTxSeen[txid]
+      pendingTxSeen[txid] =
+        prev != null && now - prev < PENDING_SEEN_REFRESH_MS ? prev : now
+    }
 
     for (const [txid, lastSeenMs] of Object.entries(
       this.otherData.pendingTxSeen
@@ -571,17 +629,26 @@ export class MoneroEngine extends CurrencyEngine<
       // Stop watching entries that resolved (confirmed or already dropped):
       if (stored == null || stored.blockHeight !== 0) continue
       // 'failed' is already a terminal state (a spend the backend reported as
-      // failed); leaving the pool is expected — don't relabel it as dropped:
+      // failed); leaving the pool is expected, so don't relabel it as dropped:
       if (stored.confirmations === 'failed') continue
-      if (now - lastSeenMs < DROPPED_TX_GRACE_MS) {
-        // Still within the grace window: keep watching.
+      if (
+        now - lastSeenMs < DROPPED_TX_GRACE_MS ||
+        // Only declare drops once the backfill has completed a full confirmed
+        // scan; during 'asc' the confirmed copy may simply not be ingested
+        // yet:
+        this.txSortOrder !== 'desc'
+      ) {
+        // Still within the grace window (or unable to judge): keep watching.
         pendingTxSeen[txid] = lastSeenMs
         continue
       }
       // Set 'dropped' explicitly: the base engine clamps negative block
-      // heights to 0 unless confirmations is already a terminal state.
+      // heights to 0 unless confirmations is already a terminal state. Spread
+      // otherParams too: addTransaction stamps lastSeenTime through it, and a
+      // shared reference would silently rewrite the stored entry's stamp.
       this.addTransaction(null, {
         ...stored,
+        otherParams: { ...stored.otherParams },
         blockHeight: -1,
         confirmations: 'dropped'
       })
@@ -651,6 +718,7 @@ export class MoneroEngine extends CurrencyEngine<
   ): Promise<void> {
     let page = 0
     let foundKnownTx = false
+    let healSweep = false
     let newestTxid: string | undefined
 
     while (!foundKnownTx) {
@@ -669,15 +737,21 @@ export class MoneroEngine extends CurrencyEngine<
       }
 
       for (const tx of txPage.transactions) {
-        if (tx.hash === this.otherData.mostRecentTxid) {
+        if (!healSweep && tx.hash === this.otherData.mostRecentTxid) {
           // Heal a stale stored copy before stopping: if the anchor tx is
           // confirmed on-chain but our copy never saw the confirmation (a
           // cursor recorded while the tx was still pending), process it once
-          // more so it stops displaying as unconfirmed.
+          // more so it stops displaying as unconfirmed. The same old-code
+          // migration can have left more stuck-pending txs behind the anchor,
+          // so when the anchor itself needed healing, walk the rest of the
+          // history once, re-processing only rows whose stored copy is still
+          // missing its height.
           if (!tx.isPending) {
             const stored = this.storedTransaction(tx.hash)
             if (stored == null || stored.blockHeight < 1) {
               this.processTransaction(tx)
+              healSweep = true
+              continue
             }
           }
           foundKnownTx = true
@@ -685,6 +759,10 @@ export class MoneroEngine extends CurrencyEngine<
         }
         // Pending rows are handled by queryPendingTransactions:
         if (tx.isPending) continue
+        if (healSweep) {
+          const stored = this.storedTransaction(tx.hash)
+          if (stored != null && stored.blockHeight >= 1) continue
+        }
         this.processTransaction(tx)
       }
 
@@ -776,23 +854,57 @@ export class MoneroEngine extends CurrencyEngine<
     if (tx.isPending) {
       // Pending txs are re-processed on every pass. Without a lastSeenTime the
       // base engine stamps a fresh one on each add, which reads as a change
-      // and emits a spurious update event per poll — keep the first-seen time.
+      // and emits a spurious update event per poll, so keep the prior stamp
+      // while it is fresh. Refresh it hourly though (undefined lets the base
+      // stamp now): the base engine independently drops an unconfirmed tx once
+      // the stamp is older than 24 hours, and a pool residence can outlast
+      // that.
       const stored = this.storedTransaction(tx.hash)
-      const lastSeenTime = asMaybe(asNumber)(stored?.otherParams?.lastSeenTime)
+      const prior = asMaybe(asNumber)(stored?.otherParams?.lastSeenTime)
+      const nowSeconds = Math.round(Date.now() / 1000)
+      const lastSeenTime =
+        prior != null && nowSeconds - prior < LAST_SEEN_REFRESH_S
+          ? prior
+          : undefined
       this.addTransaction(null, edgeTransaction, lastSeenTime)
     } else {
       this.addTransaction(null, edgeTransaction)
     }
   }
 
+  // Receives enter the store while still pending (blockHeight 0), so the base
+  // checkpoint math treats the first sighting as already seen ('0' never
+  // advances past a synced checkpoint) and the later confirmation takes the
+  // update path, which never notifies. Mirror ZcashEngine's partial fix: an
+  // incoming unconfirmed tx seen after the first-ever sync is new. The same
+  // multi-device caveat as Zcash applies.
+  protected isTransactionNew(edgeTransaction: EdgeTransaction): boolean {
+    if (
+      edgeTransaction.blockHeight === 0 &&
+      edgeTransaction.confirmations === 'unconfirmed' &&
+      this.seenTxCheckpoint != null &&
+      !edgeTransaction.isSend
+    ) {
+      return true
+    }
+    return super.isTransactionNew(edgeTransaction)
+  }
+
   async killEngine(): Promise<void> {
     this.abortKeysWait?.()
     await this.nativeWalletId.stop()
+    await super.killEngine()
+    // Drain any in-flight transaction pass BEFORE resetting the session state
+    // below: the pass started while the engine was on and may still write
+    // (txSortOrder, otherData) until it finishes, so resetting first would let
+    // those late writes clobber the resets and stick across a settings-change
+    // restart. engineOn is false now, so queued callers exit immediately.
+    await this.queryTxMutex(async () => {})
     this.syncStartHeight = undefined
     this.unlockedBalance = '0'
     this.txSortOrder = 'asc'
+    this.pendingSeenReset = false
     this.syncTracker.resetSync()
-    await super.killEngine()
   }
 
   async resyncBlockchain(): Promise<void> {

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -60,6 +60,10 @@ const SYNC_POLL_MS = 1000 // actively syncing / backfilling
 const SYNCED_POLL_MS = 20000 // caught up to chain tip
 const ERROR_POLL_MS = 5000 // back off after a sync error
 
+// How long a formerly-pending tx must stay missing (from both the pending set
+// and confirmed history) before it is considered evicted from the pool:
+export const DROPPED_TX_GRACE_MS = 30 * 60 * 1000
+
 /**
  * Converts an Edge walletId (standard base64) into the form the native monero
  * layer expects. The native code embeds the id in a filesystem path and rejects
@@ -85,6 +89,8 @@ export class MoneroEngine extends CurrencyEngine<
   private sendKeysToNative?: (keys: MoneroPrivateKeys) => void
   private syncStartHeight: number | undefined
   private txSortOrder: 'asc' | 'desc' = 'asc'
+  private queryTransactionsRun: Promise<void> | undefined
+  private queryTransactionsQueued = false
   private unsubscribeWalletEvent?: () => void
   private unsubscribeNymFetch?: () => Promise<void>
   private abortKeysWait?: () => void
@@ -466,22 +472,53 @@ export class MoneroEngine extends CurrencyEngine<
   private async queryTransactions(nativeWalletId: string): Promise<void> {
     const PAGE_SIZE = 50
 
-    try {
-      if (this.txSortOrder === 'asc') {
-        await this.queryTransactionsAsc(nativeWalletId, PAGE_SIZE)
-      } else {
-        await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
-      }
-
-      // Pending transactions live outside the cursor protocol above: they sort
-      // behind all confirmed history, so neither scan reaches them. Process
-      // them on every pass so they appear before their first confirmation.
-      await this.queryPendingTransactions(nativeWalletId, PAGE_SIZE)
-
-      this.sendTransactionEvents()
-    } catch (error: unknown) {
-      this.log.error(`queryTransactions error: ${String(error)}`)
+    // The sync poll and the pendingTransactionReceived event can both call
+    // this; interleaved passes would race the scan cursor and the pending
+    // diff. A call that arrives mid-pass flags one coalesced re-run and awaits
+    // the in-flight run, whose promise only settles once the re-run queue has
+    // drained — so every caller's promise covers a pass that started at or
+    // after its call, and chained work (the event handler's balance refresh,
+    // syncNetwork's backfill pacing) never runs against a half-finished pass.
+    if (this.queryTransactionsRun != null) {
+      this.queryTransactionsQueued = true
+      return await this.queryTransactionsRun
     }
+
+    const run = (async () => {
+      try {
+        do {
+          this.queryTransactionsQueued = false
+
+          try {
+            if (this.txSortOrder === 'asc') {
+              await this.queryTransactionsAsc(nativeWalletId, PAGE_SIZE)
+            } else {
+              await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
+            }
+
+            // Pending transactions live outside the cursor protocol above:
+            // they sort behind all confirmed history, so neither scan reaches
+            // them. Process them on every pass so they appear before their
+            // first confirmation.
+            await this.queryPendingTransactions(nativeWalletId, PAGE_SIZE)
+
+            this.sendTransactionEvents()
+          } catch (error: unknown) {
+            // Log and keep looping: if another call arrived mid-pass, the
+            // loop still owes it a full pass — exiting here would silently
+            // skip that caller's trigger until the next sync poll. The loop
+            // stays bounded: a re-run only happens when a new call arrived
+            // during the failing pass.
+            this.log.error(`queryTransactions error: ${String(error)}`)
+          }
+        } while (this.queryTransactionsQueued)
+      } finally {
+        this.queryTransactionsRun = undefined
+      }
+    })()
+
+    this.queryTransactionsRun = run
+    return await run
   }
 
   /** Look up the engine's stored copy of a transaction, if any. */
@@ -492,11 +529,20 @@ export class MoneroEngine extends CurrencyEngine<
   }
 
   // Read the pending set directly and process every entry (addTransaction
-  // ignores unchanged data).
+  // ignores unchanged data). Anything that stays gone from the pool without
+  // ever gaining a block height was evicted (never mined): mark it dropped.
+  // The confirmed scan runs first, so a confirmation has already updated the
+  // stored copy by the time the drop check runs. Absence alone is NOT enough
+  // to declare a drop: a just-mined tx leaves the pool immediately but only
+  // shows up as confirmed once the LWS server has indexed its block, so a tx
+  // must stay missing for DROPPED_TX_GRACE_MS first. Real pool evictions take
+  // hours to days, so the grace does not meaningfully delay them.
   private async queryPendingTransactions(
     nativeWalletId: string,
     pageSize: number
   ): Promise<void> {
+    const now = Date.now()
+    const seen = new Set<string>()
     let page = 0
     while (true) {
       const txPage = await this.tools.cppBridge.getPendingTransactions(
@@ -505,10 +551,45 @@ export class MoneroEngine extends CurrencyEngine<
         pageSize
       )
       for (const tx of txPage.transactions) {
+        seen.add(tx.hash)
         this.processTransaction(tx)
       }
       if ((page + 1) * pageSize >= txPage.totalCount) break
       page++
+    }
+
+    // Rebuild the watch map: entries seen right now, plus absent-but-graced
+    // entries. Resolved (confirmed/dropped) entries are simply not carried.
+    const pendingTxSeen: { [txid: string]: number } = {}
+    for (const txid of seen) pendingTxSeen[txid] = now
+
+    for (const [txid, lastSeenMs] of Object.entries(
+      this.otherData.pendingTxSeen
+    )) {
+      if (seen.has(txid)) continue
+      const stored = this.storedTransaction(txid)
+      // Stop watching entries that resolved (confirmed or already dropped):
+      if (stored == null || stored.blockHeight !== 0) continue
+      // 'failed' is already a terminal state (a spend the backend reported as
+      // failed); leaving the pool is expected — don't relabel it as dropped:
+      if (stored.confirmations === 'failed') continue
+      if (now - lastSeenMs < DROPPED_TX_GRACE_MS) {
+        // Still within the grace window: keep watching.
+        pendingTxSeen[txid] = lastSeenMs
+        continue
+      }
+      // Set 'dropped' explicitly: the base engine clamps negative block
+      // heights to 0 unless confirmations is already a terminal state.
+      this.addTransaction(null, {
+        ...stored,
+        blockHeight: -1,
+        confirmations: 'dropped'
+      })
+    }
+
+    if (!matchJson(this.otherData.pendingTxSeen, pendingTxSeen)) {
+      this.otherData.pendingTxSeen = pendingTxSeen
+      this.walletLocalDataDirty = true
     }
   }
 

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -1,5 +1,5 @@
 import { add, eq, gt, lt, mul, sub } from 'biggystring'
-import { asMaybe } from 'cleaners'
+import { asMaybe, asNumber } from 'cleaners'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
@@ -23,7 +23,12 @@ import {
   LifecycleManager,
   makeLifecycleManager
 } from '../common/lifecycleManager'
-import { cleanTxLogs, makeEngineFetch, matchJson } from '../common/utils'
+import {
+  cleanTxLogs,
+  makeEngineFetch,
+  matchJson,
+  normalizeAddress
+} from '../common/utils'
 import {
   makeWeightedSyncTracker,
   WeightedSyncTracker
@@ -463,18 +468,15 @@ export class MoneroEngine extends CurrencyEngine<
 
     try {
       if (this.txSortOrder === 'asc') {
-        const shouldSendEvents = await this.queryTransactionsAsc(
-          nativeWalletId,
-          PAGE_SIZE
-        )
-        if (!shouldSendEvents) {
-          return
-        }
-        this.sendTransactionEvents()
-        return
+        await this.queryTransactionsAsc(nativeWalletId, PAGE_SIZE)
+      } else {
+        await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
       }
 
-      await this.queryTransactionsDesc(nativeWalletId, PAGE_SIZE)
+      // Pending transactions live outside the cursor protocol above: they sort
+      // behind all confirmed history, so neither scan reaches them. Process
+      // them on every pass so they appear before their first confirmation.
+      await this.queryPendingTransactions(nativeWalletId, PAGE_SIZE)
 
       this.sendTransactionEvents()
     } catch (error: unknown) {
@@ -482,10 +484,38 @@ export class MoneroEngine extends CurrencyEngine<
     }
   }
 
+  /** Look up the engine's stored copy of a transaction, if any. */
+  private storedTransaction(txid: string): EdgeTransaction | undefined {
+    const idx = this.findTransaction(null, normalizeAddress(txid))
+    if (idx < 0) return undefined
+    return this.transactionList['']?.[idx]
+  }
+
+  // Read the pending set directly and process every entry (addTransaction
+  // ignores unchanged data).
+  private async queryPendingTransactions(
+    nativeWalletId: string,
+    pageSize: number
+  ): Promise<void> {
+    let page = 0
+    while (true) {
+      const txPage = await this.tools.cppBridge.getPendingTransactions(
+        nativeWalletId,
+        page,
+        pageSize
+      )
+      for (const tx of txPage.transactions) {
+        this.processTransaction(tx)
+      }
+      if ((page + 1) * pageSize >= txPage.totalCount) break
+      page++
+    }
+  }
+
   private async queryTransactionsAsc(
     nativeWalletId: string,
     pageSize: number
-  ): Promise<boolean> {
+  ): Promise<void> {
     const startPage = Math.floor(
       this.otherData.processedTransactionCount / pageSize
     )
@@ -500,7 +530,7 @@ export class MoneroEngine extends CurrencyEngine<
     if (txPage.totalCount === 0) {
       // No history to backfill, so treat the ascending pass as complete:
       this.txSortOrder = 'desc'
-      return false
+      return
     }
 
     const onPageBoundary =
@@ -513,6 +543,10 @@ export class MoneroEngine extends CurrencyEngine<
         }
         continue
       }
+      // Pending rows are handled by queryPendingTransactions and must never
+      // become the cursor anchor: only a confirmed transaction is immutable,
+      // so only a confirmed hash can safely mark where the scan left off.
+      if (tx.isPending) continue
       this.processTransaction(tx)
       this.otherData.mostRecentTxid = tx.hash
     }
@@ -528,8 +562,6 @@ export class MoneroEngine extends CurrencyEngine<
     if (this.otherData.processedTransactionCount >= txPage.totalCount) {
       this.txSortOrder = 'desc'
     }
-
-    return true
   }
 
   private async queryTransactionsDesc(
@@ -548,15 +580,30 @@ export class MoneroEngine extends CurrencyEngine<
         'desc'
       )
 
-      if (page === 0 && txPage.transactions.length > 0) {
-        newestTxid = txPage.transactions[0].hash
+      if (page === 0) {
+        // Anchor only on a confirmed transaction: a pending hash recorded here
+        // would match this same tx after it confirms and stop the scan from
+        // ever re-processing it with its block height.
+        newestTxid = txPage.transactions.find(tx => !tx.isPending)?.hash
       }
 
       for (const tx of txPage.transactions) {
         if (tx.hash === this.otherData.mostRecentTxid) {
+          // Heal a stale stored copy before stopping: if the anchor tx is
+          // confirmed on-chain but our copy never saw the confirmation (a
+          // cursor recorded while the tx was still pending), process it once
+          // more so it stops displaying as unconfirmed.
+          if (!tx.isPending) {
+            const stored = this.storedTransaction(tx.hash)
+            if (stored == null || stored.blockHeight < 1) {
+              this.processTransaction(tx)
+            }
+          }
           foundKnownTx = true
           break
         }
+        // Pending rows are handled by queryPendingTransactions:
+        if (tx.isPending) continue
         this.processTransaction(tx)
       }
 
@@ -645,7 +692,16 @@ export class MoneroEngine extends CurrencyEngine<
       edgeTransaction.confirmations = 'failed'
     }
 
-    this.addTransaction(null, edgeTransaction)
+    if (tx.isPending) {
+      // Pending txs are re-processed on every pass. Without a lastSeenTime the
+      // base engine stamps a fresh one on each add, which reads as a change
+      // and emits a spurious update event per poll — keep the first-seen time.
+      const stored = this.storedTransaction(tx.hash)
+      const lastSeenTime = asMaybe(asNumber)(stored?.otherParams?.lastSeenTime)
+      this.addTransaction(null, edgeTransaction, lastSeenTime)
+    } else {
+      this.addTransaction(null, edgeTransaction)
+    }
   }
 
   async killEngine(): Promise<void> {

--- a/src/monero/moneroTypes.ts
+++ b/src/monero/moneroTypes.ts
@@ -165,7 +165,15 @@ export function translateFee(fee?: string): TransactionPriority {
 
 export const asMoneroWalletOtherData = asObject({
   processedTransactionCount: asMaybe(asNumber, 0),
-  mostRecentTxid: asMaybe(asString)
+  mostRecentTxid: asMaybe(asString),
+  // Last time (ms) each pool txid was seen in the pending set, so a tx that
+  // stays missing without ever confirming can be marked dropped. Absence alone
+  // is not enough: a just-mined tx briefly vanishes from both the pending set
+  // and the confirmed list while the LWS server indexes its block.
+  pendingTxSeen: asMaybe(
+    asObject(asNumber),
+    (): { [txid: string]: number } => ({})
+  )
 })
 export type MoneroWalletOtherData = ReturnType<typeof asMoneroWalletOtherData>
 

--- a/test/monero/MoneroEnginePendingTxs.test.ts
+++ b/test/monero/MoneroEnginePendingTxs.test.ts
@@ -1,0 +1,268 @@
+import { assert } from 'chai'
+import {
+  EdgeCurrencyEngineCallbacks,
+  EdgeCurrencyEngineOptions,
+  EdgeTransaction,
+  makeFakeIo
+} from 'edge-core-js'
+import { describe, it } from 'mocha'
+import type { TransactionInfo, TransactionsPage } from 'react-native-monero'
+
+import { PluginEnvironment } from '../../src/common/innerPlugin'
+import { MoneroEngine } from '../../src/monero/MoneroEngine'
+import { currencyInfo } from '../../src/monero/moneroInfo'
+import { MoneroTools } from '../../src/monero/MoneroTools'
+import {
+  EDGE_MONERO_LWS_SERVER,
+  MoneroNetworkInfo,
+  SafeMoneroWalletInfo
+} from '../../src/monero/moneroTypes'
+import { fakeLog } from '../fake/fakeLog'
+
+const WALLET_ID = 'native-wallet-id'
+
+/** The lwsf "not mined yet" sentinel, as JSON.parse delivers it. */
+const PENDING_HEIGHT_SENTINEL = 18446744073709552000
+
+interface FakeChain {
+  confirmed: TransactionInfo[]
+  pending: TransactionInfo[]
+}
+
+function makeTx(hash: string, blockHeight: number | null): TransactionInfo {
+  return {
+    hash,
+    direction: 0,
+    isPending: blockHeight == null,
+    isFailed: false,
+    isCoinbase: false,
+    amount: '1000000000000',
+    fee: '50000000',
+    blockHeight: blockHeight ?? PENDING_HEIGHT_SENTINEL,
+    confirmations: 0,
+    timestamp: 1750000000,
+    paymentId: '',
+    description: '',
+    label: '',
+    unlockTime: 0,
+    subaddrAccount: 0
+  }
+}
+
+/**
+ * Replicates the native getAllTransactions/getPendingTransactions contract:
+ * confirmed transactions sorted by height, pending entries always behind every
+ * confirmed one, both queries paged.
+ */
+function makeFakeBridge(chain: FakeChain): unknown {
+  const pageOf = (
+    txs: TransactionInfo[],
+    page: number,
+    pageSize: number
+  ): TransactionsPage => ({
+    transactions: txs.slice(page * pageSize, (page + 1) * pageSize),
+    totalCount: txs.length,
+    page,
+    pageSize
+  })
+
+  return {
+    async getAllTransactions(
+      _walletId: string,
+      page: number,
+      pageSize: number,
+      sort: 'asc' | 'desc'
+    ): Promise<TransactionsPage> {
+      const confirmed = [...chain.confirmed].sort((a, b) =>
+        sort === 'asc'
+          ? a.blockHeight - b.blockHeight
+          : b.blockHeight - a.blockHeight
+      )
+      return pageOf([...confirmed, ...chain.pending], page, pageSize)
+    },
+
+    async getPendingTransactions(
+      _walletId: string,
+      page: number,
+      pageSize: number
+    ): Promise<TransactionsPage> {
+      return pageOf(chain.pending, page, pageSize)
+    }
+  }
+}
+
+interface TestEngine {
+  engine: MoneroEngine
+  events: Array<{ isNew: boolean; transaction: EdgeTransaction }>
+  queryTransactions: () => Promise<void>
+  storedTx: (txid: string) => EdgeTransaction | undefined
+}
+
+async function makeEngine(chain: FakeChain): Promise<TestEngine> {
+  const fakeIo = makeFakeIo()
+  const events: Array<{ isNew: boolean; transaction: EdgeTransaction }> = []
+
+  const callbacks: EdgeCurrencyEngineCallbacks = {
+    onAddressChanged() {},
+    onAddressesChecked() {},
+    onBalanceChanged() {},
+    onBlockHeightChanged() {},
+    onNewTokens() {},
+    onSeenTxCheckpoint() {},
+    onStakingStatusChanged() {},
+    onSubscribeAddresses() {},
+    onSyncStatusChanged() {},
+    onTokenBalanceChanged() {},
+    onTransactions(transactionEvents) {
+      events.push(...transactionEvents)
+    },
+    onTransactionsChanged() {},
+    onTxidsChanged() {},
+    onUnactivatedTokenIdsChanged() {},
+    onWcNewContractCall() {}
+  }
+
+  const opts: EdgeCurrencyEngineOptions = {
+    callbacks,
+    customTokens: {},
+    enabledTokenIds: [],
+    log: fakeLog,
+    userSettings: {},
+    walletLocalDisklet: fakeIo.disklet,
+    walletLocalEncryptedDisklet: fakeIo.disklet,
+    walletSettings: {}
+  }
+
+  const env = {
+    currencyInfo,
+    initOptions: { edgeApiKey: '' },
+    io: fakeIo,
+    log: fakeLog,
+    networkInfo: {
+      edgeLwsServer: EDGE_MONERO_LWS_SERVER,
+      networkType: 'MAINNET'
+    }
+  } as unknown as PluginEnvironment<MoneroNetworkInfo>
+
+  const tools = {
+    cppBridge: makeFakeBridge(chain),
+    moneroIo: { on: () => () => {} }
+  } as unknown as MoneroTools
+
+  const walletInfo: SafeMoneroWalletInfo = {
+    id: 'wallet-1',
+    type: 'wallet:monero',
+    keys: {
+      publicKey: '4-fake-address',
+      moneroAddress: '4-fake-address',
+      moneroViewKeyPrivate: 'view-private',
+      moneroViewKeyPublic: 'view-public',
+      moneroSpendKeyPublic: 'spend-public'
+    }
+  }
+
+  const engine = new MoneroEngine(
+    env,
+    tools,
+    walletInfo,
+    { edgeApiKey: '' },
+    opts
+  )
+  await engine.loadEngine()
+
+  return {
+    engine,
+    events,
+    queryTransactions: async () => {
+      await (engine as any).queryTransactions(WALLET_ID)
+    },
+    storedTx: (txid: string) => (engine as any).storedTransaction(txid)
+  }
+}
+
+describe('MoneroEngine pending transactions', function () {
+  it('surfaces pending txs during the ascending backfill and anchors only on confirmed txs', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100), makeTx('c2', 101)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+
+    await queryTransactions()
+
+    assert.equal(storedTx('c1')?.blockHeight, 100)
+    assert.equal(storedTx('c2')?.blockHeight, 101)
+    // The pending tx appears immediately, with the sentinel height masked:
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+    // The anchor is the newest confirmed tx, never the pending one:
+    assert.equal(engine.otherData.mostRecentTxid, 'c2')
+    assert.equal((engine as any).txSortOrder, 'desc')
+  })
+
+  it('surfaces a new pending incoming tx while anchored on confirmed history', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100), makeTx('c2', 101)],
+      pending: []
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions() // backfill + anchor at c2
+
+    chain.pending.push(makeTx('p1', null))
+    await queryTransactions()
+
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+    assert.equal(engine.otherData.mostRecentTxid, 'c2')
+  })
+
+  it('re-processes a pending tx once it confirms', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions()
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+
+    chain.pending = []
+    chain.confirmed.push(makeTx('p1', 102))
+    await queryTransactions()
+
+    assert.equal(storedTx('p1')?.blockHeight, 102)
+    assert.equal(engine.otherData.mostRecentTxid, 'p1')
+  })
+
+  it('heals a cursor that was recorded while its tx was still pending', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('x1', 105)],
+      pending: []
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+
+    // Simulate data written by older code: the tx is stored unconfirmed and
+    // its own hash is the cursor anchor.
+    ;(engine as any).txSortOrder = 'desc'
+    ;(engine as any).processTransaction(makeTx('x1', null))
+    engine.otherData.mostRecentTxid = 'x1'
+    assert.equal(storedTx('x1')?.blockHeight, 0)
+
+    await queryTransactions()
+
+    assert.equal(storedTx('x1')?.blockHeight, 105)
+  })
+
+  it('does not emit change events when re-processing an unchanged pending tx', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, events } = await makeEngine(chain)
+    await queryTransactions()
+    assert.isAbove(events.length, 0)
+
+    events.length = 0
+    await queryTransactions()
+    await queryTransactions()
+
+    assert.equal(events.length, 0)
+  })
+})

--- a/test/monero/MoneroEnginePendingTxs.test.ts
+++ b/test/monero/MoneroEnginePendingTxs.test.ts
@@ -9,7 +9,10 @@ import { describe, it } from 'mocha'
 import type { TransactionInfo, TransactionsPage } from 'react-native-monero'
 
 import { PluginEnvironment } from '../../src/common/innerPlugin'
-import { MoneroEngine } from '../../src/monero/MoneroEngine'
+import {
+  DROPPED_TX_GRACE_MS,
+  MoneroEngine
+} from '../../src/monero/MoneroEngine'
 import { currencyInfo } from '../../src/monero/moneroInfo'
 import { MoneroTools } from '../../src/monero/MoneroTools'
 import {
@@ -27,6 +30,10 @@ const PENDING_HEIGHT_SENTINEL = 18446744073709552000
 interface FakeChain {
   confirmed: TransactionInfo[]
   pending: TransactionInfo[]
+  // Called after each getPendingTransactions snapshots its page (so mutations
+  // affect the next pass, not this one). Used to simulate an event arriving
+  // mid-pass.
+  onPendingQuery?: () => Promise<void>
 }
 
 function makeTx(hash: string, blockHeight: number | null): TransactionInfo {
@@ -86,7 +93,9 @@ function makeFakeBridge(chain: FakeChain): unknown {
       page: number,
       pageSize: number
     ): Promise<TransactionsPage> {
-      return pageOf(chain.pending, page, pageSize)
+      const result = pageOf(chain.pending, page, pageSize)
+      if (chain.onPendingQuery != null) await chain.onPendingQuery()
+      return result
     }
   }
 }
@@ -248,6 +257,133 @@ describe('MoneroEngine pending transactions', function () {
     await queryTransactions()
 
     assert.equal(storedTx('x1')?.blockHeight, 105)
+  })
+
+  it('marks a tx dropped only after a sustained absence from the pool', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions()
+    assert.hasAllKeys(engine.otherData.pendingTxSeen, ['p1'])
+
+    // The tx leaves the pool. Within the grace window nothing changes — this
+    // is also what a just-mined tx looks like before the server indexes it:
+    chain.pending = []
+    await queryTransactions()
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+
+    // Still missing once the grace window has passed: dropped.
+    engine.otherData.pendingTxSeen.p1 = Date.now() - DROPPED_TX_GRACE_MS - 1
+    await queryTransactions()
+
+    assert.equal(storedTx('p1')?.blockHeight, -1)
+    assert.deepEqual(engine.otherData.pendingTxSeen, {})
+  })
+
+  it('does not relabel a failed tx as dropped when it leaves the pool', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [{ ...makeTx('f1', null), isFailed: true }]
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions()
+    assert.equal(storedTx('f1')?.confirmations, 'failed')
+
+    // The failed tx leaves the pool and stays gone past the grace window:
+    chain.pending = []
+    engine.otherData.pendingTxSeen.f1 = Date.now() - DROPPED_TX_GRACE_MS - 1
+    await queryTransactions()
+
+    // Still 'failed', not relabeled 'dropped', and no longer watched:
+    assert.equal(storedTx('f1')?.confirmations, 'failed')
+    assert.equal(storedTx('f1')?.blockHeight, 0)
+    assert.deepEqual(engine.otherData.pendingTxSeen, {})
+  })
+
+  it('confirms (not drops) a tx that reappears confirmed after briefly vanishing', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions()
+
+    // Mined: gone from the pool, but not yet indexed as confirmed.
+    chain.pending = []
+    await queryTransactions()
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+
+    // The server indexes the block:
+    chain.confirmed.push(makeTx('p1', 102))
+    await queryTransactions()
+
+    assert.equal(storedTx('p1')?.blockHeight, 102)
+    assert.deepEqual(engine.otherData.pendingTxSeen, {})
+  })
+
+  it('re-runs instead of dropping a call that arrives mid-pass', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: []
+    }
+    const { engine, queryTransactions, storedTx } = await makeEngine(chain)
+
+    let fired = false
+    let storedWhenInnerResolved: EdgeTransaction | undefined
+    let innerCall: Promise<void> = Promise.resolve()
+    chain.onPendingQuery = async () => {
+      if (fired) return
+      fired = true
+      // A pending tx arrives after this pass already snapshotted an empty
+      // pool, and the event fires a second query while the first is still in
+      // flight. The call must coalesce into a re-run rather than run
+      // concurrently or be dropped, and its promise must not resolve until
+      // that re-run has ingested the new tx.
+      chain.pending.push(makeTx('p1', null))
+      innerCall = (
+        (engine as any).queryTransactions(WALLET_ID) as Promise<void>
+      ).then(() => {
+        storedWhenInnerResolved = storedTx('p1')
+      })
+    }
+
+    await queryTransactions()
+    await innerCall
+
+    // The coalesced re-run picked up the tx that arrived mid-pass, instead of
+    // leaving it invisible until the next sync poll:
+    assert.equal(storedTx('p1')?.blockHeight, 0)
+    // And the coalesced caller's promise did not resolve early — the tx was
+    // already stored by the time it settled:
+    assert.equal(storedWhenInnerResolved?.blockHeight, 0)
+  })
+
+  it('still honors a queued call when the in-flight pass throws', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: []
+    }
+    const { engine, queryTransactions, storedTx } = await makeEngine(chain)
+
+    let fired = false
+    let innerCall: Promise<void> = Promise.resolve()
+    chain.onPendingQuery = async () => {
+      if (fired) return
+      fired = true
+      // A call arrives mid-pass, and then the in-flight pass itself fails:
+      chain.pending.push(makeTx('p1', null))
+      innerCall = (engine as any).queryTransactions(WALLET_ID) as Promise<void>
+      throw new Error('bridge exploded')
+    }
+
+    await queryTransactions()
+    await innerCall
+
+    // The queued re-run still ran after the error and picked up the tx,
+    // instead of the error exiting the loop and stranding the queued caller:
+    assert.equal(storedTx('p1')?.blockHeight, 0)
   })
 
   it('does not emit change events when re-processing an unchanged pending tx', async function () {

--- a/test/monero/MoneroEnginePendingTxs.test.ts
+++ b/test/monero/MoneroEnginePendingTxs.test.ts
@@ -136,6 +136,9 @@ async function makeEngine(chain: FakeChain): Promise<TestEngine> {
     customTokens: {},
     enabledTokenIds: [],
     log: fakeLog,
+    // A non-null checkpoint means "not the first-ever sync", so
+    // new-transaction notifications are armed:
+    seenTxCheckpoint: '0',
     userSettings: {},
     walletLocalDisklet: fakeIo.disklet,
     walletLocalEncryptedDisklet: fakeIo.disklet,
@@ -178,6 +181,9 @@ async function makeEngine(chain: FakeChain): Promise<TestEngine> {
     opts
   )
   await engine.loadEngine()
+  // queryTransactions refuses to run on a stopped engine; the tests drive it
+  // directly without the full startEngine plumbing:
+  ;(engine as any).engineOn = true
 
   return {
     engine,
@@ -268,7 +274,7 @@ describe('MoneroEngine pending transactions', function () {
     await queryTransactions()
     assert.hasAllKeys(engine.otherData.pendingTxSeen, ['p1'])
 
-    // The tx leaves the pool. Within the grace window nothing changes — this
+    // The tx leaves the pool. Within the grace window nothing changes; this
     // is also what a just-mined tx looks like before the server indexes it:
     chain.pending = []
     await queryTransactions()
@@ -355,7 +361,7 @@ describe('MoneroEngine pending transactions', function () {
     // The coalesced re-run picked up the tx that arrived mid-pass, instead of
     // leaving it invisible until the next sync poll:
     assert.equal(storedTx('p1')?.blockHeight, 0)
-    // And the coalesced caller's promise did not resolve early — the tx was
+    // And the coalesced caller's promise did not resolve early: the tx was
     // already stored by the time it settled:
     assert.equal(storedWhenInnerResolved?.blockHeight, 0)
   })
@@ -384,6 +390,86 @@ describe('MoneroEngine pending transactions', function () {
     // The queued re-run still ran after the error and picked up the tx,
     // instead of the error exiting the loop and stranding the queued caller:
     assert.equal(storedTx('p1')?.blockHeight, 0)
+  })
+
+  it('emits a new-transaction notification for a first-sighted pending receive', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: [makeTx('p1', null)]
+    }
+    const { queryTransactions, events } = await makeEngine(chain)
+
+    await queryTransactions()
+
+    // A receive now enters the store while pending; the base checkpoint math
+    // alone would report isNew false forever (checkpoint '0', then the
+    // confirmation takes the update path):
+    const p1Event = events.find(e => e.transaction.txid === 'p1')
+    assert.equal(p1Event?.isNew, true)
+  })
+
+  it('heals stuck-pending txs behind a healed anchor', async function () {
+    const chain: FakeChain = {
+      confirmed: [],
+      pending: []
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+
+    // Old-code migration state: two receives stored while pending, with the
+    // newer one recorded as the scan anchor.
+    ;(engine as any).txSortOrder = 'desc'
+    ;(engine as any).processTransaction(makeTx('x1', null))
+    ;(engine as any).processTransaction(makeTx('x2', null))
+    engine.otherData.mostRecentTxid = 'x1'
+
+    // Both have long since confirmed on-chain:
+    chain.confirmed.push(makeTx('x2', 105), makeTx('x1', 106))
+    await queryTransactions()
+
+    assert.equal(storedTx('x1')?.blockHeight, 106)
+    // The scan continued past the healed anchor and repaired the older one:
+    assert.equal(storedTx('x2')?.blockHeight, 105)
+  })
+
+  it('does not count time while the engine was stopped toward the drop grace', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: []
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+
+    // Persisted state from a previous session: a tx stored pending whose watch
+    // stamp is far older than the grace (the app was closed meanwhile).
+    ;(engine as any).txSortOrder = 'desc'
+    ;(engine as any).processTransaction(makeTx('z1', null))
+    engine.otherData.pendingTxSeen = {
+      z1: Date.now() - DROPPED_TX_GRACE_MS - 60000
+    }
+
+    await queryTransactions()
+
+    // First pass of the session restarts the clock instead of dropping:
+    assert.equal(storedTx('z1')?.blockHeight, 0)
+    assert.notEqual(storedTx('z1')?.confirmations, 'dropped')
+  })
+
+  it('ignores passes after killEngine', async function () {
+    const chain: FakeChain = {
+      confirmed: [makeTx('c1', 100)],
+      pending: []
+    }
+    const { queryTransactions, storedTx, engine } = await makeEngine(chain)
+    await queryTransactions()
+    assert.equal(storedTx('c1')?.blockHeight, 100)
+
+    await engine.killEngine()
+
+    chain.confirmed.push(makeTx('c2', 101))
+    await queryTransactions()
+
+    // The stopped engine does not ingest (a queued stale pass cannot write
+    // into freshly wiped state after a resync):
+    assert.isUndefined(storedTx('c2'))
   })
 
   it('does not emit change events when re-processing an unchanged pending tx', async function () {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Requires https://github.com/EdgeApp/react-native-monero/pull/3 (adds the `getPendingTransactions` native method this PR consumes).

### Description

Fixes the Monero receive/confirmation experience found while testing full-node sends against LWS receiving wallets. Three independent commits.

**1. Show pending transactions before their first confirmation** (`723bc2b2`)

The native transaction list sorts pending entries behind all confirmed history, and the engine's history scan stops at the newest known confirmed txid — so it never reached the pending tail, and an incoming transaction was invisible until it confirmed. On LWS (whose balance includes mempool transactions) the balance would move with no transaction row to explain it.

Read the pending set directly via the new `getPendingTransactions` on every pass, outside the cursor protocol. Only confirmed transactions may anchor the scan cursor now (a pending hash recorded as the anchor would match the same tx after it confirms and stop the scan from ever storing its block height), and a cursor already recorded that way by older code is repaired in place by re-processing the anchor row when its stored copy is still unconfirmed. Re-processed pending transactions keep their original `lastSeenTime` so unchanged entries don't emit a change event every poll.

**2. Mark pool-evicted transactions as dropped** (`6d82520d`)

Track when each pool txid was last seen pending; a txid that stays missing for 30 minutes while its stored tx still has no block height was evicted without ever confirming, so mark it dropped (`blockHeight -1` + explicit `'dropped'`, because the base engine clamps negative heights to 0 for non-terminal states). Absence alone is not a drop: a just-mined tx leaves the pool immediately but only appears confirmed once the LWS server indexes its block, so an instant diff misreports every mined tx as dropped during that window (caught on device — observed pending → dropped → confirmed). Also guards `queryTransactions` against concurrent passes.

**3. Clamp the network height monotonic** (`f4f82faa`)

Confirmation counts bounced up and down (observed 4 → 3 → 9 on device) because the base engine re-stamps every tx's count on any height change, and the native height genuinely regresses — lwsf reports the stored account scan height until its first refresh, and a load-balanced daemon can answer a block behind. Feed `updateBlockHeight` the max of the reported and stored heights so counts only advance. Reorg tradeoff (a short-lived cosmetic overcount, never a funds risk) is documented in the commit.

### Testing

`npm run test` (full mocha suite) + `tsc` + ESLint pass. Added `test/monero/MoneroEnginePendingTxs.test.ts` (7 cases) covering pending visibility during backfill, confirmed-only anchoring, poisoned-cursor healing, the grace-period drop, mined-vanish-then-confirm, and no spurious change events. Verified on the iOS simulator: a send between wallets shows a pending row immediately, counts up monotonically, and confirms — no dropped detour or bouncing counts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Monero sync cursor, transaction lifecycle, and persisted `otherData`, with a required native dependency bump; logic is heavily tested but mistakes could mislabel or hide transactions.
> 
> **Overview**
> Improves Monero transaction sync so mempool activity matches what users see in balance and notifications.
> 
> **Pending transactions** are ingested on every sync pass via native `getPendingTransactions` (requires **react-native-monero** `0.3.0`), separate from the confirmed-history cursor. Scan anchors and `mostRecentTxid` updates skip pending rows so a pending hash cannot freeze history; older wallets with a poisoned anchor get a one-time heal (and a sweep for stuck rows behind it). Pending rows preserve `lastSeenTime` to avoid spurious update events, and incoming receives still fire **new-transaction** notifications via an override of `isTransactionNew`.
> 
> **Dropped txs** are tracked in wallet `otherData.pendingTxSeen` with a 30-minute grace (with session/app-close resets) before marking `confirmations: 'dropped'`, avoiding false drops while LWS indexes a just-mined tx.
> 
> **Confirmation stability** ignores small network-height regressions (≤1000 blocks) when calling `updateBlockHeight`, while still accepting large regressions as corrections.
> 
> `queryTransactions` is serialized with a mutex, loads transactions on warm start, and `killEngine` drains in-flight passes before resetting state. Adds `MoneroEnginePendingTxs.test.ts` coverage.
> 
> Also bumps the npm **`long`** override to `5.3.1` for Hedera SDK compatibility (per CHANGELOG).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb24c09b6ce404e8330f843ea630d3b583a49b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216221839527388