### PR TITLE
fixed: (Hedera) HBAR send failed with fromBigInt error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Hedera) HBAR sends failed with an "[object Object]" error. The npm conversion re-resolved `@hashgraph/sdk` to 2.81, whose account-ID serialization calls `Long.fromBigInt` — a method missing from the pinned `long@4.0.0` override. Bump the `long` override to the `5.3.1` the SDK declares so transactions serialize, sign, and broadcast.
+
 ## 4.85.0 (2026-06-29)
 
 - changed: (Monero, Zano) Report sync progress at least once a second while it is still advancing, so a slow chain shows steady movement instead of appearing frozen between whole-percent updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13187,9 +13187,9 @@
       }
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
       "license": "Apache-2.0"
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "create-hmac": "1.1.7",
     "ecurve": "1.0.6",
     "hdkey": "1.1.1",
-    "long": "4.0.0",
+    "long": "5.3.1",
     "randombytes": "2.1.0",
     "readable-stream": "2.3.7",
     "regenerator-runtime": "0.13.11",


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

[Asana task](https://app.asana.com/0/0/1216238399713632/f)

HBAR sends failed on the confirm step with a generic **"[object Object]"** error. The real exception, captured live in the send screen, is:

> `H.fromBigInt is not a function (In 'H.fromBigInt(0n)', 'H.fromBigInt' is undefined)`

**Root cause:** the yarn→npm conversion re-resolved `@hashgraph/sdk` from 2.44.0 to **2.81.0** (the `^2.59.0` range picks npm's latest). SDK 2.81 serializes account IDs via `Long.fromBigInt` in `AccountId._toProtobuf` — a static added in **long@5.3.0**. But the `overrides` block pins **`"long": "4.0.0"`** tree-wide, so the SDK resolves long@4, which has no `fromBigInt`, throwing in `makeSpend`, `signTx`, and `broadcastTx`. Under yarn + SDK 2.44 the pin was harmless (2.44 never called `fromBigInt`). The GUI showed `[object Object]` because the thrown `TypeError` loses its string message crossing the yaob bridge, so `translateError` hits its `Unrecognized exception: ${String(raw)}` fallback.

**Fix:** bump the `long` override `4.0.0` → **`5.3.1`** — the exact version `@hashgraph/sdk@2.81` declares. This keeps the single deduped `long` the pin intends; long@5 is a backward-compatible superset that adds `fromBigInt`.

**Verification (Hedera mainnet):**

- Fee now computes in the send flow where the `fromBigInt` error previously fired ✅
- In-app **"Transaction Success"** sending HBAR wallet→wallet ✅
- On-chain: tx `0.0.443395-1783052797-931000000` result **SUCCESS**, 28.12 HBAR credited to the recipient ✅
- `tsc` + the full unit-test suite (all currencies) pass via the precommit hook ✅

Proof screenshots attached below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tree-wide `long` override affects every dependency that uses `long`, not only Hedera, though 5.x is intended as backward-compatible with 4.x for typical usage.
> 
> **Overview**
> **Restores Hedera (HBAR) sends** by raising the npm `overrides` pin for `long` from `4.0.0` to **`5.3.1`**, matching what newer `@hashgraph/sdk` expects after the yarn→npm migration pulled a newer SDK that serializes account IDs with `Long.fromBigInt`.
> 
> With `long@4` still forced tree-wide, that call was missing and send/confirm failed (often surfaced in the UI as a generic **"[object Object]"** error). The lockfile updates to `long@5.3.1` accordingly; **CHANGELOG** documents the Hedera fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2420f8af3035944f2b2e35f1bf1df18645c80c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->