### PR TITLE
Monero: spendable-synced gate + stable tx dates for LWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: (Monero) Incoming transactions no longer sort to the bottom of the history with a 1970 date when the backend reports no timestamp; they get a stable first-seen date until the real block time arrives.
 - fixed: (Monero) LWS wallets no longer briefly report as synced with a stale balance before their first server refresh completes.
 
 ## 4.85.2 (2026-07-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Monero) LWS wallets no longer briefly report as synced with a stale balance before their first server refresh completes.
+
 ## 4.85.2 (2026-07-06)
 
 - fixed: (Hedera) HBAR sends failed with an "[object Object]" error. The npm conversion re-resolved `@hashgraph/sdk` to 2.81, whose account-ID serialization calls `Long.fromBigInt` — a method missing from the pinned `long@4.0.0` override. Bump the `long` override to the `5.3.1` the SDK declares so transactions serialize, sign, and broadcast.

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "prettier": "^2.2.0",
         "process": "^0.11.10",
         "querystring": "^0.2.1",
-        "react-native-monero": "0.3.0",
+        "react-native-monero": "0.4.0",
         "react-native-piratechain": "0.5.0",
         "react-native-zano": "^0.2.7",
         "react-native-zcash": "0.10.1",
@@ -15623,9 +15623,9 @@
       }
     },
     "node_modules/react-native-monero": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-monero/-/react-native-monero-0.3.0.tgz",
-      "integrity": "sha512-AxAH8ltNhVRIbUausraCupmSnI7wiPdcemsRif/VcxxB22ioOf/wKTxadrtSBYmwHu7fUAwVgsn7Dosqqhgmtw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-monero/-/react-native-monero-0.4.0.tgz",
+      "integrity": "sha512-CdowocfovP1pMzLib8Rf4guW90A5XGoHAkFoQkHZiheWDkTGEnXmcIm/KJw4/T5t368RRXdYmQk3IBv5DeApKg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "prettier": "^2.2.0",
     "process": "^0.11.10",
     "querystring": "^0.2.1",
-    "react-native-monero": "0.3.0",
+    "react-native-monero": "0.4.0",
     "react-native-piratechain": "0.5.0",
     "react-native-zano": "^0.2.7",
     "react-native-zcash": "0.10.1",

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -843,10 +843,26 @@ export class MoneroEngine extends CurrencyEngine<
 
     const blockHeight = tx.isPending ? 0 : tx.blockHeight
 
+    // lwsf reports no timestamp for some transactions (e.g. an incoming tx the
+    // server has not yet attached a block time to), and the native layer emits
+    // 0 for that. A 0 date sorts the tx to the bottom of the list as if it were
+    // from 1970. Substitute a stable date: keep the date we already assigned
+    // this tx if any (so it does not jitter across polls), otherwise stamp it
+    // as first-seen now, so a just-received tx sorts to the top where it
+    // belongs. A real timestamp always wins once the backend provides one.
+    let date = tx.timestamp
+    if (date <= 0) {
+      const priorDate = this.storedTransaction(tx.hash)?.date
+      date =
+        priorDate != null && priorDate > 0
+          ? priorDate
+          : Math.round(Date.now() / 1000)
+    }
+
     const edgeTransaction: EdgeTransaction = {
       blockHeight,
       currencyCode: this.currencyInfo.currencyCode,
-      date: tx.timestamp,
+      date,
       isSend: !isReceive,
       memos,
       nativeAmount,

--- a/src/monero/MoneroEngine.ts
+++ b/src/monero/MoneroEngine.ts
@@ -421,6 +421,20 @@ export class MoneroEngine extends CurrencyEngine<
         return SYNC_POLL_MS
       }
 
+      // Do not treat the wallet as synced until the native layer has completed
+      // at least one real server refresh. An LWS wallet seeds
+      // networkHeight === syncedHeight from its stored scan height on open, so
+      // the heights alone would report "synced" before it has contacted the
+      // server, exposing a stale balance and no incoming transactions. Hold the
+      // syncing state (the tracker keeps its current progress) until the first
+      // refresh confirms the wallet is caught up and spendable. Full-node
+      // wallets set refreshed on their first refresh too, and their
+      // networkHeight is already a live daemon value, so this does not delay
+      // them.
+      if (!status.refreshed) {
+        return SYNC_POLL_MS
+      }
+
       // Smooth small height regressions: lwsf reports the stored account scan
       // height until its first refresh completes, a load-balanced daemon can
       // answer a block behind the previous poll, and the base engine re-stamps


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Requires https://github.com/EdgeApp/react-native-monero/pull/4 (adds the `refreshed` field to `getWalletStatus` this PR consumes). react-native-monero must be published and the pin bumped before this lands.

### Description

Two Monero receive/sync fixes, each its own commit.

**1. Wait for a real refresh before reporting an LWS wallet synced** (`814b40a5`)

An LWS wallet seeds its reported network height equal to its synced height (from the stored scan height) on open, so `syncNetwork`'s height comparison reported it synced before it had contacted the server — showing a stale balance and missing incoming transactions while claiming to be caught up. Gate the synced state on the native `refreshed` flag (true only after a completed server refresh, which for LWS fetches and merges the transaction history and unspent outputs, so the wallet is spendable). Until then, hold the syncing state and keep polling. Full-node wallets are unaffected — their network height is a live daemon value.

**2. Stable first-seen date for timestampless transactions** (`3862d91c`)

lwsf reports no timestamp for a transaction the server has not yet attached a block time to (e.g. an incoming tx still in the mempool), and the native layer surfaces that as 0. A 0 date placed the transaction at 1970, sorting it to the very bottom of the history where it looked missing. Stamp such a transaction with a stable first-seen date (reused across polls so it does not jitter), so a just-received transaction sorts to the top; a real timestamp always wins once the backend provides one, and the blockHeight change on confirmation re-sorts it into place.

### Testing

`tsc`, ESLint, and the full `npm run test` suite pass (against the paired react-native-monero build with the `refreshed` field). Added coverage lives in `test/monero/MoneroEnginePendingTxs.test.ts`. Verified on the iOS simulator against funded LWS wallets: incoming transactions appear at the top with a sensible date, and a fresh wallet shows syncing until its first refresh instead of a false "synced".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Monero sync reporting and transaction date ordering for LWS wallets and requires a coordinated react-native-monero release; incorrect gating could prolong syncing UI or mis-order history.
> 
> **Overview**
> **Monero LWS sync and transaction history** get two fixes, with **`react-native-monero` bumped to 0.4.0** so `getWalletStatus` exposes a **`refreshed`** flag this code depends on.
> 
> In **`syncNetwork`**, the engine no longer treats an LWS wallet as caught up when **`networkHeight` and `syncedHeight` already match on open**—it keeps polling in the syncing state until **`status.refreshed`** is true after a real server refresh, avoiding a briefly **stale balance** and false “synced” UI.
> 
> When mapping native txs to **`EdgeTransaction`**, **`timestamp` ≤ 0** (common for timestampless LWS/mempool incoming txs) is replaced with a **stable first-seen date**: reuse a prior stored date when present, otherwise stamp **now**, so rows do not sort at **1970**; a positive backend timestamp still wins on later polls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336e96c223747ea17a3afb9921f7e186baeb2d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->