### PR TITLE
feat(base): use dynamic eth_feeHistory fee estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (Base) Use dynamic `eth_feeHistory` fee estimation instead of a hardcoded 2 gwei priority floor. The previous static floor caused sends to overpay by ~200x during normal network conditions. The dynamic algorithm tracks real-time percentile-based priority fees with a 2x base-fee buffer, so fees rise naturally during congestion spikes and drop to market rate otherwise. The static `minPriorityFee` fallback (used only when `eth_feeHistory` fails) is lowered from 2 gwei to 0.1 gwei, matching Arbitrum's proven floor.
+
 ## 4.85.3 (2026-07-06)
 
 - fixed: (Monero) Incoming transactions no longer sort to the bottom of the history with a 1970 date when the backend reports no timestamp; they get a stable first-seen date until the real block time arrives.

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -51,7 +51,7 @@ const networkFees: EthereumFees = {
       highFee: '40000000001',
       minGasPrice: '100000'
     },
-    minPriorityFee: '2000000000'
+    minPriorityFee: '100000000'
   }
 }
 
@@ -85,6 +85,10 @@ const networkInfo: EthereumNetworkInfo = {
   },
   optimismRollup: true,
   supportsEIP1559: true,
+  feeAlgorithm: {
+    type: 'eth_feeHistory',
+    blocksToAnalyze: 12 // 2 minutes at Base's 2s block time
+  },
   hdPathCoinType: 60,
   pluginMnemonicKeyName: 'baseMnemonic',
   pluginRegularKeyName: 'baseKey',


### PR DESCRIPTION
## Summary

- **Commit 1** — Enable `eth_feeHistory` dynamic fee estimation for Base, replacing the hardcoded 2 gwei `minPriorityFee` floor that causes sends to overpay by ~200x during normal network conditions
- **Commit 2** — Lower the static `minPriorityFee` fallback from 2 gwei to 0.1 gwei (matching Arbitrum's proven floor) for when `eth_feeHistory` RPC calls fail
- No engine changes required — the `eth_feeHistory` algorithm already exists and is in production on Botanix

## Problem

Base's live `baseFee` is typically ~0.005 gwei with `eth_maxPriorityFeePerGas` returning ~0.001 gwei. The hardcoded `minPriorityFee: '2000000000'` (2 gwei) in the EIP-1559 fallback formula means Edge adds a 2 gwei priority floor on a network asking for ~0.001 gwei. USDC sends show ~$0.44 when comparable wallets show fractions of a cent.

## How it works

The fee provider chain runs in order: `fetchFeesFromFeeHistory` → `fetchFeesFromEvmScan` → `fetchFeesFromEvmGasStation` → `updateNetworkFeesFromBaseFeePerGas`. First success wins.

**Commit 1** adds `feeAlgorithm: { type: 'eth_feeHistory', blocksToAnalyze: 12 }` to Base's network info:
1. **Normal conditions**: `eth_feeHistory` queries the last 12 blocks for p10/p50/p90 percentile priority fees, applies a 2x `baseFee` buffer → fees track market rate
2. **Congestion spikes**: The algorithm naturally picks up elevated priority fees from recent blocks (e.g., a 5.5 gwei spike would produce ~11 gwei maxFee from the 2x buffer alone, plus the elevated tips)
3. **RPC failure**: Falls through to the old `baseFee * multiplier + minPriorityFee` path

**Commit 2** lowers the fallback `minPriorityFee` from 2 gwei to 0.1 gwei:
- 0.1 gwei matches Arbitrum's proven production floor
- Covers Base's p99 median priority fee over the last 1024 blocks
- During spikes, the baseFee multiplier portion handles congestion — `minPriorityFee` is just the tip floor
- Fail-safe direction: still slightly overpays vs market rate, never underpays

## Verification

- Tested `eth_feeHistory` and `eth_maxPriorityFeePerGas` RPC calls against Base's public endpoints — both return valid, meaningful data with real percentile differentiation
- Analyzed last 1024 blocks: p50 total fee ~0.006 gwei, p99 total fee ~0.01 gwei, p99 priority fee median 0.1 gwei
- The OP-stack L1 data fee path (`calcOptimismRollupFees`) is untouched — it's a separate calculation from execution gas pricing
- Botanix has been running the same `eth_feeHistory` algorithm in production

## Test plan

- [ ] Verify Base ETH send shows fees comparable to other wallets (~fractions of a cent for simple transfers)
- [ ] Verify Base USDC send fee is dramatically lower than the previous ~$0.44
- [ ] Verify fee estimation still works during Base congestion spikes (fees should rise with network demand)
- [ ] Verify sends complete successfully (not stuck in mempool from underpaying)
- [ ] Check that Optimism/BOB/opBNB behavior is unchanged (this PR only touches Base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Base fee quoting and spend fee selection; wrong floors could underpay (stuck txs) or overpay, but the dynamic path and conservative 0.1 gwei fallback mirror production patterns on other chains.
> 
> **Overview**
> **Base send fees** are retuned so quoted costs track the network instead of sitting on a 2 gwei priority floor that inflated fees (~200×) when Base’s base and tip fees are sub‑gwei.
> 
> `baseInfo` now sets **`feeAlgorithm: { type: 'eth_feeHistory', blocksToAnalyze: 12 }`** (~2 minutes at 2s blocks), so the existing provider chain prefers percentile priority fees from recent blocks plus the usual 2× base-fee buffer—same pattern already used on Botanix, with no engine changes.
> 
> The **EIP-1559 fallback** path (when `eth_feeHistory` and other providers fail) still uses `baseFee × multiplier + minPriorityFee`, but **`minPriorityFee` drops from 2 gwei to 0.1 gwei**, aligned with Arbitrum’s floor. OP-stack L1 data fees are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94965ce10006ea1775d24e89f1c1f4f38f3c6317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->