### PR TITLE
Fix Tron token balance sync under TronWeb 5.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
+
 ## 4.85.3 (2026-07-06)
 
 - fixed: (Monero) Incoming transactions no longer sort to the bottom of the history with a 1970 date when the backend reports no timestamp; they get a stable first-seen date until the real block time arrives.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "stellar-sdk": "^13.3.0",
         "tezos-uri": "^1.0.3",
         "ton-watcher": "^1.1.7",
-        "tronweb": "^5.1.0",
+        "tronweb": "5.1.0",
         "ts-proto": "^1.162.1",
         "tweetnacl": "^1.0.3",
         "uri-js": "^3.0.2",
@@ -163,12 +163,6 @@
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
         "typescript": "^5.0.0 || ^6.0.0"
       }
-    },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -15523,14 +15517,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -17859,240 +17845,37 @@
       }
     },
     "node_modules/tronweb": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-5.3.5.tgz",
-      "integrity": "sha512-F1dbhctXPc3aWH0O3WTYVJ7+e9kl59//bz8xAuMEY0k/VAOzVfKPqZH9zqZWLjmq2X4uExh3zcJUm77096hdxg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-5.1.0.tgz",
+      "integrity": "sha512-8a+mYKVUzsUWjeTHSAKcxAp82FseFTLlNLoLQ0KIL1rIt6Dy5whcyJwYatxUktbaztl55lnImHbupkKqMdIj1w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "7.28.6",
-        "@ethersproject/abi": "5.0.9",
-        "@tronweb3/google-protobuf": "3.21.2",
-        "axios": "1.13.6",
-        "bignumber.js": "9.0.1",
-        "ethereum-cryptography": "2.0.0",
-        "ethers": "6.16.0",
-        "eventemitter3": "3.1.0",
-        "injectpromise": "1.0.0",
-        "lodash": "4.17.23",
-        "querystring-es3": "0.2.1",
-        "semver": "5.7.2",
-        "validator": "13.15.26"
+        "@babel/runtime": "^7.0.0",
+        "@tronweb3/google-protobuf": "^3.21.2",
+        "axios": "^0.26.1",
+        "bignumber.js": "^9.0.1",
+        "elliptic": "^6.5.4",
+        "ethers": "^5.4.4",
+        "eventemitter3": "^3.1.0",
+        "injectpromise": "^1.0.0",
+        "lodash": "^4.17.21",
+        "semver": "^5.6.0",
+        "validator": "^13.7.0"
       }
-    },
-    "node_modules/tronweb/node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/@ethersproject/abi": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.9.tgz",
-      "integrity": "sha512-ily2OufA2DTrxkiHQw5GqbkMSnNKuwZBqKsajtT0ERhZy1r9w2CpW1bmtRMIGzaqQxCdn/GEoFogexk72cBBZQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      }
-    },
-    "node_modules/tronweb/node_modules/@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/tronweb/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/tronweb/node_modules/@scure/bip32": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.0.tgz",
-      "integrity": "sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.0.0",
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/@scure/bip39": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.0.tgz",
-      "integrity": "sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/tronweb/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
     },
     "node_modules/tronweb/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tronweb/node_modules/ethereum-cryptography": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.0.0.tgz",
-      "integrity": "sha512-g25m4EtfQGjstWgVE1aIz7XYYjf3kH5kG17ULWVB5dH6uLahsoltOhACzSxyDV+fhn4gbR4xRrOXGe6r2uh4Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.0.0",
-        "@noble/hashes": "1.3.0",
-        "@scure/bip32": "1.3.0",
-        "@scure/bip39": "1.2.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tronweb/node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/tronweb/node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/tronweb/node_modules/eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
-      "license": "MIT"
-    },
-    "node_modules/tronweb/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/tronweb/node_modules/semver": {
@@ -18102,33 +17885,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/tronweb/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
-    "node_modules/tronweb/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/ts-interface-checker": {
@@ -18466,12 +18222,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "stellar-sdk": "^13.3.0",
     "tezos-uri": "^1.0.3",
     "ton-watcher": "^1.1.7",
-    "tronweb": "^5.1.0",
+    "tronweb": "5.1.0",
     "ts-proto": "^1.162.1",
     "tweetnacl": "^1.0.3",
     "uri-js": "^3.0.2",

--- a/src/tron/TronEngine.ts
+++ b/src/tron/TronEngine.ts
@@ -217,12 +217,17 @@ export class TronEngine extends CurrencyEngine<
     const detectedTokenIds: string[] = []
     const tokenIds = Object.keys(this.allTokensMap)
     try {
+      // TronWeb 5.3+ rejects bare hex inside address arrays, which is why
+      // tronweb is pinned to 5.1.0. Pass 0x-prefixed lowercase hex anyway
+      // (lowercase avoids EIP-55 checksum validation of the uppercase hex
+      // from base58ToHexAddress) so this call also survives a future unpin.
       const encodedParams = encodeParams(
         ['address[]', 'address[]'],
         [
-          [address.slice(2)],
-          tokenIds.map(tokenAddress =>
-            base58ToHexAddress(tokenAddress).slice(2)
+          [`0x${address.slice(2).toLowerCase()}`],
+          tokenIds.map(
+            tokenAddress =>
+              `0x${base58ToHexAddress(tokenAddress).slice(2).toLowerCase()}`
           )
         ]
       )


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Tron wallets fail to sync token balances with:

```
checkTokenBalances error Error: invalid BigNumber string (argument="value", value="F3DD6DA082A2B68D6F6E214E482D3B2080ED0056", code=INVALID_ARGUMENT, version=bignumber/5.8.0)
```

**Root cause:** this repo's own lockfile resolves `tronweb ^5.1.0` to **5.3.5** (since the yarn→npm conversion), and TronWeb 5.3+ rejects the bare-hex values `checkTokenBalances` passes inside `address[]` parameters — they fall through to ethers `BigNumber.from()`, which requires a `0x` prefix. Every TRC20 balance poll throws, so token balances never update. The value in the error is just whichever address the coder hits first (it is a 20-byte address, not a number).

The GUI's lockfile pins `tronweb` 5.1.0, so published app builds are unaffected — this bites any consumer of this repo's own lockfile (dev servers, CI) and becomes a production bug on the next GUI lockfile refresh.

**Fix (two layers):**
1. Pin `tronweb` to exactly `5.1.0`, restoring parity with the version production has always shipped (same precedent as pinning `ethers` during the npm conversion). Only the `encodeParams` paths were verified safe on 5.3.5; TronWeb's signing/protobuf utils were not, hence the pin rather than an upgrade.
2. Harden the balance-checker call to pass `0x`-prefixed lowercase hex, which encodes correctly on both 5.1.0 and 5.3.5 (verified) — so a future tronweb unpin/upgrade does not silently re-break this call. Lowercase avoids EIP-55 checksum validation of the uppercase hex `base58ToHexAddress` produces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Tron token balance polling and locks a major dependency; scope is narrow (encode format + version pin) with no auth or spend-path edits.
> 
> **Overview**
> Fixes **Tron TRC20 token balance sync** failing with `invalid BigNumber string` when the lockfile had resolved `tronweb` to 5.3.x instead of the 5.1.0 production builds use.
> 
> **`tronweb` is pinned to exactly `5.1.0`** in `package.json` / lockfile so installs no longer float to 5.3.5 after the yarn→npm conversion.
> 
> In **`checkTokenBalances`**, the batch balance checker’s `encodeParams` call now passes **`0x`-prefixed lowercase** wallet and token addresses instead of bare hex, which TronWeb 5.3+ mis-handles (values hit `BigNumber.from` and throw). Lowercase avoids EIP-55 checksum issues with uppercase hex from `base58ToHexAddress`, and keeps the call valid if `tronweb` is upgraded later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded04b0036d18ec48baf94ae01fc2c2ce87ebb70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216518055560903