### PR TITLE
Add Bridgeless Zano assets and Solana/TON makeTx support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
 - added: (Zano) Bridgeless bridge tokens SOLx (Solana) and TONx (Toncoin).
+- added: (TON) `otherMethods.makeTx` to build custom-body internal-message transactions (e.g. Bridgeless bridge deposits).
 
 ## 4.85.3 (2026-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
+- added: (Zano) Bridgeless bridge tokens SOLx (Solana) and TONx (Toncoin).
 
 ## 4.85.3 (2026-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
-- added: (Zano) Bridgeless bridge tokens SOLx (Solana) and TONx (Toncoin).
+- added: (Zano) Bridgeless bridge tokens SOLx (Solana), TONx (Toncoin), and FUSDx (Freedom Dollar).
+- added: (Ethereum) FUSD (Freedom Dollar) token for Bridgeless swaps.
 - added: (TON) `otherMethods.makeTx` to build custom-body internal-message transactions (e.g. Bridgeless bridge deposits).
 - added: (Solana) `otherMethods.makeTx` to build custom program-instruction transactions (e.g. Bridgeless bridge deposits).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
 - added: (Zano) Bridgeless bridge tokens SOLx (Solana) and TONx (Toncoin).
 - added: (TON) `otherMethods.makeTx` to build custom-body internal-message transactions (e.g. Bridgeless bridge deposits).
+- added: (Solana) `otherMethods.makeTx` to build custom program-instruction transactions (e.g. Bridgeless bridge deposits).
 
 ## 4.85.3 (2026-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-- fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
 - added: (Zano) Bridgeless bridge tokens SOLx (Solana), TONx (Toncoin), and FUSDx (Freedom Dollar).
 - added: (Ethereum) FUSD (Freedom Dollar) token for Bridgeless swaps.
 - added: (TON) `otherMethods.makeTx` to build custom-body internal-message transactions (e.g. Bridgeless bridge deposits).
 - added: (Solana) `otherMethods.makeTx` to build custom program-instruction transactions (e.g. Bridgeless bridge deposits).
+- added: (Solana/TON) `otherMethods.getMaxTx` reporting the maximum spendable amount for makeTx transactions, and a Solana makeTx balance check so deposits that cannot cover the network fee fail before broadcasting.
+- fixed: (Tron) Token balance sync failing with `invalid BigNumber string` — pin `tronweb` to exactly 5.1.0 (5.3.x rejects the bare-hex address arrays used by the TRC20 balance checker) and pass 0x-prefixed lowercase addresses so the call also works on newer TronWeb versions.
 
 ## 4.85.3 (2026-07-06)
 

--- a/src/ethereum/info/ethereumInfo.ts
+++ b/src/ethereum/info/ethereumInfo.ts
@@ -412,6 +412,14 @@ export const builtinTokens: EdgeTokenMap = {
       contractAddress: '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b'
     }
   },
+  f446aabf60f10c2f455f0a1728afdd48c653a5a3: {
+    currencyCode: 'FUSD',
+    displayName: 'Freedom Dollar',
+    denominations: [{ name: 'FUSD', multiplier: '1000000' }],
+    networkLocation: {
+      contractAddress: '0xf446aaBf60f10C2F455f0a1728Afdd48C653a5a3'
+    }
+  },
   '7dd9c5cba05e151c895fde1cf355c9a1d5da6429': {
     currencyCode: 'GLM',
     displayName: 'Golem',

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -17,6 +17,7 @@ import {
   TokenAmount,
   TokenBalance,
   TransactionInstruction,
+  TransactionMessage,
   TransactionResponse,
   VersionedTransaction,
   VersionedTransactionResponse
@@ -48,6 +49,7 @@ import {
   timeout
 } from '../common/promiseUtils'
 import { makeTokenSyncTracker, TokenSyncTracker } from '../common/SyncTracker'
+import { MakeTxParams } from '../common/types'
 import { cache, cleanTxLogs, getOtherParams, snooze } from '../common/utils'
 import { SolanaTools } from './SolanaTools'
 import {
@@ -56,6 +58,7 @@ import {
   asBlocktime,
   asSafeSolanaWalletInfo,
   asSolanaCustomFee,
+  asSolanaMakeTxParams,
   asSolanaPrivateKeys,
   asSolanaSpendInfoOtherParams,
   asSolanaTxOtherParams,
@@ -1046,6 +1049,97 @@ export class SolanaEngine extends CurrencyEngine<
     }
 
     return edgeTransaction
+  }
+
+  otherMethods = {
+    // Build a custom-instruction transaction (e.g. a bridge deposit). The caller
+    // supplies raw program instruction(s); signing (blockhash refresh + wallet
+    // signature) and broadcast reuse the generic otherParams.unsignedTx path,
+    // exactly like makeSpend.
+    //
+    // Caller constraints:
+    // - Transactions are compiled as LEGACY (no address lookup tables), so
+    //   account-heavy instruction sets may exceed the transaction size limit.
+    // - The wallet is the fee payer and the only signer; instructions that
+    //   require additional signers are not supported.
+    // - networkFee is reported as the flat per-signature fee; include your own
+    //   ComputeBudget instructions if priority fees are needed.
+    // - nativeAmount and tokenId are trusted for balance checks and display
+    //   accounting; they are not derived from the instructions. Callers must
+    //   ensure they match what the instructions actually spend.
+    makeTx: async (makeTxParams: MakeTxParams): Promise<EdgeTransaction> => {
+      if (makeTxParams.type !== 'MakeTx') {
+        throw new Error('Unrecognized makeTx type')
+      }
+      const { unsignedTx, metadata } = makeTxParams
+      const { instructions, nativeAmount, tokenId } = asSolanaMakeTxParams(
+        JSON.parse(new TextDecoder().decode(unsignedTx))
+      )
+
+      const currencyCode = this.getCurrencyCode(tokenId)
+      if (currencyCode == null) throw new Error('Unknown tokenId')
+
+      const payer = new PublicKey(this.base58PublicKey)
+      const txInstructions = instructions.map(
+        ix =>
+          new TransactionInstruction({
+            programId: new PublicKey(ix.programId),
+            keys: ix.keys.map(k => ({
+              pubkey: new PublicKey(k.pubkey),
+              isSigner: k.isSigner,
+              isWritable: k.isWritable
+            })),
+            data: Buffer.from(ix.data)
+          })
+      )
+
+      const recentBlockhash = await this.getRecentBlockhash()
+      // Compile a legacy (non-versioned) message: the bridge tooling parses
+      // deposits with legacy transactions, and v0 transactions error on
+      // getTransaction calls that omit maxSupportedTransactionVersion.
+      const legacyMessage = new TransactionMessage({
+        instructions: txInstructions,
+        payerKey: payer,
+        recentBlockhash: recentBlockhash.blockhash
+      }).compileToLegacyMessage()
+      const versionedTx = new VersionedTransaction(legacyMessage)
+
+      const otherParams = wasSolanaTxOtherParams({
+        unsignedTx: versionedTx.serialize(),
+        blockhash: recentBlockhash.blockhash,
+        lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+      })
+
+      const networkFee = this.feePerSignature
+      const isNative = tokenId == null
+
+      const edgeTransaction: EdgeTransaction = {
+        assetAction: metadata?.assetAction,
+        savedAction: metadata?.savedAction,
+        metadata: metadata?.metadata,
+        swapData: metadata?.swapData,
+        blockHeight: 0,
+        currencyCode,
+        date: Date.now() / 1000,
+        isSend: true,
+        memos: metadata?.memos ?? [],
+        nativeAmount: isNative
+          ? `-${add(nativeAmount, networkFee)}`
+          : `-${nativeAmount}`,
+        // The signature fee is a SOL cost: token transactions report it only
+        // as parentNetworkFee, matching the engine's makeSpend convention.
+        networkFee: isNative ? networkFee : '0',
+        networkFees: [],
+        otherParams,
+        ourReceiveAddresses: [],
+        parentNetworkFee: isNative ? undefined : networkFee,
+        signedTx: '',
+        tokenId,
+        txid: '',
+        walletId: this.walletId
+      }
+      return edgeTransaction
+    }
   }
 }
 

--- a/src/solana/SolanaEngine.ts
+++ b/src/solana/SolanaEngine.ts
@@ -1067,6 +1067,21 @@ export class SolanaEngine extends CurrencyEngine<
     // - nativeAmount and tokenId are trusted for balance checks and display
     //   accounting; they are not derived from the instructions. Callers must
     //   ensure they match what the instructions actually spend.
+    // Report the maximum amount spendable by a makeTx transaction. Native
+    // sends spend the full balance minus the flat per-signature fee; token
+    // sends spend the full token balance (the fee is paid in SOL).
+    getMaxTx: async (makeTxParams: MakeTxParams): Promise<string> => {
+      if (makeTxParams.type !== 'MakeTx') {
+        throw new Error('Unrecognized makeTx type')
+      }
+      const { tokenId } = asSolanaMakeTxParams(
+        JSON.parse(new TextDecoder().decode(makeTxParams.unsignedTx))
+      )
+      if (tokenId != null) return this.getBalance({ tokenId })
+      const balance = this.getBalance({ tokenId: null })
+      const max = sub(balance, this.feePerSignature)
+      return lt(max, '0') ? '0' : max
+    },
     makeTx: async (makeTxParams: MakeTxParams): Promise<EdgeTransaction> => {
       if (makeTxParams.type !== 'MakeTx') {
         throw new Error('Unrecognized makeTx type')
@@ -1078,6 +1093,28 @@ export class SolanaEngine extends CurrencyEngine<
 
       const currencyCode = this.getCurrencyCode(tokenId)
       if (currencyCode == null) throw new Error('Unknown tokenId')
+
+      // The transaction fee comes out of the same native balance the deposit
+      // spends, so reject amounts the wallet cannot actually cover. Like
+      // makeSpend, reserve the rent-exempt minimum unless the transaction
+      // drains the account to exactly zero.
+      const solBalance = this.getBalance({ tokenId: null })
+      const minimumAddressBalance = await this.getMinimumAddressBalance()
+      if (tokenId == null) {
+        const totalTxAmount = add(nativeAmount, this.feePerSignature)
+        if (eq(totalTxAmount, solBalance)) {
+          // A full-balance send may drain the account to zero
+        } else if (gt(add(totalTxAmount, minimumAddressBalance), solBalance)) {
+          throw new InsufficientFundsError({ tokenId: null })
+        }
+      } else {
+        if (gt(nativeAmount, this.getBalance({ tokenId }))) {
+          throw new InsufficientFundsError({ tokenId })
+        }
+        if (gt(add(this.feePerSignature, minimumAddressBalance), solBalance)) {
+          throw new InsufficientFundsError({ tokenId: null })
+        }
+      }
 
       const payer = new PublicKey(this.base58PublicKey)
       const txInstructions = instructions.map(

--- a/src/solana/solanaTypes.ts
+++ b/src/solana/solanaTypes.ts
@@ -1,7 +1,10 @@
 import {
   asArray,
+  asBoolean,
   asCodec,
+  asEither,
   asMaybe,
+  asNull,
   asNumber,
   asObject,
   asOptional,
@@ -138,6 +141,27 @@ export const asSolanaTxOtherParams = asObject({
 })
 
 export const wasSolanaTxOtherParams = uncleaner(asSolanaTxOtherParams)
+
+// Params for the `otherMethods.makeTx` custom-transaction path (e.g. bridge
+// deposits). The caller supplies raw program instruction(s) plus the amount and
+// tokenId so the engine can compile, price, and stash the transaction.
+export const asSolanaMakeTxParams = asObject({
+  instructions: asArray(
+    asObject({
+      programId: asString,
+      keys: asArray(
+        asObject({
+          pubkey: asString,
+          isSigner: asBoolean,
+          isWritable: asBoolean
+        })
+      ),
+      data: asBase64
+    })
+  ),
+  nativeAmount: asString,
+  tokenId: asEither(asString, asNull)
+})
 
 //
 // Info Payload

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -537,6 +537,58 @@ export class TonEngine extends CurrencyEngine<
     // - Sent with IGNORE_ERRORS + PAY_GAS_SEPARATELY: if the action phase
     //   fails (e.g. insufficient balance), the wallet consumes the seqno and
     //   silently sends nothing.
+    // Report the maximum native amount spendable by a makeTx transaction:
+    // the full balance minus the estimated fee and the minimum address
+    // balance the wallet must retain.
+    getMaxTx: async (makeTxParams: MakeTxParams): Promise<string> => {
+      if (makeTxParams.type !== 'MakeTx') {
+        throw new Error('Unrecognized makeTx type')
+      }
+      const { unsignedTx } = makeTxParams
+      const { toAddress, bodyBoc, bounce } = asTonMakeTxParams(
+        JSON.parse(new TextDecoder().decode(unsignedTx))
+      )
+      const balance = this.getBalance({ tokenId: null })
+
+      // Fees are effectively amount-independent, so estimate with the full
+      // balance as the transfer value.
+      const bodyCell = Cell.fromBoc(Buffer.from(base64.parse(bodyBoc)))[0]
+      const transferMessage: MessageRelaxed = internal({
+        value: fromNano(balance),
+        to: Address.parse(toAddress),
+        body: bodyCell,
+        bounce
+      })
+      const transfer = this.wallet.createTransfer({
+        sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
+        messages: [transferMessage],
+        seqno: 0,
+        secretKey: Buffer.alloc(64)
+      })
+      const needsInit = this.otherData.contractState === 'uninitialized'
+      const feeRaw = await this.tools.fetchDrpc('/estimateFee', {
+        address: this.wallet.address.toRawString(),
+        body: base64.stringify(transfer.toBoc()),
+        init_code: needsInit
+          ? base64.stringify(this.wallet.init.code.toBoc())
+          : '',
+        init_data: needsInit
+          ? base64.stringify(this.wallet.init.data.toBoc())
+          : ''
+      })
+      const { result: feeResult } = asDrpcEstimateFee(feeRaw)
+      const networkFee =
+        feeResult.source_fees.fwd_fee +
+        feeResult.source_fees.gas_fee +
+        feeResult.source_fees.in_fwd_fee +
+        feeResult.source_fees.storage_fee
+
+      const max = sub(
+        sub(balance, networkFee.toString()),
+        this.networkInfo.minimumAddressBalance
+      )
+      return lt(max, '0') ? '0' : max
+    },
     makeTx: async (makeTxParams: MakeTxParams): Promise<EdgeTransaction> => {
       if (makeTxParams.type !== 'MakeTx') {
         throw new Error('Unrecognized makeTx type')

--- a/src/ton/TonEngine.ts
+++ b/src/ton/TonEngine.ts
@@ -37,7 +37,11 @@ import { PluginEnvironment } from '../common/innerPlugin'
 import { getRandomDelayMs } from '../common/network'
 import { asyncWaterfall } from '../common/promiseUtils'
 import { makeTokenSyncTracker, TokenSyncTracker } from '../common/SyncTracker'
-import { asSafeCommonWalletInfo, SafeCommonWalletInfo } from '../common/types'
+import {
+  asSafeCommonWalletInfo,
+  MakeTxParams,
+  SafeCommonWalletInfo
+} from '../common/types'
 import { snooze } from '../common/utils'
 import {
   asDrpcAddressInfo,
@@ -49,6 +53,7 @@ import {
 import { TonTools } from './TonTools'
 import {
   asParsedTx,
+  asTonMakeTxParams,
   asTonPrivateKeys,
   asTonTxOtherParams,
   asTonWalletOtherData,
@@ -519,6 +524,108 @@ export class TonEngine extends CurrencyEngine<
   async getFreshAddress(): Promise<EdgeFreshAddress> {
     const publicAddress = this.wallet.address.toString({ bounceable: false })
     return { publicAddress }
+  }
+
+  otherMethods = {
+    // Build a custom-body internal-message transaction (e.g. a bridge deposit).
+    // The signed broadcast reuses the generic signTx/broadcastTx path via
+    // `otherParams.unsignedTxBase64`, exactly like makeSpend.
+    //
+    // Caller constraints:
+    // - Exactly one internal message, with no stateInit (cannot deploy a
+    //   contract or initialize the destination account).
+    // - Sent with IGNORE_ERRORS + PAY_GAS_SEPARATELY: if the action phase
+    //   fails (e.g. insufficient balance), the wallet consumes the seqno and
+    //   silently sends nothing.
+    makeTx: async (makeTxParams: MakeTxParams): Promise<EdgeTransaction> => {
+      if (makeTxParams.type !== 'MakeTx') {
+        throw new Error('Unrecognized makeTx type')
+      }
+      const { unsignedTx, metadata } = makeTxParams
+      const { toAddress, amount, bodyBoc, bounce } = asTonMakeTxParams(
+        JSON.parse(new TextDecoder().decode(unsignedTx))
+      )
+
+      const bodyCell = Cell.fromBoc(Buffer.from(base64.parse(bodyBoc)))[0]
+      const needsInit = this.otherData.contractState === 'uninitialized'
+
+      const transferMessage: MessageRelaxed = internal({
+        value: fromNano(amount),
+        to: Address.parse(toAddress),
+        body: bodyCell,
+        bounce
+      })
+
+      const transferArgs: Parameters<WalletContractV5R1['createTransfer']>[0] =
+        {
+          sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
+          messages: [transferMessage],
+
+          // Fake data that doesn't impact fee calc
+          seqno: 0,
+          secretKey: Buffer.alloc(64)
+        }
+      const transfer = this.wallet.createTransfer(transferArgs)
+
+      let networkFee = '0'
+      if (amount !== '0') {
+        const addr = this.wallet.address.toRawString()
+        const feeBodyBoc = base64.stringify(transfer.toBoc())
+        const initCodeBoc = needsInit
+          ? base64.stringify(this.wallet.init.code.toBoc())
+          : ''
+        const initDataBoc = needsInit
+          ? base64.stringify(this.wallet.init.data.toBoc())
+          : ''
+        const feeRaw = await this.tools.fetchDrpc('/estimateFee', {
+          address: addr,
+          body: feeBodyBoc,
+          init_code: initCodeBoc,
+          init_data: initDataBoc
+        })
+        const { result: feeResult } = asDrpcEstimateFee(feeRaw)
+        const totalFee =
+          feeResult.source_fees.fwd_fee +
+          feeResult.source_fees.gas_fee +
+          feeResult.source_fees.in_fwd_fee +
+          feeResult.source_fees.storage_fee
+        networkFee = totalFee.toString()
+      }
+
+      const total = add(amount, networkFee)
+      const balance = this.getBalance({ tokenId: null })
+      if (gt(add(total, this.networkInfo.minimumAddressBalance), balance)) {
+        throw new InsufficientFundsError({ tokenId: null })
+      }
+
+      const builder = beginCell()
+      storeMessageRelaxed(transferMessage)(builder)
+      const otherParams = {
+        unsignedTxBase64: base64.stringify(builder.asSlice().asCell().toBoc())
+      }
+
+      const edgeTransaction: EdgeTransaction = {
+        assetAction: metadata?.assetAction,
+        savedAction: metadata?.savedAction,
+        metadata: metadata?.metadata,
+        swapData: metadata?.swapData,
+        blockHeight: 0,
+        currencyCode: this.currencyInfo.currencyCode,
+        date: Date.now() / 1000,
+        isSend: true,
+        memos: metadata?.memos ?? [],
+        nativeAmount: `-${total}`,
+        networkFee,
+        networkFees: [],
+        otherParams,
+        ourReceiveAddresses: [],
+        signedTx: '',
+        tokenId: null,
+        txid: '',
+        walletId: this.walletId
+      }
+      return edgeTransaction
+    }
   }
 }
 

--- a/src/ton/tonTypes.ts
+++ b/src/ton/tonTypes.ts
@@ -1,5 +1,6 @@
 import {
   asArray,
+  asBoolean,
   asCodec,
   asNumber,
   asObject,
@@ -96,6 +97,16 @@ export type ParsedTx = ReturnType<typeof asParsedTx>
 
 export const asTonTxOtherParams = asObject({
   unsignedTxBase64: asString
+})
+
+// Params for the `otherMethods.makeTx` custom-transaction path (e.g. bridge
+// deposits). The caller supplies a fully-built message body cell (base64 BOC),
+// the destination contract, the native amount, and the bounce flag.
+export const asTonMakeTxParams = asObject({
+  toAddress: asString,
+  amount: asString,
+  bodyBoc: asString,
+  bounce: asOptional(asBoolean, true)
 })
 
 export const asTonInitOptions = asObject({

--- a/src/zano/zanoInfo.ts
+++ b/src/zano/zanoInfo.ts
@@ -122,6 +122,20 @@ const builtinTokens: EdgeTokenMap = {
       contractAddress:
         '65b3bc549c8bc2c773781d5436f25f7af84644e61baaabd675d9867b007d17b4'
     }
+  },
+  '2cac029d4850464eff91828336ac06468737a19fbdd500cdabcc633db2fe0a2e': {
+    currencyCode: 'FUSDx',
+    displayName: 'Freedom Dollar',
+    denominations: [
+      {
+        name: 'FUSDx',
+        multiplier: '1000000000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '2cac029d4850464eff91828336ac06468737a19fbdd500cdabcc633db2fe0a2e'
+    }
   }
 }
 

--- a/src/zano/zanoInfo.ts
+++ b/src/zano/zanoInfo.ts
@@ -94,6 +94,34 @@ const builtinTokens: EdgeTokenMap = {
       contractAddress:
         '3de9ad7243afa49e0ade6839e97a9f10a527c4958ece2fc9cb1b87a44032167d'
     }
+  },
+  bfa6609a94e39f418d9adb000f89edc7bd180fd120f1cd272201220e3070fb4f: {
+    currencyCode: 'TONx',
+    displayName: 'Toncoin',
+    denominations: [
+      {
+        name: 'TONx',
+        multiplier: '1000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        'bfa6609a94e39f418d9adb000f89edc7bd180fd120f1cd272201220e3070fb4f'
+    }
+  },
+  '65b3bc549c8bc2c773781d5436f25f7af84644e61baaabd675d9867b007d17b4': {
+    currencyCode: 'SOLx',
+    displayName: 'Solana',
+    denominations: [
+      {
+        name: 'SOLx',
+        multiplier: '1000000'
+      }
+    ],
+    networkLocation: {
+      contractAddress:
+        '65b3bc549c8bc2c773781d5436f25f7af84644e61baaabd675d9867b007d17b4'
+    }
   }
 }
 


### PR DESCRIPTION
Adds the accountbased pieces for the Bridgeless Solana/TON/FUSD swap expansion:

- **Zano**: register Bridgeless bridge assets SOLx (Solana), TONx (Toncoin), and FUSDx (Freedom Dollar) as builtin tokens, so bridged balances appear instead of being dropped from history / throwing on burn.
- **TON**: new `otherMethods.makeTx` — builds a custom-body internal-message transaction (single message, no stateInit; sendMode `IGNORE_ERRORS + PAY_GAS_SEPARATELY`). Signing/broadcast reuse the existing generic `otherParams.unsignedTxBase64` path.
- **Solana**: new `otherMethods.makeTx` — builds a transaction from caller-supplied program instructions, compiled as a **legacy** message (no address lookup tables; the bridge tooling cannot parse v0). Wallet is fee payer and sole signer. Reuses the generic signTx/broadcastTx path.
- **Ethereum**: add FUSD (Freedom Dollar, `0xf446…3a5a3`, 6 decimals — verified on-chain) for the ETH-FUSD ⇄ Zano-FUSDx pair.

Both makeTx methods are chain-generic (no bridge-specific knowledge); caller constraints are documented at each method. Consumed by the Bridgeless swap plugin PR in edge-exchange-plugins.

**Testing**: `builtinTokens` test passes (zano + ethereum key/tokenId parity); TON body cell and Solana instruction encodings byte-verified against live on-chain Bridgeless deposits; live E2E: TON→Zano deposit accepted by the bridge contract and credited after TSS submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New fund-moving transaction paths on Solana and TON with caller-trusted amounts and TON’s IGNORE_ERRORS send mode; mistakes in the swap plugin could mis-price or fail deposits, but engines reuse established sign/broadcast and enforce balance checks.
> 
> **Overview**
> Adds **Bridgeless** support: new Zano wrapped assets (**SOLx**, **TONx**, **FUSDx**), Ethereum **FUSD**, and chain-generic **`otherMethods.makeTx`** / **`getMaxTx`** on Solana and TON so swap plugins can build bridge deposits without going through normal `makeSpend`.
> 
> **Solana** accepts caller-supplied program instructions, compiles a **legacy** transaction (for bridge tooling compatibility), runs balance checks (including SOL fee + rent rules for native spends), and stashes `otherParams` for the existing sign/broadcast path. **`getMaxTx`** returns max spendable native or token amounts for those txs.
> 
> **TON** builds a single internal message from a custom **body BOC**, destination, amount, and bounce flag; fees come from dRPC **`estimateFee`**; signing/broadcast still use **`unsignedTxBase64`** like `makeSpend`. **`getMaxTx`** subtracts estimated fee and minimum address balance from the full balance.
> 
> Token metadata-only changes on Ethereum and Zano; engines are not bridge-specific—callers must match `nativeAmount` / instructions to what actually spends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85efea4624fd515858b8e707cb8947d07c91097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216504872021067