### PR TITLE
Stop recording failed Midgard actions as successful transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (MAYAChain/THORChain) Failed transactions no longer appear in history as successful receives. Midgard reports a reverted transaction's full `in`/`out` amounts even though nothing moved on-chain; we now honor the action `status` and, for a failed action, record a fee-only transaction marked `failed` for the signer (like a failed EVM transaction) instead of crediting the intended recipient.
+
 ## 4.86.0 (2026-07-13)
 
 - added: (Zano) Bridgeless bridge tokens SOLx (Solana), TONx (Toncoin), and FUSDx (Freedom Dollar).

--- a/src/cosmos/engine/CosmosEngine.ts
+++ b/src/cosmos/engine/CosmosEngine.ts
@@ -23,7 +23,7 @@ import {
 } from '@cosmjs/stargate'
 import { longify } from '@cosmjs/stargate/build/queryclient'
 import { fromRfc3339WithNanoseconds, toSeconds } from '@cosmjs/tendermint-rpc'
-import { add, ceil, gt, lt, mul, sub } from 'biggystring'
+import { abs, add, ceil, gt, lt, mul, sub } from 'biggystring'
 import {
   asArray,
   asEither,
@@ -857,7 +857,8 @@ export class CosmosEngine extends CurrencyEngine<
     cosmosCoin: CosmosCoin,
     memo: string,
     height: number,
-    fee?: Fee
+    fee?: Fee,
+    failed: boolean = false
   ): void {
     const { amount, denom } = cosmosCoin
 
@@ -891,7 +892,12 @@ export class CosmosEngine extends CurrencyEngine<
     let nativeAmount = amount
     let parentNetworkFee: string | undefined
     if (isSend) {
-      if (isMainnet) {
+      if (failed) {
+        // A failed transaction's only real balance change is the burned fee,
+        // which the coin events already carry in `amount`. Don't subtract a
+        // fee on top of it; the whole outflow is the fee.
+        networkFee = abs(nativeAmount)
+      } else if (isMainnet) {
         nativeAmount = sub(nativeAmount, networkFee)
       } else {
         parentNetworkFee = networkFee !== '0' ? networkFee : undefined
@@ -912,6 +918,7 @@ export class CosmosEngine extends CurrencyEngine<
 
     const edgeTransaction: EdgeTransaction = {
       blockHeight: height,
+      confirmations: failed ? 'failed' : undefined,
       currencyCode,
       date,
       isSend,

--- a/src/cosmos/engine/MidgardEngine.ts
+++ b/src/cosmos/engine/MidgardEngine.ts
@@ -18,13 +18,77 @@ import {
   asChainIdUpdate,
   asMidgardActionsResponse,
   asMidgardWalletOtherData,
-  MidgardAction,
+  MidgardActionResponse,
   MidgardNetworkInfo,
   MidgardWalletOtherData
 } from '../midgardTypes'
 import { CosmosEngine } from './CosmosEngine'
 
 const QUERY_POLL_MILLISECONDS = getRandomDelayMs(20000)
+
+/**
+ * Converts a single Midgard action into the coin_spent/coin_received events
+ * used to compute our wallet's net balance change.
+ *
+ * A failed action reverted its state changes on-chain, so the `in`/`out`
+ * amounts Midgard reports never actually moved. The only real balance change is
+ * the network fee, which is still charged to the signer even though the message
+ * reverted (exactly like a failed EVM transaction). For a failed action we
+ * therefore emit only the burned fee, and only when our wallet signed the
+ * transaction. If our wallet was merely the intended recipient it paid nothing
+ * and gets no events, so the action is ignored rather than shown as a
+ * successful receive.
+ */
+export function midgardActionToCoinEvents(
+  action: MidgardActionResponse,
+  ourAddress: string
+): Event[] {
+  const events: Event[] = []
+  const pushCoinEvent = (
+    address: string,
+    asset: string,
+    amount: string,
+    type: 'coin_spent' | 'coin_received'
+  ): void => {
+    // The coin might have a prefix like "RUNE.RUNE" or "MAYA.CACAO",
+    // or it might be a plain currency code like "TCY":
+    const assetParts = asset.split('.')
+    const assetCode = assetParts[1] ?? assetParts[0]
+    const typeValue = type === 'coin_received' ? 'receiver' : 'spender'
+    events.push({
+      type,
+      attributes: [
+        { key: 'amount', value: `${abs(amount)}${assetCode.toLowerCase()}` },
+        { key: typeValue, value: address }
+      ]
+    })
+  }
+
+  if (action.status === 'failed') {
+    const isSigner = action.in.some(
+      subAction => subAction.address === ourAddress
+    )
+    if (isSigner) {
+      const { networkFees } = Object.values(action.metadata)[0]
+      for (const feeCoin of networkFees) {
+        pushCoinEvent(ourAddress, feeCoin.asset, feeCoin.amount, 'coin_spent')
+      }
+    }
+    return events
+  }
+
+  for (const subAction of action.in) {
+    for (const coin of subAction.coins) {
+      pushCoinEvent(subAction.address, coin.asset, coin.amount, 'coin_spent')
+    }
+  }
+  for (const subAction of action.out) {
+    for (const coin of subAction.coins) {
+      pushCoinEvent(subAction.address, coin.asset, coin.amount, 'coin_received')
+    }
+  }
+  return events
+}
 
 /**
  * Base engine for chains that use Midgard API for transaction history.
@@ -109,44 +173,18 @@ export class MidgardEngine extends CosmosEngine {
           inLoopHeight = max(inLoopHeight, action.height)
           const date = parseInt(div(action.date, '1000000000'))
           const { memo } = Object.values(action.metadata)[0]
+          const ourAddress = this.walletInfo.keys.bech32Address
+
+          // The transaction id is the longest txID across all in/out
+          // sub-actions (internal/synthetic movements can use a shorter id).
           let txidHex = ''
-          // Convert actions to Events
-          const events: Event[] = []
-          const convertToEvents = (
-            actions: MidgardAction[],
-            type: 'coin_spent' | 'coin_received'
-          ): void => {
-            for (const action of actions) {
-              if (action.txID.length > txidHex.length) {
-                txidHex = action.txID
-              }
-              for (const coin of action.coins) {
-                const typeValue =
-                  type === 'coin_received' ? 'receiver' : 'spender'
-
-                // The coin might have a prefix like "RUNE.RUNE" or "MAYA.CACAO",
-                // or it might be a plain currency code like "TCY":
-                const assetParts = coin.asset.split('.')
-                const asset = assetParts[1] ?? assetParts[0]
-
-                events.push({
-                  type,
-                  attributes: [
-                    {
-                      key: 'amount',
-                      value: `${abs(coin.amount)}${asset.toLowerCase()}`
-                    },
-                    {
-                      key: typeValue,
-                      value: action.address
-                    }
-                  ]
-                })
-              }
+          for (const subAction of [...action.in, ...action.out]) {
+            if (subAction.txID.length > txidHex.length) {
+              txidHex = subAction.txID
             }
           }
-          convertToEvents(action.in, 'coin_spent')
-          convertToEvents(action.out, 'coin_received')
+
+          const events = midgardActionToCoinEvents(action, ourAddress)
 
           if (txidHex === mostRecentTxId) {
             breakWhileLoop = true
@@ -156,17 +194,17 @@ export class MidgardEngine extends CosmosEngine {
 
           let netBalanceChanges: CosmosCoin[] = []
           try {
-            netBalanceChanges = reduceCoinEventsForAddress(
-              events,
-              this.walletInfo.keys.bech32Address
-            )
+            netBalanceChanges = reduceCoinEventsForAddress(events, ourAddress)
           } catch (e) {
             this.log.warn('reduceCoinEventsForAddress error:', String(e))
           }
           if (netBalanceChanges.length === 0) continue
 
-          // Get the fee from the subclass
-          const fee = this.getMidgardTransactionFee()
+          // For a failed action the events already carry the burned fee as
+          // the entire balance change, so don't pass a fee that would be
+          // subtracted on top of it. Otherwise get the fee from the subclass.
+          const isFailed = action.status === 'failed'
+          const fee = isFailed ? undefined : this.getMidgardTransactionFee()
 
           netBalanceChanges.forEach(coin => {
             this.processCosmosTransaction(
@@ -176,7 +214,8 @@ export class MidgardEngine extends CosmosEngine {
               coin,
               memo,
               parseInt(action.height),
-              fee
+              fee,
+              isFailed
             )
           })
         }

--- a/src/cosmos/midgardTypes.ts
+++ b/src/cosmos/midgardTypes.ts
@@ -42,32 +42,36 @@ const asMidgardAction = asObject({
   txID: asString
 })
 export type MidgardAction = ReturnType<typeof asMidgardAction>
-export const asMidgardActionsResponse = asObject({
-  actions: asArray(
+export const asMidgardActionResponse = asObject({
+  date: asString,
+  height: asString,
+  in: asArray(asMidgardAction),
+  metadata: asObject(
     asObject({
-      date: asString,
-      height: asString,
-      in: asArray(asMidgardAction),
-      metadata: asObject(
-        asObject({
-          memo: asString,
-          networkFees: asOptional(
-            asArray(
-              asObject({
-                amount: asString,
-                asset: asString // 'THOR.RUNE' or 'MAYA.CACAO'
-              })
-            ),
-            () => []
-          )
-        })
-      ),
-      out: asArray(asMidgardAction)
-      // pools: ['BTC.BTC'],
-      // status: 'success',
-      // type: 'swap'
+      memo: asString,
+      networkFees: asOptional(
+        asArray(
+          asObject({
+            amount: asString,
+            asset: asString // 'THOR.RUNE' or 'MAYA.CACAO'
+          })
+        ),
+        () => []
+      )
     })
   ),
+  out: asArray(asMidgardAction),
+  // Midgard reports 'success', 'pending', or 'failed'. A failed action
+  // reverted its state changes on-chain, so its `in`/`out` amounts never
+  // actually moved (only the network fee was burned). Default to 'success'
+  // to preserve behavior if the field is ever absent.
+  status: asMaybe(asString, () => 'success')
+  // pools: ['BTC.BTC'],
+  // type: 'swap'
+})
+export type MidgardActionResponse = ReturnType<typeof asMidgardActionResponse>
+export const asMidgardActionsResponse = asObject({
+  actions: asArray(asMidgardActionResponse),
   // count: '5',
   meta: asObject({
     nextPageToken: asString // '169417139000000051',

--- a/test/cosmos/fixtures/mayachainActions_maya1ut0p7v.json
+++ b/test/cosmos/fixtures/mayachainActions_maya1ut0p7v.json
@@ -1,0 +1,352 @@
+{
+    "actions": [
+        {
+            "date": "1783442549112683137",
+            "height": "17355148",
+            "in": [
+                {
+                    "address": "bc1ql7585fs0ehw3g6l29rr8jv6pdn7t87wsffz2kx",
+                    "coins": [
+                        {
+                            "amount": "78259",
+                            "asset": "BTC.BTC"
+                        }
+                    ],
+                    "txID": "1FAA85289C5B2B2D7CC948ECB7C3C5D1BA244C97D038F581F5199E544D6EA59E"
+                }
+            ],
+            "metadata": {
+                "swap": {
+                    "affiliateAddress": "ej",
+                    "affiliateFee": "75",
+                    "inPriceUSD": "63949.76170382617",
+                    "isStreamingSwap": false,
+                    "liquidityFee": "108361352",
+                    "memo": "=:c:maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh:0/1/1:ej:75",
+                    "networkFees": [],
+                    "outPriceUSD": "0.11684728186080506",
+                    "streamingSwapMeta": {
+                        "count": "1",
+                        "depositedCoin": {
+                            "amount": "78259",
+                            "asset": "BTC.BTC"
+                        },
+                        "inCoin": {
+                            "amount": "78259",
+                            "asset": "BTC.BTC"
+                        },
+                        "interval": "1",
+                        "lastHeight": "17355148",
+                        "outCoin": {
+                            "amount": "4280922817651",
+                            "asset": "MAYA.CACAO"
+                        },
+                        "outEstimation": "4280922817651",
+                        "quantity": "1"
+                    },
+                    "swapSlip": "5",
+                    "swapTarget": "0"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1kp68vjldscfw5ke6gktyaufkvq8gzh2ky76sjr",
+                    "affiliate": true,
+                    "coins": [
+                        {
+                            "amount": "32106921132",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "height": "17355148",
+                    "txID": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "4248815896519",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "height": "17355148",
+                    "txID": ""
+                }
+            ],
+            "pools": [
+                "BTC.BTC"
+            ],
+            "status": "success",
+            "type": "swap"
+        },
+        {
+            "date": "1782920131538096319",
+            "height": "17270898",
+            "in": [
+                {
+                    "address": "maya1pac6fe5jdmkpnpnmyye8geqn72v4dsncy7qm36",
+                    "coins": [
+                        {
+                            "amount": "12128369999999",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "1",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "reason": "failed to execute message; message index: 0: insufficient funds: 1 error occurred:\n\t* insufficient funds\n\n"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "12128369999999",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380"
+                }
+            ],
+            "pools": [],
+            "status": "failed",
+            "type": "send"
+        },
+        {
+            "date": "1781543083238179197",
+            "height": "17038615",
+            "in": [
+                {
+                    "address": "maya1gkqusev608ysnw4j9sqsr553dh3z58c2lewk8t",
+                    "coins": [
+                        {
+                            "amount": "2103999999994",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "6AAA12B1E65DE62BB4BBC5E3A854660AE56DE98DBD56F16D9811DB044875E508"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "1",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "reason": "failed to execute message; message index: 0: insufficient funds: 1 error occurred:\n\t* insufficient funds\n\n"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "2103999999994",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "6AAA12B1E65DE62BB4BBC5E3A854660AE56DE98DBD56F16D9811DB044875E508"
+                }
+            ],
+            "pools": [],
+            "status": "failed",
+            "type": "send"
+        },
+        {
+            "date": "1781543071902644911",
+            "height": "17038613",
+            "in": [
+                {
+                    "address": "maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz",
+                    "coins": [
+                        {
+                            "amount": "1002299849426",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "2323E614F64462732738F16116A0D4FA941875A60510EFA1C019E1A2EAB2BA80"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "1",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "reason": "failed to execute message; message index: 0: insufficient funds: 1 error occurred:\n\t* insufficient funds\n\n"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "1002299849426",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "2323E614F64462732738F16116A0D4FA941875A60510EFA1C019E1A2EAB2BA80"
+                }
+            ],
+            "pools": [],
+            "status": "failed",
+            "type": "send"
+        },
+        {
+            "date": "1781543049113163984",
+            "height": "17038609",
+            "in": [
+                {
+                    "address": "maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz",
+                    "coins": [
+                        {
+                            "amount": "23664",
+                            "asset": "MAYA"
+                        }
+                    ],
+                    "txID": "A66DA0A696138267772DE92AFEC2B08149E046A03BB2BAE7EFFFA151204791EF"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "0",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA"
+                        }
+                    ],
+                    "reason": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"maya1dheycdevq39qlkxs2a6wuuzyn4aqxhve4hc8sm\"},{\"key\":\"amount\",\"value\":\"1780000000cacao\"},{\"key\":\"receiver\",\"value\":\"maya1577sz8j7xnthm3cl3vgfvmdmkrp7dqrhd9tafd\"},{\"key\":\"amount\",\"value\":\"200000000cacao\"},{\"key\":\"receiver\",\"value\":\"maya19764xganmndarzhn7mrls7tc0r59c7gj5twkz7\"},{\"key\":\"amount\",\"value\":\"20000000cacao\"},{\"key\":\"receiver\",\"value\":\"maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh\"},{\"key\":\"amount\",\"value\":\"23664maya\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"1780000000cacao\"},{\"key\":\"spender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"200000000cacao\"},{\"key\":\"spender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"20000000cacao\"},{\"key\":\"spender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"23664maya\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"send\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"module\",\"value\":\"governance\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"maya1dheycdevq39qlkxs2a6wuuzyn4aqxhve4hc8sm\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"1780000000cacao\"},{\"key\":\"recipient\",\"value\":\"maya1577sz8j7xnthm3cl3vgfvmdmkrp7dqrhd9tafd\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"200000000cacao\"},{\"key\":\"recipient\",\"value\":\"maya19764xganmndarzhn7mrls7tc0r59c7gj5twkz7\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"20000000cacao\"},{\"key\":\"recipient\",\"value\":\"maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh\"},{\"key\":\"sender\",\"value\":\"maya1ul9kyc2txf3927z6l5nz0nhc9km3fwny0kywkz\"},{\"key\":\"amount\",\"value\":\"23664maya\"}]}]}]"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "23664",
+                            "asset": "MAYA"
+                        }
+                    ],
+                    "txID": "A66DA0A696138267772DE92AFEC2B08149E046A03BB2BAE7EFFFA151204791EF"
+                }
+            ],
+            "pools": [],
+            "status": "success",
+            "type": "send"
+        },
+        {
+            "date": "1778509342799709594",
+            "height": "16515563",
+            "in": [
+                {
+                    "address": "maya1je8uqzk5j3783pu8uqc2g78ntxshxzfmm5sp2m",
+                    "coins": [
+                        {
+                            "amount": "41999999996",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "5AB75CD3949E92132D4D6F722A59CAA8778050EC2844F86CAD9D2EF0A5641A09"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "1",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "reason": "failed to execute message; message index: 0: insufficient funds: 1 error occurred:\n\t* insufficient funds\n\n"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "41999999996",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "5AB75CD3949E92132D4D6F722A59CAA8778050EC2844F86CAD9D2EF0A5641A09"
+                }
+            ],
+            "pools": [],
+            "status": "failed",
+            "type": "send"
+        },
+        {
+            "date": "1777951870448717885",
+            "height": "16420326",
+            "in": [
+                {
+                    "address": "maya1je8uqzk5j3783pu8uqc2g78ntxshxzfmm5sp2m",
+                    "coins": [
+                        {
+                            "amount": "41999999997",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "BF959A0D61135FD88727116ED82D4EE9AB0CC1EA6B8EA5B110651794328ED6B7"
+                }
+            ],
+            "metadata": {
+                "send": {
+                    "code": "1",
+                    "memo": "",
+                    "networkFees": [
+                        {
+                            "amount": "2000000000",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "reason": "failed to execute message; message index: 0: insufficient funds: 1 error occurred:\n\t* insufficient funds\n\n"
+                }
+            },
+            "out": [
+                {
+                    "address": "maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh",
+                    "coins": [
+                        {
+                            "amount": "41999999997",
+                            "asset": "MAYA.CACAO"
+                        }
+                    ],
+                    "txID": "BF959A0D61135FD88727116ED82D4EE9AB0CC1EA6B8EA5B110651794328ED6B7"
+                }
+            ],
+            "pools": [],
+            "status": "failed",
+            "type": "send"
+        }
+    ],
+    "count": "7",
+    "meta": {
+        "nextPageToken": "164203261000010001",
+        "prevPageToken": "173551489000000001"
+    }
+}

--- a/test/cosmos/midgardActionToCoinEvents.test.ts
+++ b/test/cosmos/midgardActionToCoinEvents.test.ts
@@ -1,0 +1,88 @@
+import { Event } from '@cosmjs/stargate'
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { reduceCoinEventsForAddress } from '../../src/cosmos/cosmosUtils'
+import { midgardActionToCoinEvents } from '../../src/cosmos/engine/MidgardEngine'
+import { MidgardActionResponse } from '../../src/cosmos/midgardTypes'
+
+const SENDER = 'maya1pac6fe5jdmkpnpnmyye8geqn72v4dsncy7qm36'
+const RECIPIENT = 'maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh'
+const OTHER = 'maya1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq'
+
+// Real MAYAChain send that reverted on-chain with "insufficient funds" but is
+// still reported by Midgard with the full amount in both `in` and `out`.
+// Source: the CACAO Balance ticket / midgard.mayachain.info actions API.
+const failedSend: MidgardActionResponse = {
+  date: '1782920131538096319',
+  height: '17270898',
+  in: [
+    {
+      address: SENDER,
+      coins: [{ amount: '12128369999999', asset: 'MAYA.CACAO' }],
+      txID: 'CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380'
+    }
+  ],
+  metadata: {
+    send: {
+      memo: '',
+      networkFees: [{ amount: '2000000000', asset: 'MAYA.CACAO' }]
+    }
+  },
+  out: [
+    {
+      address: RECIPIENT,
+      coins: [{ amount: '12128369999999', asset: 'MAYA.CACAO' }],
+      txID: 'CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380'
+    }
+  ],
+  status: 'failed'
+}
+
+const successfulSend: MidgardActionResponse = {
+  ...failedSend,
+  metadata: {
+    send: {
+      memo: 'gm',
+      networkFees: [{ amount: '2000000000', asset: 'MAYA.CACAO' }]
+    }
+  },
+  status: 'success'
+}
+
+const netChange = (events: Event[], address: string): string | undefined =>
+  reduceCoinEventsForAddress(events, address).find(c => c.denom === 'cacao')
+    ?.amount
+
+describe('midgardActionToCoinEvents', function () {
+  it('ignores a failed transaction for the intended recipient', function () {
+    const events = midgardActionToCoinEvents(failedSend, RECIPIENT)
+    // The recipient never received anything and paid no fee, so there must be
+    // no balance change to record (this is the bug being fixed: it previously
+    // showed a bogus +12128369999999 receive).
+    assert.deepEqual(events, [])
+    assert.deepEqual(reduceCoinEventsForAddress(events, RECIPIENT), [])
+  })
+
+  it('records only the burned fee against the signer of a failed transaction', function () {
+    const events = midgardActionToCoinEvents(failedSend, SENDER)
+    // The signer's balance dropped only by the burned network fee, not the
+    // full reverted send amount (matches failed EVM transaction behavior).
+    assert.equal(netChange(events, SENDER), '-2000000000')
+  })
+
+  it('ignores a failed transaction for an unrelated address', function () {
+    const events = midgardActionToCoinEvents(failedSend, OTHER)
+    assert.deepEqual(events, [])
+  })
+
+  it('records the full receive for a successful transaction', function () {
+    const events = midgardActionToCoinEvents(successfulSend, RECIPIENT)
+    assert.equal(netChange(events, RECIPIENT), '12128369999999')
+  })
+
+  it('records the full send for a successful transaction', function () {
+    const events = midgardActionToCoinEvents(successfulSend, SENDER)
+    assert.equal(netChange(events, SENDER), '-12128369999999')
+  })
+})

--- a/test/cosmos/midgardLiveTaskAddress.test.ts
+++ b/test/cosmos/midgardLiveTaskAddress.test.ts
@@ -1,0 +1,92 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { reduceCoinEventsForAddress } from '../../src/cosmos/cosmosUtils'
+import { midgardActionToCoinEvents } from '../../src/cosmos/engine/MidgardEngine'
+import { asMidgardActionsResponse } from '../../src/cosmos/midgardTypes'
+import liveActions from './fixtures/mayachainActions_maya1ut0p7v.json'
+
+// The exact address from the CACAO Balance ticket, and a snapshot of what
+// midgard.mayachain.info returned for `?address=<that address>` on 2026-07-13.
+// This proves the fix against real production data, not just a hand-built
+// fixture: the wallet was the recipient of 5 failed sends (bogus receives) plus
+// 2 genuinely-successful actions.
+const TASK_ADDRESS = 'maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh'
+
+// Replicates the OLD (buggy) behavior: build spent/received events from every
+// in/out sub-action regardless of the action status.
+const legacyEvents = (action: any): any[] => {
+  const events: any[] = []
+  const push = (
+    address: string,
+    asset: string,
+    amount: string,
+    type: string
+  ): void => {
+    const parts = asset.split('.')
+    const code = parts[1] ?? parts[0]
+    events.push({
+      type,
+      attributes: [
+        {
+          key: 'amount',
+          value: `${amount.replace('-', '')}${code.toLowerCase()}`
+        },
+        {
+          key: type === 'coin_received' ? 'receiver' : 'spender',
+          value: address
+        }
+      ]
+    })
+  }
+  for (const s of action.in)
+    for (const c of s.coins) push(s.address, c.asset, c.amount, 'coin_spent')
+  for (const s of action.out)
+    for (const c of s.coins) push(s.address, c.asset, c.amount, 'coin_received')
+  return events
+}
+
+describe('Midgard fix against live task address', function () {
+  const { actions } = asMidgardActionsResponse(liveActions)
+
+  it('has the expected mix of live actions (2 success, 5 failed)', function () {
+    const failed = actions.filter(a => a.status === 'failed').length
+    const success = actions.filter(a => a.status === 'success').length
+    assert.equal(actions.length, 7)
+    assert.equal(failed, 5)
+    assert.equal(success, 2)
+  })
+
+  it('OLD behavior credited every failed action as a receive (the bug)', function () {
+    const bogus = actions
+      .filter(a => a.status === 'failed')
+      .map(a => reduceCoinEventsForAddress(legacyEvents(a), TASK_ADDRESS))
+      .filter(net =>
+        net.some(c => !c.amount.startsWith('-') && c.amount !== '0')
+      )
+    // All 5 failed sends would have shown a positive (incoming) balance change.
+    assert.equal(bogus.length, 5)
+  })
+
+  it('NEW behavior drops every failed action for this recipient', function () {
+    for (const action of actions.filter(a => a.status === 'failed')) {
+      const events = midgardActionToCoinEvents(action, TASK_ADDRESS)
+      assert.deepEqual(events, [], `failed action should be dropped`)
+      assert.deepEqual(reduceCoinEventsForAddress(events, TASK_ADDRESS), [])
+    }
+  })
+
+  it('NEW behavior still records the successful receives', function () {
+    const kept = actions
+      .filter(a => a.status === 'success')
+      .map(a =>
+        reduceCoinEventsForAddress(
+          midgardActionToCoinEvents(a, TASK_ADDRESS),
+          TASK_ADDRESS
+        )
+      )
+      .filter(net => net.length > 0)
+    // Both successful actions still produce a real balance change.
+    assert.equal(kept.length, 2)
+  })
+})

--- a/test/cosmos/processFailedCosmosTransaction.test.ts
+++ b/test/cosmos/processFailedCosmosTransaction.test.ts
@@ -1,0 +1,65 @@
+import { assert } from 'chai'
+import { EdgeTransaction } from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { CosmosEngine } from '../../src/cosmos/engine/CosmosEngine'
+
+const makeFakeEngine = (captured: EdgeTransaction[]): any => ({
+  networkInfo: { nativeDenom: 'cacao' },
+  tokenIdFromDenom: () => null,
+  getCurrencyCode: () => 'CACAO',
+  walletInfo: { keys: { bech32Address: 'maya1sender' } },
+  walletId: 'test-wallet',
+  addTransaction: (_tokenId: unknown, tx: EdgeTransaction) => captured.push(tx)
+})
+
+describe('processCosmosTransaction failed transactions', function () {
+  it('records a fee-only failed send without double-counting the fee', function () {
+    const captured: EdgeTransaction[] = []
+    CosmosEngine.prototype.processCosmosTransaction.call(
+      makeFakeEngine(captured),
+      'CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380',
+      1782920131,
+      '',
+      // The burned fee is the entire balance change from the coin events:
+      { denom: 'cacao', amount: '-2000000000' },
+      '',
+      17270898,
+      undefined, // failed actions pass no fee to subtract...
+      true // ...and are flagged failed
+    )
+    assert.equal(captured.length, 1)
+    const tx = captured[0]
+    // The outflow is the burned fee exactly once, not fee-from-events plus
+    // fee-from-getMidgardTransactionFee (-4000000000).
+    assert.equal(tx.nativeAmount, '-2000000000')
+    assert.equal(tx.networkFee, '2000000000')
+    assert.equal(tx.confirmations, 'failed')
+    assert.equal(tx.isSend, true)
+  })
+
+  it('still subtracts the fee for successful mainnet sends', function () {
+    const captured: EdgeTransaction[] = []
+    CosmosEngine.prototype.processCosmosTransaction.call(
+      makeFakeEngine(captured),
+      'A66DA0A6961300000000000000000000000000000000000000000000000000',
+      1782920131,
+      '',
+      { denom: 'cacao', amount: '-12128369999999' },
+      '',
+      17270898,
+      {
+        amount: [{ denom: 'cacao', amount: '2000000000' }],
+        gasLimit: BigInt(0),
+        payer: '',
+        granter: ''
+      },
+      false
+    )
+    assert.equal(captured.length, 1)
+    const tx = captured[0]
+    assert.equal(tx.nativeAmount, '-12130369999999') // amount + fee
+    assert.equal(tx.networkFee, '2000000000')
+    assert.equal(tx.confirmations, undefined)
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216361287211965/f)

Fixes the CACAO balance issue where failed MAYAChain transactions appeared in the transaction history as successful receives.

**Root cause:** `MidgardEngine` (shared by MAYAChain and THORChain) builds balance-change events from each Midgard action's `in`/`out` arrays but ignored the action's `status` field. Midgard reports a reverted transaction's full intended amounts in `in`/`out` even though nothing moved on-chain, so a failed send was recorded as a full send for the signer and a full receive for the intended recipient. The ticket wallet (`maya1ut0p7v…`) had five such failed sends inflating its history and balance.

**Fix:** honor `status`. A `failed` action now records a fee-only transaction for the signer — `nativeAmount = -burnedFee`, `networkFee = burnedFee`, `confirmations: 'failed'`, matching how failed EVM transactions are handled — and is dropped entirely for the intended recipient, who paid nothing and received nothing. The fee is recorded exactly once: failed actions skip `getMidgardTransactionFee()`, since the burned fee already arrives via the coin events.

**Testing:**
- `midgardActionToCoinEvents` unit tests covering signer, recipient, and unrelated-address perspectives of the ticket's failed tx.
- A regression test that runs the real code over a vendored snapshot of the live Midgard response for the ticket's address (2 successful + 5 failed actions): old behavior credited all 5 failed sends as receives; new behavior drops exactly those 5 and keeps both genuine receives.
- `processCosmosTransaction` regression tests: a failed send records the burned fee once (not doubled via `getMidgardTransactionFee()`) and is marked `failed`; successful sends still add the fee to `nativeAmount`.
- Full suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Midgard-derived transactions affect displayed history and balances for MAYAChain/THORChain; wrong handling could hide real txs or mis-state fees, though behavior is covered by regression tests.
> 
> **Overview**
> **MAYAChain and THORChain** wallets that sync history from Midgard no longer treat reverted actions as successful transfers.
> 
> Midgard still lists full `in`/`out` amounts for failed actions even though only the fee moved on-chain. The Midgard path now reads action **`status`**, builds balance events via **`midgardActionToCoinEvents`**, and for **`failed`**: signers get a **fee-only** send marked **`confirmations: 'failed'`** (EVM-style); intended recipients get **no** history row. **`processCosmosTransaction`** accepts a **`failed`** flag so fees are not subtracted twice, and failed Midgard rows skip **`getMidgardTransactionFee()`**.
> 
> Types add **`status`** on Midgard actions (default **`success`**). Regression tests cover unit cases, a live Midgard snapshot for the ticket address, and failed vs successful fee math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98a3841bd018b1fabe88fa1e619a0fb414f8d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

