### PR TITLE
Update react-native-zcash to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: zcash - Update react-native-zcash to 0.12.2 (Zcash SDK 2.5.2) to align the plugin's declared dependency with the version the app ships.
+
 ## 4.86.0 (2026-07-13)
 
 - added: (Zano) Bridgeless bridge tokens SOLx (Solana), TONx (Toncoin), and FUSDx (Freedom Dollar).

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "react-native-monero": "0.4.0",
         "react-native-piratechain": "0.5.0",
         "react-native-zano": "^0.2.7",
-        "react-native-zcash": "0.10.1",
+        "react-native-zcash": "0.12.2",
         "rimraf": "^3.0.2",
         "shell-quote": "^1.8.1",
         "stream-browserify": "^2.0.2",
@@ -133,7 +133,7 @@
         "react-native-monero": "^0.3.0",
         "react-native-piratechain": "v0.5.0",
         "react-native-zano": "^0.2.7",
-        "react-native-zcash": "^0.10.1"
+        "react-native-zcash": "^0.12.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -15645,9 +15645,9 @@
       }
     },
     "node_modules/react-native-zcash": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/react-native-zcash/-/react-native-zcash-0.10.1.tgz",
-      "integrity": "sha512-lL2gMxyq3QVEerTgdcBz9Q2c4Bzu66DxQrcZXzM9uN/kvI9LH1JpAJs0LAFUVUwqQKPTvywKYVim0tuBL7xO2A==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/react-native-zcash/-/react-native-zcash-0.12.2.tgz",
+      "integrity": "sha512-Fl99JoR7d9AYX/45UxDIjHbCT0K6SefxWKLV9z3J0X3UBGQImaguC8Zd1qLDJ9Ae5pBdD6t1Oj+o5BYBp+hT7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "react-native-monero": "0.4.0",
     "react-native-piratechain": "0.5.0",
     "react-native-zano": "^0.2.7",
-    "react-native-zcash": "0.10.1",
+    "react-native-zcash": "0.12.2",
     "rimraf": "^3.0.2",
     "shell-quote": "^1.8.1",
     "stream-browserify": "^2.0.2",
@@ -189,7 +189,7 @@
     "react-native-monero": "^0.3.0",
     "react-native-piratechain": "v0.5.0",
     "react-native-zano": "^0.2.7",
-    "react-native-zcash": "^0.10.1"
+    "react-native-zcash": "^0.12.0"
   },
   "overrides": {
     "@greymass/eosio": "^0.6.8",


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216467071647813/f)

Aligns the plugin's declared `react-native-zcash` dependency and peer range with the `0.12.x` line (Zcash SDK `2.5.2`) that the app already ships via `edge-react-gui` (`react-native-zcash@^0.12.1`).

Previously `edge-currency-accountbased` declared `react-native-zcash@0.10.1` (Zcash SDK `2.4.0`) in `dependencies` and `^0.10.1` as a peer, neither of which is satisfied by the `0.12.x` the app hoists for the native module. This bumps both to `0.12.2` / `^0.12.0`, so the plugin type-checks against the same SDK JS the native module actually runs and the peer range matches production.

Verified: `verify-repo.sh` passes (build + tests), `tsc --noEmit` clean against `0.12.2`. No runtime behavior change (the app already runs `react-native-zcash 0.12.x`), so there is no new in-app flow to drive.

This is Ironwood (NU6.3) readiness groundwork. The Ironwood consensus integration itself is a separate change in `react-native-zcash` (bump the vendored Zcash mobile SDK from `2.5.2` to an NU6.3 release), which is blocked on ECC/`zcash` publishing the NU6.3 mobile SDK (as of now, iOS `libzcashlc.xcframework` tops out at `2.6.0-alpha.6` = NU6.2 and Android Maven `zcash-android-sdk` at `2.5.2`; librustzcash core shipped NU6.3 on 2026-07-09). For Edge that upgrade is purely at the SDK layer: no user action and no new UI are required (the Orchard to Ironwood turnstile migration is handled inside the SDK proposal logic, like the existing auto-shield flow). The one code caveat is that if the NU6.3 SDK reports migrated funds as a separate Ironwood `AccountBalance` pool, `react-native-zcash`'s balance aggregation must sum it or migrated funds go invisible.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1216467071647813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and peer-range alignment only; the app already runs 0.12.x, with no engine or Zcash logic changes in this diff.
> 
> **Overview**
> Bumps **`react-native-zcash`** from **0.10.1** to **0.12.2** (Zcash SDK **2.5.2**) in **`package.json`** / lockfile and widens the peer range to **`^0.12.0`**, so this plugin matches the **`0.12.x`** native module **`edge-react-gui`** already hoists.
> 
> Adds an **Unreleased** CHANGELOG entry for the Zcash dependency alignment. No plugin source changes; intent is correct TypeScript/types against the SDK JS the app runs, not new wallet behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6850e08bde0c6f5df961e47d52d48216d1a6d16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->