### PR TITLE
Flag account-based chains with hasStableAddresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Set `hasStableAddresses: true` on every account-based plugin, whose receive address is derived once from the key and never rotates. This lets the core and GUI serve and reconcile a cached receive address on a warm login. Requires the `edge-core-js` version that adds the field.
+
 ## 4.86.2 (2026-07-17)
 
 - changed: (Base) Use dynamic `eth_feeHistory` fee estimation instead of a hardcoded 2 gwei priority floor. The previous static floor caused sends to overpay by ~200x during normal network conditions. The dynamic algorithm tracks real-time percentile-based priority fees with a 2x base-fee buffer, so fees rise naturally during congestion spikes and drop to market rate otherwise. The static `minPriorityFee` fallback (used only when `eth_feeHistory` fails) is lowered from 2 gwei to 0.1 gwei, a conservative 20x reduction that covered the observed p99 priority fee in a 1,024-block Base sample.

--- a/src/algorand/algorandInfo.ts
+++ b/src/algorand/algorandInfo.ts
@@ -41,6 +41,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Algorand',
   chainDisplayName: 'Algorand',
   pluginId: 'algorand',
+  hasStableAddresses: true,
   walletType: 'wallet:algorand',
 
   // Explorers:

--- a/src/algorand/algorandTestnetInfo.ts
+++ b/src/algorand/algorandTestnetInfo.ts
@@ -34,6 +34,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Algorand Testnet',
   chainDisplayName: 'Algorand Testnet',
   pluginId: 'algorandtestnet',
+  hasStableAddresses: true,
   walletType: 'wallet:algorandtestnet',
 
   // Explorers:

--- a/src/binance/binanceInfo.ts
+++ b/src/binance/binanceInfo.ts
@@ -23,6 +23,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'BNB Beacon Chain',
   chainDisplayName: 'BNB Beacon Chain',
   pluginId: 'binance',
+  hasStableAddresses: true,
   walletType: 'wallet:binance',
 
   // Explorers:

--- a/src/cardano/cardanoInfo.ts
+++ b/src/cardano/cardanoInfo.ts
@@ -20,6 +20,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Cardano',
   chainDisplayName: 'Cardano',
   pluginId: 'cardano',
+  hasStableAddresses: true,
   walletType: 'wallet:cardano',
 
   // Explorers:

--- a/src/cardano/cardanoTestnetInfo.ts
+++ b/src/cardano/cardanoTestnetInfo.ts
@@ -20,6 +20,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Cardano PreProd Testnet',
   chainDisplayName: 'Cardano PreProd Testnet',
   pluginId: 'cardanotestnet',
+  hasStableAddresses: true,
   walletType: 'wallet:cardanotestnet',
 
   // Explorers:

--- a/src/cosmos/info/axelarInfo.ts
+++ b/src/cosmos/info/axelarInfo.ts
@@ -42,6 +42,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Axelar',
   chainDisplayName: 'Axelar',
   pluginId: 'axelar',
+  hasStableAddresses: true,
   walletType: 'wallet:axelar',
 
   // Explorers:

--- a/src/cosmos/info/coreumInfo.ts
+++ b/src/cosmos/info/coreumInfo.ts
@@ -163,6 +163,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'TX',
   chainDisplayName: 'TX',
   pluginId: 'coreum',
+  hasStableAddresses: true,
   walletType: 'wallet:coreum',
 
   // Explorers:

--- a/src/cosmos/info/cosmoshubInfo.ts
+++ b/src/cosmos/info/cosmoshubInfo.ts
@@ -35,6 +35,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Cosmos Hub',
   chainDisplayName: 'Cosmos Hub',
   pluginId: 'cosmoshub',
+  hasStableAddresses: true,
   walletType: 'wallet:cosmoshub',
 
   // Explorers:

--- a/src/cosmos/info/mayachainInfo.ts
+++ b/src/cosmos/info/mayachainInfo.ts
@@ -46,6 +46,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Cacao',
   chainDisplayName: 'MAYAChain',
   pluginId: 'mayachain',
+  hasStableAddresses: true,
   walletType: 'wallet:mayachain',
 
   // Explorers:

--- a/src/cosmos/info/nymInfo.ts
+++ b/src/cosmos/info/nymInfo.ts
@@ -42,6 +42,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Nym',
   chainDisplayName: 'Nyx',
   pluginId: 'nym',
+  hasStableAddresses: true,
   walletType: 'wallet:nym',
 
   // Explorers:

--- a/src/cosmos/info/osmosisInfo.ts
+++ b/src/cosmos/info/osmosisInfo.ts
@@ -66,6 +66,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Osmosis',
   chainDisplayName: 'Osmosis',
   pluginId: 'osmosis',
+  hasStableAddresses: true,
   walletType: 'wallet:osmosis',
 
   // Explorers:

--- a/src/cosmos/info/thorchainruneInfo.ts
+++ b/src/cosmos/info/thorchainruneInfo.ts
@@ -70,6 +70,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'THORChain',
   chainDisplayName: 'THORChain',
   pluginId: 'thorchainrune',
+  hasStableAddresses: true,
   walletType: 'wallet:thorchainrune',
 
   // Explorers:

--- a/src/cosmos/info/thorchainruneStagenetInfo.ts
+++ b/src/cosmos/info/thorchainruneStagenetInfo.ts
@@ -62,6 +62,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'THORChain Stagenet',
   chainDisplayName: 'THORChain Stagenet',
   pluginId: 'thorchainrunestagenet',
+  hasStableAddresses: true,
   walletType: 'wallet:thorchainrunestagenet',
 
   // Explorers:

--- a/src/eos/info/eosInfo.ts
+++ b/src/eos/info/eosInfo.ts
@@ -39,6 +39,7 @@ export const eosCurrencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'EOS',
   memoOptions: eosMemoOptions,
   pluginId: 'eos',
+  hasStableAddresses: true,
   unsafeBroadcastTx: true,
   walletType: 'wallet:eos',
 

--- a/src/eos/info/telosInfo.ts
+++ b/src/eos/info/telosInfo.ts
@@ -32,6 +32,7 @@ export const telosCurrencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Telos',
   memoOptions: eosMemoOptions,
   pluginId: 'telos',
+  hasStableAddresses: true,
   walletType: 'wallet:telos',
 
   // Explorers:

--- a/src/eos/info/waxInfo.ts
+++ b/src/eos/info/waxInfo.ts
@@ -28,6 +28,7 @@ export const waxCurrencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Wax',
   memoOptions: eosMemoOptions,
   pluginId: 'wax',
+  hasStableAddresses: true,
   walletType: 'wallet:wax',
 
   // Explorers:

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -84,6 +84,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'abstract',
+  hasStableAddresses: true,
   walletType: 'wallet:abstract',
 
   // Explorers:

--- a/src/ethereum/info/amoyInfo.ts
+++ b/src/ethereum/info/amoyInfo.ts
@@ -90,6 +90,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Amoy Testnet',
   memoOptions: evmMemoOptions,
   pluginId: 'amoy',
+  hasStableAddresses: true,
   walletType: 'wallet:amoy',
 
   // Explorers:

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -192,6 +192,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'arbitrum',
+  hasStableAddresses: true,
   walletType: 'wallet:arbitrum',
 
   // Explorers:

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -234,6 +234,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Avalanche',
   memoOptions: evmMemoOptions,
   pluginId: 'avalanche', // matching mnemonic here
+  hasStableAddresses: true,
   walletType: 'wallet:avalanche',
 
   // Explorers:

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -115,6 +115,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'base',
+  hasStableAddresses: true,
   walletType: 'wallet:base',
 
   // Explorers:

--- a/src/ethereum/info/binancesmartchainInfo.ts
+++ b/src/ethereum/info/binancesmartchainInfo.ts
@@ -193,6 +193,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'BNB Smart Chain',
   memoOptions: evmMemoOptions,
   pluginId: 'binancesmartchain',
+  hasStableAddresses: true,
   walletType: 'wallet:binancesmartchain',
 
   // Explorers:

--- a/src/ethereum/info/bobevmInfo.ts
+++ b/src/ethereum/info/bobevmInfo.ts
@@ -92,6 +92,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'BOB',
   memoOptions: evmMemoOptions,
   pluginId: 'bobevm',
+  hasStableAddresses: true,
   walletType: 'wallet:bobevm',
 
   // Explorers:

--- a/src/ethereum/info/botanixInfo.ts
+++ b/src/ethereum/info/botanixInfo.ts
@@ -90,6 +90,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Botanix',
   memoOptions: evmMemoOptions,
   pluginId: 'botanix',
+  hasStableAddresses: true,
   walletType: 'wallet:botanix',
 
   // Explorers:

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -110,6 +110,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Celo',
   memoOptions: evmMemoOptions,
   pluginId: 'celo',
+  hasStableAddresses: true,
   walletType: 'wallet:celo',
 
   // Explorers:

--- a/src/ethereum/info/ethDevInfo.ts
+++ b/src/ethereum/info/ethDevInfo.ts
@@ -138,6 +138,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Dev Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'ethDev',
+  hasStableAddresses: true,
   walletType: 'wallet:ethDev',
 
   // Explorers:

--- a/src/ethereum/info/ethereumInfo.ts
+++ b/src/ethereum/info/ethereumInfo.ts
@@ -1257,6 +1257,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'ethereum',
+  hasStableAddresses: true,
   walletType: 'wallet:ethereum',
 
   // Explorers:

--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -130,6 +130,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Ethereum Classic',
   memoOptions: evmMemoOptions,
   pluginId: 'ethereumclassic',
+  hasStableAddresses: true,
   walletType: 'wallet:ethereumclassic',
 
   // Explorers:

--- a/src/ethereum/info/ethereumpowInfo.ts
+++ b/src/ethereum/info/ethereumpowInfo.ts
@@ -101,6 +101,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'EthereumPoW',
   memoOptions: evmMemoOptions,
   pluginId: 'ethereumpow',
+  hasStableAddresses: true,
   walletType: 'wallet:ethereumpow',
 
   // Explorers:

--- a/src/ethereum/info/fantomInfo.ts
+++ b/src/ethereum/info/fantomInfo.ts
@@ -332,6 +332,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Fantom',
   memoOptions: evmMemoOptions,
   pluginId: 'fantom',
+  hasStableAddresses: true,
   walletType: 'wallet:fantom',
 
   // Explorers:

--- a/src/ethereum/info/filecoinFevmCalibrationInfo.ts
+++ b/src/ethereum/info/filecoinFevmCalibrationInfo.ts
@@ -96,6 +96,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Filecoin FEVM (Calibration Testnet)',
   memoOptions: evmMemoOptions,
   pluginId: 'filecoinfevmcalibration',
+  hasStableAddresses: true,
   requiredConfirmations: 900,
   walletType: 'wallet:filecoinfevmcalibration',
 

--- a/src/ethereum/info/filecoinFevmInfo.ts
+++ b/src/ethereum/info/filecoinFevmInfo.ts
@@ -102,6 +102,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Filecoin FEVM',
   memoOptions: evmMemoOptions,
   pluginId: 'filecoinfevm',
+  hasStableAddresses: true,
   requiredConfirmations: 900,
   walletType: 'wallet:filecoinfevm',
 

--- a/src/ethereum/info/holeskyInfo.ts
+++ b/src/ethereum/info/holeskyInfo.ts
@@ -109,6 +109,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Holesky Testnet',
   memoOptions: evmMemoOptions,
   pluginId: 'holesky',
+  hasStableAddresses: true,
   walletType: 'wallet:holesky',
 
   // Explorers:

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -163,6 +163,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'HYPE',
   memoOptions: evmMemoOptions,
   pluginId: 'hyperevm',
+  hasStableAddresses: true,
   walletType: 'wallet:hyperevm',
 
   // Explorers:

--- a/src/ethereum/info/monadInfo.ts
+++ b/src/ethereum/info/monadInfo.ts
@@ -121,6 +121,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Monad',
   memoOptions: evmMemoOptions,
   pluginId: 'monad',
+  hasStableAddresses: true,
   walletType: 'wallet:monad',
 
   // Explorers:

--- a/src/ethereum/info/opbnbInfo.ts
+++ b/src/ethereum/info/opbnbInfo.ts
@@ -102,6 +102,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'BNB',
   memoOptions: evmMemoOptions,
   pluginId: 'opbnb',
+  hasStableAddresses: true,
   walletType: 'wallet:opbnb',
 
   // Explorers:

--- a/src/ethereum/info/optimismInfo.ts
+++ b/src/ethereum/info/optimismInfo.ts
@@ -223,6 +223,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'optimism',
+  hasStableAddresses: true,
   walletType: 'wallet:optimism',
 
   // Explorers:

--- a/src/ethereum/info/polygonInfo.ts
+++ b/src/ethereum/info/polygonInfo.ts
@@ -231,6 +231,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Polygon',
   memoOptions: evmMemoOptions,
   pluginId: 'polygon', // matching mnemonic here
+  hasStableAddresses: true,
   walletType: 'wallet:polygon',
 
   // Explorers:

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -102,6 +102,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'PulseChain',
   memoOptions: evmMemoOptions,
   pluginId: 'pulsechain',
+  hasStableAddresses: true,
   walletType: 'wallet:pulsechain',
 
   // Explorers:

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -94,6 +94,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Rootstock',
   memoOptions: evmMemoOptions,
   pluginId: 'rsk',
+  hasStableAddresses: true,
   walletType: 'wallet:rsk',
 
   // Explorers:

--- a/src/ethereum/info/sepoliaInfo.ts
+++ b/src/ethereum/info/sepoliaInfo.ts
@@ -107,6 +107,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Sepolia Testnet',
   memoOptions: evmMemoOptions,
   pluginId: 'sepolia',
+  hasStableAddresses: true,
   walletType: 'wallet:sepolia',
 
   // Explorers:

--- a/src/ethereum/info/sonicInfo.ts
+++ b/src/ethereum/info/sonicInfo.ts
@@ -178,6 +178,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   chainDisplayName: 'Sonic',
   memoOptions: evmMemoOptions,
   pluginId: 'sonic',
+  hasStableAddresses: true,
   walletType: 'wallet:sonic',
 
   // Explorers:

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -132,6 +132,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Ethereum',
   memoOptions: evmMemoOptions,
   pluginId: 'zksync',
+  hasStableAddresses: true,
   walletType: 'wallet:zksync',
 
   // Explorers:

--- a/src/filecoin/calibrationInfo.ts
+++ b/src/filecoin/calibrationInfo.ts
@@ -24,6 +24,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Filecoin Testnet (Calibration)',
   chainDisplayName: 'Filecoin Testnet (Calibration)',
   pluginId: 'calibration',
+  hasStableAddresses: true,
   requiredConfirmations: 900,
   unsafeBroadcastTx: true,
   walletType: 'wallet:calibration',

--- a/src/filecoin/filecoinInfo.ts
+++ b/src/filecoin/filecoinInfo.ts
@@ -24,6 +24,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Filecoin',
   chainDisplayName: 'Filecoin',
   pluginId: 'filecoin',
+  hasStableAddresses: true,
   requiredConfirmations: 900,
   walletType: 'wallet:filecoin',
 

--- a/src/fio/fioInfo.ts
+++ b/src/fio/fioInfo.ts
@@ -42,6 +42,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'FIO',
   chainDisplayName: 'FIO',
   pluginId: 'fio',
+  hasStableAddresses: true,
   unsafeSyncNetwork: true,
   walletType: 'wallet:fio',
 

--- a/src/hedera/hederaInfo.ts
+++ b/src/hedera/hederaInfo.ts
@@ -20,6 +20,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Hedera',
   chainDisplayName: 'Hedera',
   pluginId: 'hedera',
+  hasStableAddresses: true,
   walletType: 'wallet:hedera',
 
   // Explorers:

--- a/src/hedera/hederaTestnetInfo.ts
+++ b/src/hedera/hederaTestnetInfo.ts
@@ -20,6 +20,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Hedera Testnet',
   chainDisplayName: 'Hedera Testnet',
   pluginId: 'hederatestnet',
+  hasStableAddresses: true,
   walletType: 'wallet:hederatestnet',
 
   // Explorers:

--- a/src/monero/moneroInfo.ts
+++ b/src/monero/moneroInfo.ts
@@ -26,6 +26,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
   currencyCode: 'XMR',
   displayName: 'Monero',
   pluginId: 'monero',
+  hasStableAddresses: true,
   requiredConfirmations: 10,
   walletType: 'wallet:monero',
 

--- a/src/piratechain/piratechainInfo.ts
+++ b/src/piratechain/piratechainInfo.ts
@@ -25,6 +25,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Pirate Chain',
   chainDisplayName: 'Pirate Chain',
   pluginId: 'piratechain',
+  hasStableAddresses: true,
   requiredConfirmations: 10,
   syncDisplayPrecision: 6,
   unsafeBroadcastTx: true,

--- a/src/polkadot/info/liberlandInfo.ts
+++ b/src/polkadot/info/liberlandInfo.ts
@@ -38,6 +38,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Liberland Dollar',
   chainDisplayName: 'Liberland',
   pluginId: 'liberland',
+  hasStableAddresses: true,
   walletType: 'wallet:liberland',
 
   // Explorers:

--- a/src/polkadot/info/liberlandTestnetInfo.ts
+++ b/src/polkadot/info/liberlandTestnetInfo.ts
@@ -35,6 +35,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Liberland Testnet',
   chainDisplayName: 'Liberland Testnet',
   pluginId: 'liberlandtestnet',
+  hasStableAddresses: true,
   walletType: 'wallet:liberlandtestnet',
 
   // Explorers:

--- a/src/polkadot/info/polkadotInfo.ts
+++ b/src/polkadot/info/polkadotInfo.ts
@@ -26,6 +26,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Polkadot',
   chainDisplayName: 'Polkadot',
   pluginId: 'polkadot',
+  hasStableAddresses: true,
   walletType: 'wallet:polkadot',
 
   // Explorers:

--- a/src/ripple/rippleInfo.ts
+++ b/src/ripple/rippleInfo.ts
@@ -19,6 +19,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'XRP',
   chainDisplayName: 'XRPL',
   pluginId: 'ripple',
+  hasStableAddresses: true,
   walletType: 'wallet:ripple',
 
   // Explorers:

--- a/src/solana/solanaInfo.ts
+++ b/src/solana/solanaInfo.ts
@@ -235,6 +235,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Solana',
   chainDisplayName: 'Solana',
   pluginId: 'solana',
+  hasStableAddresses: true,
   walletType: 'wallet:solana',
 
   // Explorers:

--- a/src/stellar/stellarInfo.ts
+++ b/src/stellar/stellarInfo.ts
@@ -18,6 +18,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Stellar',
   chainDisplayName: 'Stellar',
   pluginId: 'stellar',
+  hasStableAddresses: true,
   walletType: 'wallet:stellar',
 
   // Explorers:

--- a/src/sui/suiInfo.ts
+++ b/src/sui/suiInfo.ts
@@ -27,6 +27,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Sui',
   chainDisplayName: 'Sui',
   pluginId: 'sui',
+  hasStableAddresses: true,
   walletType: 'wallet:sui',
 
   // Explorers:

--- a/src/sui/suitestnetInfo.ts
+++ b/src/sui/suitestnetInfo.ts
@@ -27,6 +27,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Sui Testnet',
   chainDisplayName: 'Sui Testnet',
   pluginId: 'suitestnet',
+  hasStableAddresses: true,
   walletType: 'wallet:suitestnet',
 
   // Explorers:

--- a/src/tezos/tezosInfo.ts
+++ b/src/tezos/tezosInfo.ts
@@ -50,6 +50,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Tezos',
   chainDisplayName: 'Tezos',
   pluginId: 'tezos',
+  hasStableAddresses: true,
   walletType: 'wallet:tezos',
 
   // Explorers:

--- a/src/ton/tonInfo.ts
+++ b/src/ton/tonInfo.ts
@@ -17,6 +17,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Toncoin',
   chainDisplayName: 'Toncoin',
   pluginId: 'ton',
+  hasStableAddresses: true,
   walletType: 'wallet:ton',
 
   // Explorers:

--- a/src/tron/tronInfo.ts
+++ b/src/tron/tronInfo.ts
@@ -121,6 +121,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Tron',
   chainDisplayName: 'Tron',
   pluginId: 'tron',
+  hasStableAddresses: true,
   walletType: 'wallet:tron',
 
   // Explorers:

--- a/src/zano/zanoInfo.ts
+++ b/src/zano/zanoInfo.ts
@@ -150,6 +150,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Zano',
   chainDisplayName: 'Zano',
   pluginId: 'zano',
+  hasStableAddresses: true,
   walletType: 'wallet:zano',
   requiredConfirmations: 10,
 

--- a/src/zcash/zcashInfo.ts
+++ b/src/zcash/zcashInfo.ts
@@ -22,6 +22,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   assetDisplayName: 'Zcash',
   chainDisplayName: 'Zcash',
   pluginId: 'zcash',
+  hasStableAddresses: true,
   requiredConfirmations: 10,
   syncDisplayPrecision: 6,
   unsafeBroadcastTx: true,


### PR DESCRIPTION
## Summary

Sets `hasStableAddresses: true` on every account-based currency plugin. These chains derive their receive address once from the key and never rotate it, so a previously shown address stays valid and reuse-safe.

This lets edge-core-js serve a wallet's cached receive address before the engine loads, and lets the edge-react-gui receive scene reconcile it, giving these chains an instant receive screen on a warm login (Login Perf - Wallet Cache, phase 6).

## Scope

`hasStableAddresses: true` added to 63 `currencyInfo` literals across: all EVM chains, Solana, XRP, Stellar, Tezos, Tron, Algorand, Hedera, EOS/Telos/WAX, FIO, all Cosmos chains, Cardano, all Polkadot chains, Ton, Sui, Filecoin, Binance, Zcash, and Piratechain. Monero and Zano (privacy chains) are included: their primary address is static and reuse-safe by CryptoNote stealth-address design. Reviewer confirmation on the Monero/Zano inclusion is welcome.

## Dependency

Depends on `edge-core-js` adding the optional `EdgeCurrencyInfo.hasStableAddresses` field ([EdgeApp/edge-core-js#733](https://github.com/EdgeApp/edge-core-js/pull/733)). This PR is a **draft** and will fail `tsc` until that dependency publishes and is bumped here.

Asana: https://app.asana.com/0/1215088146871429/1216673467164267
