### PR TITLE
Stop recording failed MsgDeposit actions as full-amount sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Thorchain/Mayachain) Stop recording failed MsgDeposit actions (Midgard `type: 'failed'`) as full-amount sends. The reverted deposit never moved funds, so only the burned network fee is recorded, marked as a failed transaction — matching the existing failed-send handling.
+
 ## 4.86.2 (2026-07-17)
 
 - changed: (Base) Use dynamic `eth_feeHistory` fee estimation instead of a hardcoded 2 gwei priority floor. The previous static floor caused sends to overpay by ~200x during normal network conditions. The dynamic algorithm tracks real-time percentile-based priority fees with a 2x base-fee buffer, so fees rise naturally during congestion spikes and drop to market rate otherwise. The static `minPriorityFee` fallback (used only when `eth_feeHistory` fails) is lowered from 2 gwei to 0.1 gwei, a conservative 20x reduction that covered the observed p99 priority fee in a 1,024-block Base sample.

--- a/src/cosmos/engine/MidgardEngine.ts
+++ b/src/cosmos/engine/MidgardEngine.ts
@@ -27,6 +27,17 @@ import { CosmosEngine } from './CosmosEngine'
 const QUERY_POLL_MILLISECONDS = getRandomDelayMs(20000)
 
 /**
+ * Midgard reports a reverted operation two ways: a reverted send is a normal
+ * action with `status: 'failed'`, while a MsgDeposit whose message failed to
+ * execute (e.g. a swap memo the chain could not parse) is its own
+ * `type: 'failed'` action whose status is still 'success'. Both mean the
+ * `in`/`out` amounts never moved on-chain.
+ */
+export function isFailedMidgardAction(action: MidgardActionResponse): boolean {
+  return action.status === 'failed' || action.type === 'failed'
+}
+
+/**
  * Converts a single Midgard action into the coin_spent/coin_received events
  * used to compute our wallet's net balance change.
  *
@@ -38,10 +49,15 @@ const QUERY_POLL_MILLISECONDS = getRandomDelayMs(20000)
  * transaction. If our wallet was merely the intended recipient it paid nothing
  * and gets no events, so the action is ignored rather than shown as a
  * successful receive.
+ *
+ * A `type: 'failed'` deposit reports no networkFees in its metadata, so
+ * callers pass the chain's standard fee as `fallbackNetworkFees` to keep the
+ * burned fee on record.
  */
 export function midgardActionToCoinEvents(
   action: MidgardActionResponse,
-  ourAddress: string
+  ourAddress: string,
+  fallbackNetworkFees: Array<{ amount: string; asset: string }> = []
 ): Event[] {
   const events: Event[] = []
   const pushCoinEvent = (
@@ -64,13 +80,15 @@ export function midgardActionToCoinEvents(
     })
   }
 
-  if (action.status === 'failed') {
+  if (isFailedMidgardAction(action)) {
     const isSigner = action.in.some(
       subAction => subAction.address === ourAddress
     )
     if (isSigner) {
       const { networkFees } = Object.values(action.metadata)[0]
-      for (const feeCoin of networkFees) {
+      const feeCoins =
+        networkFees.length > 0 ? networkFees : fallbackNetworkFees
+      for (const feeCoin of feeCoins) {
         pushCoinEvent(ourAddress, feeCoin.asset, feeCoin.amount, 'coin_spent')
       }
     }
@@ -184,7 +202,18 @@ export class MidgardEngine extends CosmosEngine {
             }
           }
 
-          const events = midgardActionToCoinEvents(action, ourAddress)
+          // A failed deposit reports no networkFees, so offer the chain's
+          // standard fee as the fallback balance change for the signer.
+          const fallbackNetworkFees =
+            this.getMidgardTransactionFee().amount.map(feeCoin => ({
+              amount: feeCoin.amount,
+              asset: feeCoin.denom
+            }))
+          const events = midgardActionToCoinEvents(
+            action,
+            ourAddress,
+            fallbackNetworkFees
+          )
 
           if (txidHex === mostRecentTxId) {
             breakWhileLoop = true
@@ -203,7 +232,7 @@ export class MidgardEngine extends CosmosEngine {
           // For a failed action the events already carry the burned fee as
           // the entire balance change, so don't pass a fee that would be
           // subtracted on top of it. Otherwise get the fee from the subclass.
-          const isFailed = action.status === 'failed'
+          const isFailed = isFailedMidgardAction(action)
           const fee = isFailed ? undefined : this.getMidgardTransactionFee()
 
           netBalanceChanges.forEach(coin => {

--- a/src/cosmos/midgardTypes.ts
+++ b/src/cosmos/midgardTypes.ts
@@ -65,9 +65,13 @@ export const asMidgardActionResponse = asObject({
   // reverted its state changes on-chain, so its `in`/`out` amounts never
   // actually moved (only the network fee was burned). Default to 'success'
   // to preserve behavior if the field is ever absent.
-  status: asMaybe(asString, () => 'success')
+  status: asMaybe(asString, () => 'success'),
+  // The action's operation, e.g. 'swap', 'send', 'refund'. A MsgDeposit whose
+  // message failed to execute (e.g. a misrouted swap memo) is reported as its
+  // own 'failed' type — with status 'success' and a metadata.failed object
+  // that carries no networkFees — rather than as a failed-status action.
+  type: asMaybe(asString, () => '')
   // pools: ['BTC.BTC'],
-  // type: 'swap'
 })
 export type MidgardActionResponse = ReturnType<typeof asMidgardActionResponse>
 export const asMidgardActionsResponse = asObject({

--- a/test/cosmos/midgardActionToCoinEvents.test.ts
+++ b/test/cosmos/midgardActionToCoinEvents.test.ts
@@ -4,7 +4,10 @@ import { describe, it } from 'mocha'
 
 import { reduceCoinEventsForAddress } from '../../src/cosmos/cosmosUtils'
 import { midgardActionToCoinEvents } from '../../src/cosmos/engine/MidgardEngine'
-import { MidgardActionResponse } from '../../src/cosmos/midgardTypes'
+import {
+  asMidgardActionResponse,
+  MidgardActionResponse
+} from '../../src/cosmos/midgardTypes'
 
 const SENDER = 'maya1pac6fe5jdmkpnpnmyye8geqn72v4dsncy7qm36'
 const RECIPIENT = 'maya1ut0p7veh9l4sdezk2yn7ypuhqml2adfmezydlh'
@@ -36,7 +39,8 @@ const failedSend: MidgardActionResponse = {
       txID: 'CADADEA87F920A0650FD438A40D415FD61EA8FD80390D4821F8758C19C0A9380'
     }
   ],
-  status: 'failed'
+  status: 'failed',
+  type: 'send'
 }
 
 const successfulSend: MidgardActionResponse = {
@@ -49,6 +53,41 @@ const successfulSend: MidgardActionResponse = {
   },
   status: 'success'
 }
+
+const DEPOSIT_SENDER = 'thor1awtcehl2tq4jg0js9tdsx623a8k3a2nqcce4el'
+
+// A real THORChain MsgDeposit that failed to execute, from an unrelated
+// third-party integration (note the `-_/t1` affiliate — not ours). Midgard
+// reports these as their own `type: 'failed'` action: the status stays
+// 'success', the metadata.failed object carries no networkFees, and the full
+// deposit amount is still listed in `in` even though it never moved.
+// Source: thorchain Midgard actions API, txid D3A914...57CDA9, verbatim.
+const failedDeposit = asMidgardActionResponse({
+  date: '1784826777907554968',
+  height: '27128571',
+  in: [
+    {
+      address: DEPOSIT_SENDER,
+      coins: [{ amount: '49856548000', asset: 'THOR.RUNE' }],
+      txID: 'D3A9148F8A242FF64D16C1656B48A2E7B58FB8FA90C69070EF4E9FEA8757CDA9'
+    }
+  ],
+  metadata: {
+    failed: {
+      code: '5',
+      memo: '=:e:0x566bc53a9648FC5f4a01DDA944EE91B66Dc8CE13:10940295/0/0:-_/t1:0/70',
+      reason: 'failed to execute message; message index: 0: insufficient funds'
+    }
+  },
+  out: [],
+  pools: [],
+  status: 'success',
+  type: 'failed'
+})
+
+// THORChain's standard native fee, as passed by the engine's
+// getMidgardTransactionFee fallback.
+const THOR_FALLBACK_FEES = [{ amount: '2000000', asset: 'rune' }]
 
 const netChange = (events: Event[], address: string): string | undefined =>
   reduceCoinEventsForAddress(events, address).find(c => c.denom === 'cacao')
@@ -84,5 +123,47 @@ describe('midgardActionToCoinEvents', function () {
   it('records the full send for a successful transaction', function () {
     const events = midgardActionToCoinEvents(successfulSend, SENDER)
     assert.equal(netChange(events, SENDER), '-12128369999999')
+  })
+
+  // A `type: 'failed'` deposit reverted on-chain even though its status reads
+  // 'success'. Treating it by status alone recorded the full deposit amount as
+  // a real send, leaving a large outgoing transaction in history against a
+  // balance that never moved.
+  it('records only the fallback fee for the signer of a failed deposit', function () {
+    const events = midgardActionToCoinEvents(
+      failedDeposit,
+      DEPOSIT_SENDER,
+      THOR_FALLBACK_FEES
+    )
+    const runeChange = reduceCoinEventsForAddress(events, DEPOSIT_SENDER).find(
+      c => c.denom === 'rune'
+    )?.amount
+    assert.equal(runeChange, '-2000000')
+  })
+
+  it('never records the full deposit amount for a failed deposit', function () {
+    const events = midgardActionToCoinEvents(
+      failedDeposit,
+      DEPOSIT_SENDER,
+      THOR_FALLBACK_FEES
+    )
+    const changes = reduceCoinEventsForAddress(events, DEPOSIT_SENDER)
+    assert.isFalse(changes.some(c => c.amount === '-49856548000'))
+  })
+
+  it('emits nothing for a failed deposit without a fallback fee', function () {
+    // Base MidgardEngine subclasses with a zero fee produce a zero event,
+    // which reduceCoinEventsForAddress filters out entirely.
+    const events = midgardActionToCoinEvents(failedDeposit, DEPOSIT_SENDER)
+    assert.deepEqual(reduceCoinEventsForAddress(events, DEPOSIT_SENDER), [])
+  })
+
+  it('ignores a failed deposit for an unrelated address', function () {
+    const events = midgardActionToCoinEvents(
+      failedDeposit,
+      OTHER,
+      THOR_FALLBACK_FEES
+    )
+    assert.deepEqual(events, [])
   })
 })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana: Swap (Maya) - RUNE-DASH routes to Thorchain and Fails](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216772228906406)

Follow-up to e98a3841 ("Stop recording failed Midgard actions as successful transactions"), which caught one of the two shapes Midgard uses to report a reverted operation.

A reverted *send* is a normal action with `status: 'failed'` — that one is handled. A `MsgDeposit` whose message failed to execute is reported as its own action `type: 'failed'`, and its status stays `'success'`:

```json
{
  "in": [{ "address": "thor1awtcehl2tq4jg0js9tdsx623a8k3a2nqcce4el",
           "coins": [{ "amount": "49856548000", "asset": "THOR.RUNE" }] }],
  "metadata": { "failed": { "code": "5",
                            "memo": "=:e:0x566b...CE13:10940295/0/0:-_/t1:0/70",
                            "reason": "...insufficient funds" } },
  "out": [],
  "status": "success",
  "type": "failed"
}
```

(a public THORChain deposit from an unrelated integration, txid `D3A914…57CDA9` — this is the fixture the tests use)

Since the engine only checked `status`, these deposits took the normal path and were recorded as a full-amount send — a large outgoing transaction sitting in history against a balance that never moved. That's the user-visible half of the linked ticket, and QA reproduced it independently: history showed the swap as sent while the synced balance was unchanged.

This treats a `'failed'` action type the same as a failed status. Such actions report no `networkFees`, so the engine now passes the chain's standard fee (`getMidgardTransactionFee` — 0.02 RUNE, 0.2 CACAO) as a fallback, keeping the burned fee on record against the signer and flagged `confirmations: 'failed'`, matching the existing failed-send behavior. The fee-only record supersedes the full-amount pending transaction the GUI saved at broadcast, because it carries a real block height and `addTransaction` updates on an increasing `blockHeight`.

Note this leaves the transaction visible in the list, marked failed and fee-only (the EVM-parity convention from e98a3841). Hiding failed transactions entirely would be a separate GUI-side filter on `confirmations === 'failed'`.

The swap-routing cause behind the particular failures in the ticket is fixed separately in edge-exchange-plugins.

### Testing

- `test/cosmos/midgardActionToCoinEvents.test.ts` adds a real `type: 'failed'` deposit as a fixture, run through `asMidgardActionResponse` so the cleaner, event builder, and reducer are all exercised — including that the full deposit amount is never recorded.
- All four new assertions were confirmed to fail against the old status-only check before being kept.
- `npm run test` (476 passing), `tsc`, and eslint clean.
- Not yet run against a live wallet resync — worth confirming on the QA wallet that the stale entry collapses to the fee-only record.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216838957023381

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet transaction history and balance reconciliation for THORChain/MayaChain Midgard sync; incorrect classification could still misreport sends or fees, but scope is limited to failed-action handling and mirrors the prior failed-send fix.
> 
> **Overview**
> Extends THORChain/MayaChain Midgard history handling so **`type: 'failed'`** actions (failed **MsgDeposit** executions with **`status: 'success'`)** are treated like **`status: 'failed'`** reverted sends, instead of recording the full **`in`** amount as a real outgoing transfer.
> 
> **`isFailedMidgardAction`** now covers both shapes. **`midgardActionToCoinEvents`** accepts **`fallbackNetworkFees`** when metadata has no **`networkFees`** (typical for failed deposits), and **`MidgardEngine.queryTransactions`** supplies the chain standard fee from **`getMidgardTransactionFee`**. Failed actions still emit fee-only coin events for the signer and are processed with **`confirmations: 'failed`**, matching existing failed-send behavior.
> 
> Midgard action parsing adds an optional **`type`** field. Tests add a real THORChain failed-deposit fixture and assert fee-only recording, no full deposit amount, and correct ignores for unrelated addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9ea9c6e4f26d44e13478de27c20101f4da304a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->