### PR TITLE
Honor evmScanApiKey on etherscan.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (EVM) Honor the `evmScanApiKey` init option on `api.etherscan.io`. Since the Etherscan V2 upgrade, key lookup for that host required the deprecated `etherscanApiKey` and threw before considering `evmScanApiKey`, so a build configured with only the supported option sent no key. Etherscan V2 rejects keyless requests, leaving the EvmScan adapter (the sole transaction-history source on 15 EVM networks) unable to return transactions, which pinned wallet sync at 50% forever. An empty string or empty array now counts as unconfigured so it falls through to the deprecated per-network keys.
+
 ## 4.86.2 (2026-07-17)
 
 - changed: (Base) Use dynamic `eth_feeHistory` fee estimation instead of a hardcoded 2 gwei priority floor. The previous static floor caused sends to overpay by ~200x during normal network conditions. The dynamic algorithm tracks real-time percentile-based priority fees with a 2x base-fee buffer, so fees rise naturally during congestion spikes and drop to market rate otherwise. The static `minPriorityFee` fallback (used only when `eth_feeHistory` fails) is lowered from 2 gwei to 0.1 gwei, a conservative 20x reduction that covered the observed p99 priority fee in a 1,024-block Base sample.

--- a/src/ethereum/fees/feeProviders.ts
+++ b/src/ethereum/fees/feeProviders.ts
@@ -339,6 +339,17 @@ export const fetchFeesFromInfoServer = async (
   return asEthereumFees(json)
 }
 
+/**
+ * An init option counts as missing when it is absent, an empty string, or an
+ * empty array. The GUI defaults `evmScanApiKey` to `[]`, so a plain null check
+ * would treat an unconfigured build as configured and send a keyless request.
+ */
+const hasApiKey = (apiKey: unknown): boolean => {
+  if (apiKey == null) return false
+  if (Array.isArray(apiKey)) return apiKey.length > 0
+  return apiKey !== ''
+}
+
 // Get API key for Etherscan v2 API or network-specific scan APIs
 export const getEvmScanApiKey = (
   initOptions: JsonObject,
@@ -351,14 +362,22 @@ export const getEvmScanApiKey = (
 
   const { currencyCode } = info
 
-  // If we have a server URL and it's etherscan.io, use the Ethereum API key
+  // `evmScanApiKey` is the supported option and is valid for every Etherscan v2
+  // network, etherscan.io included. It must be checked first, otherwise a build
+  // configured with only this option gets no key at all, Etherscan v2 rejects
+  // the keyless request, and transaction history never syncs.
+  if (hasApiKey(evmScanApiKey)) return evmScanApiKey
+
+  // Etherscan v2 rejects keyless requests with 'Missing/Invalid API Key', so a
+  // build with no usable key cannot query this server at all:
   if (serverUrl.includes('etherscan.io')) {
-    if (etherscanApiKey == null)
-      throw new Error(`Missing etherscanApiKey for etherscan.io`)
+    if (!hasApiKey(etherscanApiKey))
+      throw new Error(`Missing evmScanApiKey for etherscan.io`)
+    log.warn(
+      "INIT OPTION 'etherscanApiKey' IS DEPRECATED. USE 'evmScanApiKey' INSTEAD"
+    )
     return etherscanApiKey
   }
-
-  if (evmScanApiKey != null) return evmScanApiKey
 
   // For networks that don't support Etherscan v2, fall back to network-specific keys
   if (currencyCode === 'ETH' && etherscanApiKey != null) {

--- a/test/ethereum/fees/getEvmScanApiKey.test.ts
+++ b/test/ethereum/fees/getEvmScanApiKey.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai'
+import { EdgeLog } from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { getEvmScanApiKey } from '../../../src/ethereum/fees/feeProviders'
+import { currencyInfo as info } from '../../../src/ethereum/info/ethereumInfo'
+
+describe('getEvmScanApiKey', function () {
+  const etherscanServer = 'https://api.etherscan.io'
+  const otherScanServer = 'https://api.routescan.io'
+
+  const warnings: string[] = []
+  const log = Object.assign(() => {}, {
+    warn: (...args: any[]) => {
+      warnings.push(String(args[0]))
+    },
+    error: () => {},
+    crash: () => {}
+  }) as unknown as EdgeLog
+
+  it('uses evmScanApiKey for etherscan.io', function () {
+    // A build configured with only the supported option must work. Preferring
+    // the deprecated etherscanApiKey here left transaction history unsynced.
+    const out = getEvmScanApiKey(
+      { evmScanApiKey: ['key1'] },
+      info,
+      log,
+      etherscanServer
+    )
+    expect(out).deep.equals(['key1'])
+  })
+
+  it('uses evmScanApiKey for non-etherscan.io servers', function () {
+    const out = getEvmScanApiKey(
+      { evmScanApiKey: ['key1'] },
+      info,
+      log,
+      otherScanServer
+    )
+    expect(out).deep.equals(['key1'])
+  })
+
+  it('falls back to the deprecated etherscanApiKey when evmScanApiKey is an empty array', function () {
+    // The GUI defaults evmScanApiKey to [], so an empty array means unconfigured:
+    const out = getEvmScanApiKey(
+      { evmScanApiKey: [], etherscanApiKey: ['legacy'] },
+      info,
+      log,
+      etherscanServer
+    )
+    expect(out).deep.equals(['legacy'])
+  })
+
+  it('falls back to the deprecated etherscanApiKey when evmScanApiKey is absent', function () {
+    const out = getEvmScanApiKey(
+      { etherscanApiKey: ['legacy'] },
+      info,
+      log,
+      etherscanServer
+    )
+    expect(out).deep.equals(['legacy'])
+  })
+
+  it('throws for etherscan.io when no usable key is configured', function () {
+    expect(() =>
+      getEvmScanApiKey({ evmScanApiKey: [] }, info, log, etherscanServer)
+    ).to.throw('Missing evmScanApiKey for etherscan.io')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216605015325950/f)

`getEvmScanApiKey` requires the deprecated `etherscanApiKey` init option whenever the server is `api.etherscan.io`, and throws before it ever considers `evmScanApiKey`, the option the function itself tells callers to use:

```ts
if (serverUrl.includes('etherscan.io')) {
  if (etherscanApiKey == null)
    throw new Error(`Missing etherscanApiKey for etherscan.io`)
  return etherscanApiKey
}

if (evmScanApiKey != null) return evmScanApiKey   // never reached for etherscan.io
```

An app configured with only `evmScanApiKey` therefore gets no key at all. Etherscan V2 rejects keyless requests:

```
$ curl 'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=0x742d...'
{"status":"0","message":"NOTOK","result":"Missing/Invalid API Key"}
```

The impact is larger than fee estimation. `EvmScanAdapter` is the ONLY adapter with a non-null `fetchTxs` on the 15 EVM networks whose `networkAdapterConfigs` point at `api.etherscan.io` (ethereum, polygon, base, arbitrum, optimism, avalanche, binancesmartchain, celo, zksync, sonic, opbnb, monad, hyperEvm, holesky, sepolia). `RpcAdapter`, `BlockbookAdapter` and `AmberdataAdapter` all set `fetchTxs = null`. So the failed key lookup means `acquireTxs` never receives a `tokenTxs` update, `setHistoryRatios(_, 1)` never fires, and transaction history stays unsynced forever.

`makeTokenSyncTracker` averages balance and history progress per token, so a wallet whose balance is complete and whose history is stuck at zero reports exactly `0.5`:

```
totalRatio += ((balanceStatus + txStatus) / 2) * perTokenSlice
```

which surfaces in the app as a wallet permanently stuck at 50% sync. This was reported against a white-label build whose env.json carries only `evmScanApiKey`.

This regressed in `0296a76c` "Upgrade to Etherscan V2" (first released in v4.47.0), which moved the `evmScanApiKey` check below the new etherscan.io branch. Before that commit, `evmScanApiKey` was checked first and such a build worked.

**The fix:** check `evmScanApiKey` first for every server, etherscan.io included. Treat an empty string or empty array as unconfigured, so a caller that defaults the option to `[]` (edge-react-gui does) still falls through to the deprecated per-network keys instead of sending an empty key. The hard error for etherscan.io is kept for the case where no usable key exists at all, and the deprecation warning now fires on that path too.

### Testing

- New unit tests in `test/ethereum/fees/getEvmScanApiKey.test.ts` cover: `evmScanApiKey` resolving for etherscan.io and for other scan hosts, an empty array falling back to the deprecated key, an absent `evmScanApiKey` falling back, and no usable key still throwing.
- `npm test`: passing.
- Verified end to end in edge-react-gui on an iOS simulator with an env.json carrying only `evmScanApiKey`. Before: an ETH wallet resync left the app at "Loading Transactions... 49.9% Complete" with an empty transaction list. After: the transaction list fully repopulated and the sync indicator cleared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes init-option resolution for all EvmScan and gas-oracle calls on etherscan.io hosts across many EVM networks; behavior is intentionally different but fixes a production sync regression with targeted tests.
> 
> **Overview**
> Fixes EVM wallet sync stuck at **50%** when the app is configured with only the supported **`evmScanApiKey`** init option (no deprecated **`etherscanApiKey`**).
> 
> **`getEvmScanApiKey`** now checks **`evmScanApiKey` first** for every scan host, including **`api.etherscan.io`**. After the Etherscan V2 upgrade, the etherscan.io branch ran before that check and required **`etherscanApiKey`**, so builds with only **`evmScanApiKey`** sent no API key. Etherscan V2 rejects those requests, which broke **`EvmScanAdapter`** transaction history on the networks that rely on that host—history never advanced while balance could still sync, so overall progress averaged to half.
> 
> A new **`hasApiKey`** helper treats absent values, empty strings, and **empty arrays** as unconfigured (matching GUI defaults like **`evmScanApiKey: []`**), so those cases fall through to deprecated per-network keys instead of a keyless call. The hard error for etherscan.io with no usable key now references **`evmScanApiKey`** and logs the deprecation warning when falling back to **`etherscanApiKey`**.
> 
> Unit tests in **`test/ethereum/fees/getEvmScanApiKey.test.ts`** cover the etherscan.io and other hosts paths, empty-array fallback, and the throw when nothing is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd8113e192c8d1c24d091d43f325d40c61672f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->