### PR TITLE
Replace Sui's dead JSON-RPC endpoint with configurable node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- added: (Sui) `rpcNodes`, `rpcNodesArchival`, and `maxRequestsPerSecond` to the info payload, so nodes can be changed without a client release. Transaction sweeps start on an archival node, since the walk begins at the wallet's oldest transaction and a pruned node rejects a cursor older than its retention window.
+- changed: (Sui) Broadcast submits to every configured node at once, succeeding if any one does.
+- fixed: (Sui) Restore syncing and sending after Mysten removed JSON-RPC from the public fullnodes. The plugin used the SDK's `getFullnodeUrl`, which now answers every method with `-32601`, breaking balances, transaction history, fee estimation, and broadcast. Replaced with configurable node lists served by third-party providers that still offer JSON-RPC, raced across nodes with a per-node timeout, and made overridable from the info server.
+- fixed: (Sui) Transaction sync progress no longer reports as complete when the queries failed. A total RPC outage previously presented as a wallet frozen at 50% rather than one visibly failing to sync.
+- fixed: (Sui) Transaction sweeps commit their cursor per page. Previously a failure part-way through discarded every page of progress, so a wallet whose history could not be swept in a single pass never advanced.
+- fixed: (Sui) Token sends page through coins with a cursor. The previous loop re-read the first page indefinitely when it did not cover the send amount.
+
 ## 4.86.3 (2026-07-27)
 
 - fixed: (Thorchain/Mayachain) Stop recording failed MsgDeposit actions (Midgard `type: 'failed'`) as full-amount sends. The reverted deposit never moved funds, so only the burned network fee is recorded, marked as a failed transaction — matching the existing failed-send handling.

--- a/src/sui/SuiEngine.ts
+++ b/src/sui/SuiEngine.ts
@@ -7,7 +7,7 @@ import { SignatureWithBytes } from '@mysten/sui/cryptography'
 import { Ed25519Keypair, Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
 import { Transaction } from '@mysten/sui/transactions'
 import { SUI_TYPE_ARG } from '@mysten/sui/utils'
-import { add, eq, gt, lt, sub } from 'biggystring'
+import { add, gt, lt, sub } from 'biggystring'
 import {
   EdgeAddress,
   EdgeCurrencyEngine,
@@ -24,6 +24,7 @@ import { base64 } from 'rfc4648'
 import { CurrencyEngine } from '../common/CurrencyEngine'
 import { PluginEnvironment } from '../common/innerPlugin'
 import { getRandomDelayMs } from '../common/network'
+import { formatAggregateError } from '../common/promiseUtils'
 import { makeTokenSyncTracker, TokenSyncTracker } from '../common/SyncTracker'
 import { asMaybeContractLocation } from '../common/tokenHelpers'
 import {
@@ -31,7 +32,12 @@ import {
   MakeTxParams,
   SafeCommonWalletInfo
 } from '../common/types'
-import { cleanTxLogs, getOtherParams } from '../common/utils'
+import {
+  cleanTxLogs,
+  getOtherParams,
+  makeMutex,
+  shuffleArray
+} from '../common/utils'
 import { SuiTools } from './SuiTools'
 import {
   asSuiPrivateKeys,
@@ -45,6 +51,19 @@ import {
 
 const ADDRESS_POLL_MILLISECONDS = getRandomDelayMs(20000)
 
+/**
+ * A pruned node reports a cursor outside its retention window as JSON-RPC
+ * -32602 rather than as an empty page, so this is how "too old for me" arrives.
+ * Reading it too broadly is safe: the only consequence is falling back to an
+ * archival node, which is the conservative choice anyway.
+ */
+const isUnknownCursorError = (error: unknown): boolean => {
+  if ((error as { code?: unknown } | null)?.code === -32602) return true
+  return /could not find the referenced transaction/i.test(
+    String((error as Error | null)?.message ?? error)
+  )
+}
+
 export class SuiEngine extends CurrencyEngine<
   SuiTools,
   SafeCommonWalletInfo,
@@ -55,6 +74,23 @@ export class SuiEngine extends CurrencyEngine<
   otherData!: SuiWalletOtherData
   suiAddress: string
   otherMethods: SuiOtherMethods
+
+  /**
+   * Whether a full sweep has finished this session. Not persisted: every
+   * session re-validates against an archival node before trusting a pruned one.
+   */
+  private historySynced = false
+
+  /** Set when a pruned node rejects our cursor. Archival-only from then on. */
+  private shallowCursorRejected = false
+
+  /**
+   * Serializes transaction passes, the way Tron, Polkadot, Algorand, and
+   * Monero guard `queryTransactions`. Overlapping passes would race the saved
+   * cursors and the `historySynced` / `shallowCursorRejected` flags, and
+   * `killEngine` drains this before a resync resets that state.
+   */
+  private readonly queryTxMutex = makeMutex()
 
   constructor(
     env: PluginEnvironment<SuiNetworkInfo>,
@@ -73,15 +109,7 @@ export class SuiEngine extends CurrencyEngine<
           throw new Error('Unrecognized makeTx type')
         }
         const { unsignedTx, metadata } = makeTxParams
-        // Deserialize and validate the transaction
-        const tx = Transaction.from(unsignedTx)
-        const serialized = await tx.build({ client: this.tools.suiClient })
-
-        // Calculate fees using dry run
-        const dryRun = await this.tools.suiClient.dryRunTransactionBlock({
-          transactionBlock: serialized
-        })
-        const networkFee = this.feeSum(dryRun.effects.gasUsed)
+        const { serialized, networkFee } = await this.buildAndDryRun(unsignedTx)
 
         // For pre-built transactions, we can't determine the exact amount being sent
         // from the transaction data alone, so we set nativeAmount to '0'
@@ -130,11 +158,31 @@ export class SuiEngine extends CurrencyEngine<
     this.otherData = asSuiWalletOtherData(raw)
   }
 
+  /**
+   * Builds and dry-runs on a single node, raced across nodes. The build
+   * resolves object versions that the dry run then validates, so the pair has
+   * to see one node's view of the chain -- but racing the pair as a unit still
+   * spreads load. Each attempt deserializes its own `Transaction` so that
+   * parallel builds cannot interleave on shared internal state.
+   */
+  async buildAndDryRun(
+    unsignedTx: string | Uint8Array
+  ): Promise<{ serialized: Uint8Array; networkFee: string }> {
+    return await this.tools.raceRpc(this.tools.rpcNodes, async client => {
+      const serialized = await Transaction.from(unsignedTx).build({ client })
+      const dryRun = await client.dryRunTransactionBlock({
+        transactionBlock: serialized
+      })
+      return { serialized, networkFee: this.feeSum(dryRun.effects.gasUsed) }
+    })
+  }
+
   async queryBalance(): Promise<void> {
     try {
-      const balances = await this.tools.suiClient.getAllBalances({
-        owner: this.suiAddress
-      })
+      const balances = await this.tools.raceRpc(
+        this.tools.rpcNodes,
+        async client => await client.getAllBalances({ owner: this.suiAddress })
+      )
 
       const detectedTokenIds: string[] = []
 
@@ -167,69 +215,153 @@ export class SuiEngine extends CurrencyEngine<
   }
 
   async queryTransactions(): Promise<void> {
-    const cursorFrom = this.otherData.latestTxidFrom
+    return await this.queryTxMutex(
+      async () => await this.queryTransactionsInnerLoop()
+    )
+  }
+
+  async queryTransactionsInnerLoop(): Promise<void> {
+    // A caller queued behind the mutex can land here after `killEngine` (a
+    // resync or settings change wipes the session state next); do not write
+    // into the fresh state.
+    if (!this.engineOn) return
+
+    let fromOk = false
+    let toOk = false
+
     try {
-      const latestTxid = await this.queryTransactionsInner('from', cursorFrom)
-      if (latestTxid !== cursorFrom) {
-        this.otherData.latestTxidFrom = latestTxid
-        this.walletLocalDataDirty = true
-      }
+      await this.queryTransactionsInner('from')
+      fromOk = true
     } catch (e) {
       this.log.warn('queryTransactions from error:', e)
     }
 
-    this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 0.5)
+    // Only report progress that actually happened. These calls used to sit
+    // outside the try/catch, so history claimed to be complete even when both
+    // sweeps threw -- which is why a total RPC outage presented as a wallet
+    // frozen at 50% instead of one visibly failing to sync.
+    if (fromOk) {
+      this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 0.5)
+    }
 
-    const cursorTo = this.otherData.latestTxidTo
     try {
-      const latestTxid = await this.queryTransactionsInner('to', cursorTo)
-      if (latestTxid !== cursorTo) {
-        this.otherData.latestTxidTo = latestTxid
-        this.walletLocalDataDirty = true
-      }
+      await this.queryTransactionsInner('to')
+      toOk = true
     } catch (e) {
       this.log.warn('queryTransactions to error:', e)
     }
 
     this.sendTransactionEvents()
 
-    this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 1)
+    if (fromOk && toOk) {
+      this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 1)
+      this.historySynced = true
+    }
   }
 
-  async queryTransactionsInner(
-    direction: 'from' | 'to',
-    latestTxid?: string
-  ): Promise<string | undefined> {
+  /**
+   * Nodes eligible to serve a transaction sweep. Until a sweep completes this
+   * session the walk begins at the wallet's oldest transaction and the saved
+   * cursor may predate a pruned node's retention window, so only archival
+   * nodes can answer. Once caught up the cursor is recent enough for any node.
+   */
+  private getTxQueryUrls(): string[] {
+    const { rpcNodes, rpcNodesArchival } = this.tools
+    if (!this.historySynced || this.shallowCursorRejected) {
+      return rpcNodesArchival
+    }
+    return [...new Set([...rpcNodes, ...rpcNodesArchival])]
+  }
+
+  /**
+   * Sweeps one direction to completion. The node stays pinned for the whole
+   * sweep so pagination follows a single provider's view of history, while the
+   * choice of node is shuffled per sweep to spread load. Rotating to another
+   * node on failure is safe because each page commits its cursor as it goes.
+   */
+  async queryTransactionsInner(direction: 'from' | 'to'): Promise<void> {
+    const urls = shuffleArray([...this.getTxQueryUrls()])
+    let lastError: Error | undefined
+
+    for (const url of urls) {
+      try {
+        await this.sweepTransactions(url, direction)
+        return
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+        if (
+          isUnknownCursorError(error) &&
+          !this.tools.rpcNodesArchival.includes(url)
+        ) {
+          // A dormant wallet's cursor can predate a pruned node's window even
+          // when we are legitimately caught up, and it would fail this way on
+          // every poll. Drop back to archival for the rest of the session.
+          this.shallowCursorRejected = true
+        }
+      }
+    }
+
+    throw lastError ?? new Error('Sui: no RPC node available for tx query')
+  }
+
+  private async sweepTransactions(
+    url: string,
+    direction: 'from' | 'to'
+  ): Promise<void> {
     const filter =
       direction === 'from'
         ? { FromAddress: this.suiAddress }
         : { ToAddress: this.suiAddress }
 
+    let cursor = this.getCursor(direction)
     let queryMore = true
-    let cursor = latestTxid
 
     while (queryMore) {
-      const { data, hasNextPage, nextCursor } =
-        await this.tools.suiClient.queryTransactionBlocks({
-          cursor,
-          filter,
-          order: 'ascending',
-          options: {
-            showBalanceChanges: true,
-            showEffects: true,
-            // showEvents: false,
-            // showInput: false,
-            // showObjectChanges: false,
-            // showRawEffects: false,
-            showRawInput: true
-          }
-        })
+      const { data, hasNextPage, nextCursor } = await this.tools.callRpc(
+        url,
+        async client =>
+          await client.queryTransactionBlocks({
+            cursor,
+            filter,
+            order: 'ascending',
+            options: {
+              showBalanceChanges: true,
+              showEffects: true,
+              showRawInput: true
+            }
+          })
+      )
 
       data.forEach(tx => this.processTransaction(tx, direction))
-      cursor = nextCursor ?? undefined
+
+      // Nothing to advance to. The old code assigned a null cursor through,
+      // which would restart the walk from the beginning on the next page.
+      if (nextCursor == null) break
+
+      cursor = nextCursor
+      // Commit every page. The cursor was previously returned only after the
+      // loop finished, so any mid-sweep failure discarded all of it and the
+      // next poll began again from the start -- meaning a wallet whose history
+      // could not be swept in a single pass never advanced at all.
+      this.saveCursor(direction, cursor)
       queryMore = hasNextPage
     }
-    return cursor
+  }
+
+  private getCursor(direction: 'from' | 'to'): string | undefined {
+    return direction === 'from'
+      ? this.otherData.latestTxidFrom
+      : this.otherData.latestTxidTo
+  }
+
+  private saveCursor(direction: 'from' | 'to', cursor: string): void {
+    if (this.getCursor(direction) === cursor) return
+    if (direction === 'from') {
+      this.otherData.latestTxidFrom = cursor
+    } else {
+      this.otherData.latestTxidTo = cursor
+    }
+    this.walletLocalDataDirty = true
   }
 
   processTransaction(
@@ -293,6 +425,47 @@ export class SuiEngine extends CurrencyEngine<
     }
   }
 
+  /**
+   * Gathers coins of one type until they cover `amount`. Read-only by design:
+   * it returns the selection instead of touching the transaction, so racing it
+   * across nodes cannot produce two conflicting builds.
+   */
+  private async collectCoins(
+    url: string,
+    coinType: string,
+    amount: string
+  ): Promise<{ coins: CoinStruct[]; total: string }> {
+    const coins: CoinStruct[] = []
+    let total = '0'
+    let cursor: string | null | undefined
+
+    while (true) {
+      // Page through `callRpc` so each request is throttled and time-boxed on
+      // its own, the way `sweepTransactions` does. The node stays pinned for
+      // the whole walk, so pagination follows a single provider's view.
+      const { data, hasNextPage, nextCursor } = await this.tools.callRpc(
+        url,
+        async client =>
+          await client.getCoins({
+            owner: this.suiAddress,
+            coinType,
+            cursor
+          })
+      )
+
+      for (const coin of data) {
+        coins.push(coin)
+        total = add(total, coin.balance)
+        if (!lt(total, amount)) return { coins, total }
+      }
+
+      // This loop used to page without passing a cursor, so a wallet whose
+      // first page did not cover the amount re-read that same page forever.
+      if (!hasNextPage || nextCursor == null) return { coins, total }
+      cursor = nextCursor
+    }
+  }
+
   feeSum(gasUsed: GasCostSummary): string {
     const { computationCost, storageCost, storageRebate } = gasUsed
     return sub(add(computationCost, storageCost), storageRebate)
@@ -308,9 +481,30 @@ export class SuiEngine extends CurrencyEngine<
     await super.startEngine()
   }
 
+  async killEngine(): Promise<void> {
+    await super.killEngine()
+    // Drain any in-flight transaction pass BEFORE `resyncBlockchain` clears the
+    // cursors and resets `historySynced` below. That pass started while the
+    // engine was on and keeps running (a promise cannot be cancelled); it can
+    // still `saveCursor` and set `historySynced = true` until it finishes, so
+    // resetting first would let those late writes clobber the reset and hand a
+    // pruned node an ascending walk that silently drops history. `super`
+    // already set `engineOn = false`, so a pass queued behind the mutex exits
+    // immediately, and this empty pass simply waits out the running one.
+    await this.queryTxMutex(async () => {})
+  }
+
   async resyncBlockchain(): Promise<void> {
     await this.killEngine()
     await this.clearBlockchainCache()
+    // `clearBlockchainCache` drops the cursors, so the next sweep walks from
+    // the wallet's oldest transaction again and has to go back through an
+    // archival node. Without resetting these, a resync in a session that had
+    // already synced would allow a pruned node -- and a cursor-less ascending
+    // walk against one returns truncated history rather than an error, so the
+    // resync would report complete with transactions silently missing.
+    this.historySynced = false
+    this.shallowCursorRejected = false
     await this.startEngine()
   }
 
@@ -379,61 +573,69 @@ export class SuiEngine extends CurrencyEngine<
         tx.setGasBudgetIfNotSet(base + coinCount * gasPerCoin)
       }
 
-      const transferCoins: CoinStruct[] = []
-      let transferCoinsBalance = '0'
-      let keepSearching = true
-      do {
-        const { data: coins, hasNextPage } =
-          await this.tools.suiClient.getCoins({
-            owner: this.suiAddress,
-            coinType: networkLocation.contractAddress
-          })
-
-        for (const coin of coins) {
-          transferCoins.push(coin)
-          transferCoinsBalance = add(transferCoinsBalance, coin.balance)
-
-          if (gt(transferCoinsBalance, amount)) {
-            const overage = sub(transferCoinsBalance, amount)
-            const amountNeeded = sub(coin.balance, overage)
-
-            // Remove coin from transfer array, We'll create a new coin for the exact amount needed
-            transferCoins.pop()
-            const [newCoin] = tx.splitCoins(coin.coinObjectId, [amountNeeded])
-
-            tx.transferObjects(
-              [newCoin, ...transferCoins.map(c => tx.object(c.coinObjectId))],
-              publicAddress
-            )
-            setGasBudget(transferCoins.length + 1)
-
-            keepSearching = false
-            break
-          } else if (eq(transferCoinsBalance, amount)) {
-            // This coin gives us the exact amount needed, no need to split
-            tx.transferObjects(
-              [...transferCoins.map(c => tx.object(c.coinObjectId))],
-              publicAddress
-            )
-            setGasBudget(transferCoins.length)
-
-            keepSearching = false
-            break
+      // Gather coins from one node at a time, shuffled, paging that node with
+      // per-page throttle + timeout (like `sweepTransactions`). Running the
+      // whole pagination inside a single `raceRpc` call throttled only once
+      // and had to finish within one RPC timeout, so a wallet with many coin
+      // objects could burst a provider's rate limit or time out. Rotating on
+      // failure OR shortfall also drops a lagging node that under-reports
+      // coins in favor of a healthy one; `InsufficientFundsError` surfaces
+      // only once every node comes up short.
+      const coinUrls = shuffleArray([...this.tools.rpcNodes])
+      let coins: CoinStruct[] | undefined
+      let total: string | undefined
+      let lastCoinError: Error | undefined
+      for (const url of coinUrls) {
+        try {
+          const result = await this.collectCoins(
+            url,
+            networkLocation.contractAddress,
+            amount
+          )
+          if (lt(result.total, amount)) {
+            lastCoinError = new InsufficientFundsError({ tokenId })
+            continue
           }
+          coins = result.coins
+          total = result.total
+          break
+        } catch (error) {
+          lastCoinError =
+            error instanceof Error ? error : new Error(String(error))
         }
+      }
+      if (coins == null || total == null) {
+        throw lastCoinError ?? new InsufficientFundsError({ tokenId })
+      }
 
-        if (keepSearching && !hasNextPage && lt(transferCoinsBalance, amount)) {
-          throw new InsufficientFundsError({ tokenId })
-        }
-      } while (keepSearching)
+      const transferCoins = [...coins]
+      if (gt(total, amount)) {
+        // The final coin overshoots, so split off exactly what is needed and
+        // send that alongside the whole coins gathered before it.
+        const overshoot = transferCoins.pop() as CoinStruct
+        const amountNeeded = sub(overshoot.balance, sub(total, amount))
+        const [newCoin] = tx.splitCoins(overshoot.coinObjectId, [amountNeeded])
+
+        tx.transferObjects(
+          [newCoin, ...transferCoins.map(c => tx.object(c.coinObjectId))],
+          publicAddress
+        )
+        setGasBudget(transferCoins.length + 1)
+      } else {
+        // Exact match, so no split is needed.
+        tx.transferObjects(
+          transferCoins.map(c => tx.object(c.coinObjectId)),
+          publicAddress
+        )
+        setGasBudget(transferCoins.length)
+      }
     }
 
     tx.setSender(this.suiAddress)
-    const serialized = await tx.build({ client: this.tools.suiClient })
-    const dryRun = await this.tools.suiClient.dryRunTransactionBlock({
-      transactionBlock: serialized
-    })
-    let networkFee = this.feeSum(dryRun.effects.gasUsed)
+    const { serialized, networkFee: estimatedFee } = await this.buildAndDryRun(
+      await tx.toJSON()
+    )
+    let networkFee = estimatedFee
 
     const mainnetBalance = this.getBalance({ tokenId: null })
     let nativeAmount = amount
@@ -510,11 +712,20 @@ export class SuiEngine extends CurrencyEngine<
         JSON.parse(edgeTransaction.signedTx)
       )
 
-      const broadcastResult =
-        await this.tools.suiClient.executeTransactionBlock({
-          transactionBlock: signedTxObj.bytes,
-          signature: signedTxObj.signature
-        })
+      // Submit to every node at once. Execution is idempotent by digest, so
+      // the duplicates are harmless, and a node reporting the transaction as
+      // already executed is ignored as long as one submission succeeds.
+      const broadcastResult = await formatAggregateError(
+        this.tools.blastRpc(
+          this.tools.rpcNodes,
+          async client =>
+            await client.executeTransactionBlock({
+              transactionBlock: signedTxObj.bytes,
+              signature: signedTxObj.signature
+            })
+        ),
+        'Sui broadcast failed:'
+      )
 
       edgeTransaction.txid = broadcastResult.digest
       edgeTransaction.date = Date.now() / 1000

--- a/src/sui/SuiTools.ts
+++ b/src/sui/SuiTools.ts
@@ -1,5 +1,5 @@
 import { fromHex } from '@mysten/bcs'
-import { getFullnodeUrl, SuiClient, SuiHTTPTransport } from '@mysten/sui/client'
+import { SuiClient, SuiHTTPTransport } from '@mysten/sui/client'
 import {
   decodeSuiPrivateKey,
   encodeSuiPrivateKey
@@ -23,36 +23,149 @@ import {
 import { base16, base64 } from 'rfc4648'
 
 import { PluginEnvironment } from '../common/innerPlugin'
+import { asyncStaggeredRace, promiseAny, timeout } from '../common/promiseUtils'
 import { asMaybeContractLocation, validateToken } from '../common/tokenHelpers'
 import { asSafeCommonWalletInfo } from '../common/types'
 import { encodeUriCommon, parseUriCommon } from '../common/uriHelpers'
-import { getLegacyDenomination, mergeDeeply } from '../common/utils'
+import {
+  getLegacyDenomination,
+  mergeDeeply,
+  shuffleArray,
+  snooze
+} from '../common/utils'
 import { asSuiPrivateKeys, SuiInfoPayload, SuiNetworkInfo } from './suiTypes'
+
+/**
+ * Ceiling on a single node's response. `asyncStaggeredRace` has no timeout of
+ * its own: a node that accepts the connection but never answers is neither
+ * resolved nor failed, so without this the race can never settle, and the
+ * engine's polling loop would stop rescheduling for the rest of the session.
+ */
+const RPC_TIMEOUT_MS = 10000
+
+/** Gap before the race brings the next node in alongside the current one. */
+const STAGGER_INTERVAL_MS = 1000
 
 export class SuiTools implements EdgeCurrencyTools {
   io: EdgeIo
   builtinTokens: EdgeTokenMap
   currencyInfo: EdgeCurrencyInfo
-  networkInfo: SuiNetworkInfo
   initOptions: JsonObject
 
-  suiClient: SuiClient
+  private readonly env: PluginEnvironment<SuiNetworkInfo>
+  private readonly clients = new Map<string, SuiClient>()
+
+  /** Earliest time each node may be called again, keyed by URL. */
+  private readonly nextSlot = new Map<string, number>()
 
   constructor(env: PluginEnvironment<SuiNetworkInfo>) {
-    const { builtinTokens, currencyInfo, initOptions, io, networkInfo } = env
+    const { builtinTokens, currencyInfo, initOptions, io } = env
+    this.env = env
     this.io = io
     this.currencyInfo = currencyInfo
     this.builtinTokens = builtinTokens
-    this.networkInfo = networkInfo
     this.initOptions = initOptions
+  }
 
-    const suiTransport = new SuiHTTPTransport({
-      url: getFullnodeUrl(networkInfo.network),
-      fetch: io.fetch as typeof fetch
-    })
-    this.suiClient = new SuiClient({
-      transport: suiTransport
-    })
+  /**
+   * Read through `env` instead of copying in the constructor. `makeCurrencyTools`
+   * runs *before* `updateInfoPayload`, so a copy taken here would freeze the
+   * built-in defaults and silently ignore anything the info server sends.
+   */
+  get networkInfo(): SuiNetworkInfo {
+    return this.env.networkInfo
+  }
+
+  get rpcNodes(): string[] {
+    return this.networkInfo.rpcNodes
+  }
+
+  get rpcNodesArchival(): string[] {
+    return this.networkInfo.rpcNodesArchival
+  }
+
+  getClient(url: string): SuiClient {
+    let client = this.clients.get(url)
+    if (client == null) {
+      client = new SuiClient({
+        transport: new SuiHTTPTransport({
+          url,
+          fetch: this.io.fetch as typeof fetch
+        })
+      })
+      this.clients.set(url, client)
+    }
+    return client
+  }
+
+  /**
+   * Spaces calls to a single node. `SuiTools` is one instance per plugin, so
+   * every wallet in the app shares these slots: one wallet is latency-bound
+   * far below the limit, but several syncing at once would otherwise stack up
+   * against a provider's limiter from a single IP.
+   */
+  private async throttle(url: string): Promise<void> {
+    const gapMs = 1000 / this.networkInfo.maxRequestsPerSecond
+    const now = Date.now()
+    const slot = Math.max(now, this.nextSlot.get(url) ?? 0)
+    this.nextSlot.set(url, slot + gapMs)
+    if (slot > now) await snooze(slot - now)
+  }
+
+  /** Run `fn` against one node, throttled and time-boxed. */
+  async callRpc<T>(
+    url: string,
+    fn: (client: SuiClient) => Promise<T>
+  ): Promise<T> {
+    await this.throttle(url)
+    return await timeout(
+      fn(this.getClient(url)),
+      RPC_TIMEOUT_MS,
+      new Error(`Sui RPC timed out: ${url}`)
+    )
+  }
+
+  /**
+   * Race `fn` across nodes, staggered. Shuffled because the race only reaches
+   * past the first node when that one is slow or failing, so a fixed order
+   * would send every healthy request to one provider and leave the rest as
+   * untested spares.
+   */
+  async raceRpc<T>(
+    urls: string[],
+    fn: (client: SuiClient) => Promise<T>
+  ): Promise<T> {
+    this.assertNodes(urls)
+    const funcs = shuffleArray([...urls]).map(
+      url => async () => await this.callRpc(url, fn)
+    )
+    return await asyncStaggeredRace(funcs, STAGGER_INTERVAL_MS)
+  }
+
+  /**
+   * Run `fn` against every node at once, resolving on the first success. For
+   * idempotent writes, where submitting more than once is harmless and
+   * redundancy matters more than choosing a single node.
+   */
+  async blastRpc<T>(
+    urls: string[],
+    fn: (client: SuiClient) => Promise<T>
+  ): Promise<T> {
+    this.assertNodes(urls)
+    return await promiseAny(urls.map(async url => await this.callRpc(url, fn)))
+  }
+
+  /**
+   * An empty list is a misconfiguration rather than a failure to retry, and
+   * it has to be caught before `promiseAny`, which never settles when handed
+   * zero promises.
+   */
+  private assertNodes(urls: string[]): void {
+    if (urls.length === 0) {
+      throw new Error(
+        `No Sui RPC nodes configured for ${this.currencyInfo.pluginId}`
+      )
+    }
   }
 
   async getDisplayPrivateKey(

--- a/src/sui/suiInfo.ts
+++ b/src/sui/suiInfo.ts
@@ -19,7 +19,26 @@ const builtinTokens: EdgeTokenMap = {
 
 const networkInfo: SuiNetworkInfo = {
   network: 'mainnet',
-  pluginMnemonicKeyName: 'suiMnemonic'
+  pluginMnemonicKeyName: 'suiMnemonic',
+
+  // Mysten removed JSON-RPC from the public fullnodes, so `getFullnodeUrl` is
+  // no longer usable. These are third-party nodes that still serve it.
+  rpcNodes: [
+    'https://sui-rpc.publicnode.com',
+    'https://rpc-mainnet.suiscan.xyz',
+    // Pruned to roughly the last 220 epochs, so it is fine for the tip but
+    // must stay out of `rpcNodesArchival`:
+    'https://mainnet.suiet.app'
+  ],
+  rpcNodesArchival: [
+    // Both verified to serve checkpoint 1:
+    'https://sui-rpc.publicnode.com',
+    'https://rpc-mainnet.suiscan.xyz'
+    // blockvision is archival too, but its public endpoint rate-limits below
+    // the 5 req/s its own docs advertise, and returns no Retry-After to pace
+    // against. Left out rather than have sweeps stall on it.
+  ],
+  maxRequestsPerSecond: 10
 }
 
 const currencyInfo: EdgeCurrencyInfo = {

--- a/src/sui/suiTypes.ts
+++ b/src/sui/suiTypes.ts
@@ -1,5 +1,13 @@
 import type { SignatureWithBytes } from '@mysten/sui/cryptography'
-import { asCodec, asObject, asOptional, asString, Cleaner } from 'cleaners'
+import {
+  asArray,
+  asCodec,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  Cleaner
+} from 'cleaners'
 import type {
   EdgeAssetAction,
   EdgeMemo,
@@ -14,13 +22,37 @@ import { MakeTxParams } from '../common/types'
 export interface SuiNetworkInfo {
   network: 'mainnet' | 'testnet'
   pluginMnemonicKeyName: string
+
+  /**
+   * Nodes for balances, fees, and broadcasts. These may be pruned, since none
+   * of those operations reach back into history.
+   */
+  rpcNodes: string[]
+
+  /**
+   * Nodes verified to serve full history. Transaction queries must begin here:
+   * the engine walks history from the oldest transaction, and a pruned node
+   * rejects both that walk and any cursor older than its retention window.
+   */
+  rpcNodesArchival: string[]
+
+  /**
+   * Per-node request ceiling, shared by every wallet in the app. A single
+   * wallet is latency-bound well under this; it only binds when several
+   * wallets sync at once and would otherwise trip a provider's limiter.
+   */
+  maxRequestsPerSecond: number
 }
 
 //
 // Info Payload
 //
 
-export const asSuiInfoPayload = asObject(() => {})
+export const asSuiInfoPayload = asObject({
+  rpcNodes: asOptional(asArray(asString)),
+  rpcNodesArchival: asOptional(asArray(asString)),
+  maxRequestsPerSecond: asOptional(asNumber)
+})
 export type SuiInfoPayload = ReturnType<typeof asSuiInfoPayload>
 
 export const asSuiWalletOtherData = asObject({

--- a/src/sui/suitestnetInfo.ts
+++ b/src/sui/suitestnetInfo.ts
@@ -19,7 +19,21 @@ const builtinTokens: EdgeTokenMap = {
 
 const networkInfo: SuiNetworkInfo = {
   network: 'testnet',
-  pluginMnemonicKeyName: 'suitestnetMnemonic'
+  pluginMnemonicKeyName: 'suitestnetMnemonic',
+
+  // Testnet lost JSON-RPC alongside mainnet. Retention depth is not verified
+  // here the way it is on mainnet, but testnet is periodically wiped, so there
+  // is little history for a pruned node to be missing.
+  rpcNodes: [
+    'https://sui-testnet-rpc.publicnode.com',
+    'https://rpc-testnet.suiscan.xyz',
+    'https://sui-testnet-endpoint.blockvision.org'
+  ],
+  rpcNodesArchival: [
+    'https://sui-testnet-rpc.publicnode.com',
+    'https://rpc-testnet.suiscan.xyz'
+  ],
+  maxRequestsPerSecond: 10
 }
 
 const currencyInfo: EdgeCurrencyInfo = {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216965258637025/f)

Fixes [Sui stuck at 50% after public JSON-RPC endpoint shutdown](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216965258637025).

Mysten removed JSON-RPC from the public fullnodes. `SuiTools` built its only client from the SDK's `getFullnodeUrl`, so `https://fullnode.mainnet.sui.io:443` now answers **every** method — read and write, mainnet and testnet — with:

```
-32601 Method not found. JSON-RPC on public fullnodes has been deprecated.
```

Sui is therefore entirely non-functional, not partially: balances, transaction history, fee estimation, and broadcast all fail.

**The 50% is not evidence that transactions still worked.** `TokenSyncTracker` averages `(balanceRatio + historyRatio) / 2`. `queryBalance` set its ratio inside the `try`, so it never ran; `queryTransactions` set history ratios *outside* the try/catch, so history reported 1 even though both sweeps threw. `(0 + 1) / 2 = 0.50` exactly.

Third-party providers still serve JSON-RPC, so this is a node swap rather than a gRPC/GraphQL migration.

#### Remote configurability

`rpcNodes` / `rpcNodesArchival` / `maxRequestsPerSecond` replace the hardcoded URL and are settable from the info server, so the next outage does not need a client release. The old `asSuiInfoPayload` was `asObject(() => {})`, which accepts any object but cleans every value to `undefined` — anything sent for Sui was silently discarded.

Clients are now built lazily per URL rather than in the `SuiTools` constructor. `innerPlugin` constructs tools *before* calling `updateInfoPayload`, so a client built there could never see info-server config. Engines are constructed after, so they read through `env.networkInfo` correctly.

#### Archival vs. shallow nodes

Transaction sweeps must start on an archival node: the walk begins at the wallet's oldest transaction, and a pruned node rejects both that and any cursor older than its retention. Measured on the candidates:

| provider | checkpoint 1 | checkpoint 1M | verdict |
|---|---|---|---|
| publicnode | OK | OK | archival |
| suiscan | OK | OK | archival |
| suiet | — | `not found` | pruned, ~220 epochs |
| blockvision | — | OK | archival, but rate-limits at 2.2 req/s despite documenting 5, with no `Retry-After` |

Shallow nodes are allowed only after a sweep completes in the session, and a `-32602` from one drops the wallet back to archival for the rest of the session — a dormant wallet's cursor can predate the retention window even when it is legitimately caught up.

#### Redundancy

| operation | strategy |
|---|---|
| `getAllBalances` | shuffled staggered race |
| tx sweeps | archival-gated, node pinned per sweep, cursor committed per page |
| build + dryRun | raced as one unit per node |
| broadcast | all nodes at once via `promiseAny` |

The race is shuffled because it only reaches past the first node when that one is failing, so a fixed order would send every healthy request to one provider and leave the rest as untested spares.

Each attempt is wrapped in `timeout`, which is **required**, not defensive: `asyncStaggeredRace` has no timeout, and a node that accepts the connection but never answers is neither resolved nor failed — the race would never settle, and `makePeriodicTask` only reschedules after the task settles, so the wallet's polling loop would stop for the session. Verified against the real helper:

```
no timeout   -> *** NEVER SETTLED ***
with timeout -> rejected: node timed out
hung+good    -> resolved: balance-from-node-3
```

Build and dry run are raced as a unit so both see one node's view of object versions, each attempt deserializing its own `Transaction` so parallel builds cannot interleave on shared state. Broadcast goes to every node at once since execution is idempotent by digest.

#### Three defects fixed in surrounding code

Leaving these would have undercut the RPC work:

- Sync progress reported history as complete even when both sweeps threw — the reason the outage presented as a frozen 50% rather than a visible failure.
- Sweeps returned their cursor only after finishing, so a mid-sweep failure discarded every page and the next poll restarted from the beginning. A wallet too large to sweep in one pass never advanced at all.
- Token coin selection paged without a cursor, re-reading the first page indefinitely when it did not cover the send amount.

#### Verification

- 476 tests passing, typecheck and eslint clean
- **6/6 raced calls succeeded with the dead endpoint in the pool** — the actual outage, survived
- All-dead pool rejects in 296ms rather than hanging
- Info-payload override picked up live, confirming remote configurability
- `-32602` detection confirmed against suiet's real rejection
- `Transaction.from(await tx.toJSON())` builds **byte-identical** output for both the native and token send paths, with successful dry runs

#### Open items

- The archival pool is only publicnode + suiscan. Adding NOWNodes (which does support Sui, and whose key the GUI already carries) needs a key to verify archival depth, plus a GUI change — `corePlugins.ts` has `sui: true`, so Sui receives no initOptions object today.
- Testnet archival depth is assumed rather than measured; testnet is wiped periodically so there is little history to miss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches all Sui wallet operations (sync, fees, sends, broadcast) via new third-party RPC pools and complex tx-sync state; misconfigured nodes or archival/pruned mistakes could cause silent history gaps or send failures.
> 
> **Overview**
> Restores **Sui** after Mysten’s public fullnodes stopped serving JSON-RPC (`-32601`). The plugin no longer uses a single `getFullnodeUrl` client; it uses **configurable `rpcNodes` / `rpcNodesArchival` / `maxRequestsPerSecond`** (defaults in info + overridable via info payload).
> 
> **`SuiTools`** adds per-URL clients, shared throttling, 10s RPC timeouts, **`raceRpc`** (staggered shuffle race) for reads/build/dry-run, and **`blastRpc`** (`promiseAny`) for broadcast. **`networkInfo`** is read from `env` so info-server updates apply after tools construction.
> 
> **Transaction sync** is reworked: a mutex serializes sweeps; archival nodes are required until history is caught up or a pruned node rejects the cursor (`-32602`); each page commits its cursor; sync progress only advances when sweeps actually succeed (fixes the stuck **50%** when RPC was down). **`killEngine` / `resync`** drain the mutex and reset session flags so late cursor writes cannot corrupt a resync.
> 
> **Sends:** token coin selection pages with a cursor; coin gathering is raced across nodes with shortfall treated as failure; native/token **`makeSpend`** uses **`buildAndDryRun`** on the node pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901d3506a483594c626ed915b1afc003f825d228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->