### PR TITLE
Guard Stellar Horizon.Server against Horizon-less stellar-sdk builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Stellar) Guard `new Horizon.Server()` at engine start so a stellar-sdk build without the `Horizon` namespace fails with a clear, actionable error instead of an opaque `undefined is not an object` WebView crash, and add a resolution regression test so a Horizon-less stellar-sdk build is caught by the test suite rather than shipping as a recurring background toast.
+
 ## 4.86.3 (2026-07-27)
 
 - fixed: (Thorchain/Mayachain) Stop recording failed MsgDeposit actions (Midgard `type: 'failed'`) as full-amount sends. The reverted deposit never moved funds, so only the burned network fee is recorded, marked as a failed transaction — matching the existing failed-send handling.

--- a/src/stellar/StellarTools.ts
+++ b/src/stellar/StellarTools.ts
@@ -48,6 +48,19 @@ export class StellarTools implements EdgeCurrencyTools {
     // stellar-sdk v13 removed the global Network singleton; the network
     // passphrase is now passed per-transaction in StellarEngine's
     // TransactionBuilder options.
+    //
+    // Guard the Horizon namespace. `new Horizon.Server()` has crashed XLM
+    // engine start twice with an opaque `undefined is not an object` WebView
+    // error: once from the v13 default-import migration (fixed in #1060), and
+    // again when a bundle was built against a stale stellar-sdk (pre-v13
+    // versions expose no `Horizon` namespace, so the named import binds
+    // undefined). Fail loudly with an actionable message so the cause is
+    // obvious instead of surfacing as a recurring background toast.
+    if (typeof Horizon?.Server !== 'function') {
+      throw new Error(
+        'stellar-sdk Horizon.Server is unavailable — the bundled stellar-sdk does not expose the Horizon namespace. This usually means edge-currency-accountbased was built against the wrong stellar-sdk version (>=13 is required). Reinstall dependencies and rebuild the WebView bundle.'
+      )
+    }
     this.stellarApiServers = []
     for (const server of this.networkInfo.stellarServers) {
       const stellarServer = new Horizon.Server(server)

--- a/test/stellar/stellarSdkResolution.test.ts
+++ b/test/stellar/stellarSdkResolution.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { Horizon, Keypair } from 'stellar-sdk'
+
+// Regression guard for the recurring XLM engine-start crash
+// `undefined is not an object (evaluating 'new Horizon.Server')`.
+//
+// The Stellar plugin builds its Horizon servers with `new Horizon.Server()`
+// (StellarTools constructor). That call has broken twice when the bundled
+// stellar-sdk did not expose the `Horizon` namespace: first from a v13
+// default-import (#1060), then from a bundle built against a stale stellar-sdk
+// (pre-v13 has no `Horizon` namespace, so the named import binds undefined).
+//
+// This test fails whenever stellar-sdk resolves to a version/shape without a
+// usable Horizon namespace, so a Horizon-less build is caught by `npm test`
+// instead of shipping as a runtime toast.
+describe('stellar-sdk module resolution', function () {
+  it('exposes the Horizon namespace', function () {
+    expect(Horizon).to.be.an('object')
+  })
+
+  it('exposes Horizon.Server as a constructor', function () {
+    expect(Horizon.Server).to.be.a('function')
+  })
+
+  it('exposes Keypair as a constructor', function () {
+    expect(Keypair).to.be.a('function')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/1215088146871429/1217047261970600)

Hardens the Stellar plugin against the recurring XLM engine-start crash `undefined is not an object (evaluating 'new Horizon.Server')`, which pops a background alert whenever the bundled `stellar-sdk` does not expose the `Horizon` namespace.

**History.** This call site has broken twice. First (v4.83.0) from the stellar-sdk v13 migration reading a non-existent default export, fixed in #1060 by switching to named imports (`import { Horizon } from 'stellar-sdk'`). Then a recurrence where the runtime again reports `Horizon` undefined at `new Horizon.Server(...)`.

**Root cause of the recurrence.** Not a source or bundling defect. Investigation of the current published bundle shows the fix is intact and working:

- `stellar-sdk@13.3.0` `exports["."]` resolves `browser` to `dist/stellar-sdk.min.js` and `default` to `lib/index.js`; both builds expose a `Horizon` object with a `Server` constructor.
- A webpack build using this repo's exact config (`target: ['web','es5']`, browser resolution) resolves stellar-sdk to the browser dist and successfully runs `new Horizon.Server(...)`. The full `webpack` build compiles the call as `new G.Horizon.Server(...)` with `G` bound to the Horizon-bearing browser dist.
- Published-tarball bisect: `v4.84.0` is the last broken bundle (`new F.Server(` default-import form, no `Horizon.Server`); every release from `v4.84.1` through `v4.86.3` carries the fixed `new X.Horizon.Server`.
- `stellar-sdk@0.11.0` (a pre-`Horizon` version) exposes no `Horizon` namespace at all. A bundle built against it compiles `Horizon.Server` where `Horizon` is `undefined`, producing exactly the observed crash. This is a build-environment drift (wrong stellar-sdk version installed at bundle time), not a defect in the shipped code.

**The fix.** Since the source is correct and only a wrong-version build reintroduces the crash, this makes that failure loud and self-diagnosing instead of a silent recurring toast:

1. `StellarTools` constructor guard: throws a named, actionable error when `Horizon.Server` is not a constructor, replacing the opaque `undefined is not an object` WebView crash.
2. `test/stellar/stellarSdkResolution.test.ts`: asserts the named `Horizon` import provides a `Server` constructor (and `Keypair` is a constructor), so a Horizon-less stellar-sdk build fails `npm test` rather than shipping.

The guard is a no-op on a correct build, so it does not change XLM behavior when stellar-sdk resolves properly.

**Testing.** Built this branch, `updot`-baked it into `edge-react-gui`, and ran on the iOS 18.6 simulator (edge-funds). Confirmed the guarded bundle is embedded in the running app (`new G.Horizon.Server` + the guard string present in `Edge.app/edge-currency-accountbased.bundle`). Created a Stellar (XLM) wallet: the engine started with no Horizon crash, and funded XLM wallets synced fully (My Stellar 172 XLM / $29.32, My Stellar 2 1.281 XLM / $0.21) with live rate, price chart, and Horizon-served transaction history. Zero `new Horizon.Server` / `undefined is not an object` errors across the 14-minute session (the only alert observed was an unrelated benign sync-repo 404 for the freshly-created empty wallet). `npm run test` and the WebView webpack build both pass.
