### PR TITLE
Zcash: Keep the sync ratio honest across a resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Zcash) The sync ratio no longer holds a stale value for the whole rescan after a resync. The synchronizer is deliberately left running across a resync, so progress it sampled beforehand can be delivered after the sync tracker has been reset. The tracker trusts a first-seen 100 and never goes backwards, so one such report pinned the ratio until the next login - at 1 for a wallet that was synced, or at wherever it had reached for a wallet that was still syncing, which is a common reason to resync in the first place. Progress reports are now ignored for the span of the resync, from before the engine is torn down until the rewind has actually happened, since a stale report is indistinguishable from a fresh one and a status transition cannot mark the boundary either - iOS suppresses the synchronizer's post-rescan SYNCED entirely.
+
 ## 4.87.0 (2026-08-02)
 
 - added: (Sui) `rpcNodes`, `rpcNodesArchival`, and `maxRequestsPerSecond` to the info payload, so nodes can be changed without a client release. Transaction sweeps start on an archival node, since the walk begins at the wallet's oldest transaction and a pruned node rejects a cursor older than its retention window.

--- a/src/zcash/ZcashEngine.ts
+++ b/src/zcash/ZcashEngine.ts
@@ -57,6 +57,15 @@ export class ZcashEngine extends CurrencyEngine<
   synchronizer?: ZcashSynchronizer
   synchronizerPromise: Promise<ZcashSynchronizer>
   synchronizerResolver!: (synchronizer: ZcashSynchronizer) => void
+  /**
+   * True for the span of `resyncBlockchain`, from before it tears the engine
+   * down until the rewind has happened. While set, progress reports describe
+   * the wallet the resync is discarding and must not reach the sync tracker,
+   * whose don't-go-backwards ratchet would otherwise hold that pre-rewind
+   * ratio - 1 for a wallet that was synced, or its last position for one that
+   * was still syncing - for the whole rescan.
+   */
+  rescanSettling = false
   autoshielding: {
     createAutoshieldTx: boolean
     threshold: string
@@ -169,6 +178,17 @@ export class ZcashEngine extends CurrencyEngine<
     this.synchronizer.on('update', async payload => {
       const { scanProgress, networkBlockHeight } = payload
       this.updateBlockHeight(networkBlockHeight)
+
+      // The synchronizer is left running across a resync, so progress sampled
+      // before the rewind can be delivered after it. Every such report
+      // describes the wallet the rewind is about to discard, and the tracker
+      // both trusts a first-seen 100 and never goes backwards, so letting one
+      // through pins the ratio for the rest of the rescan - at 1 for a stale
+      // 100, or at whatever the wallet had reached if it was still syncing
+      // when the resync was requested. Ignore all of them; the flag is cleared
+      // once the rewind has actually happened (see resyncBlockchain).
+      if (this.rescanSettling) return
+
       this.syncTracker.updateProgress(scanProgress)
       await this.checkAutoshielding()
     })
@@ -429,13 +449,32 @@ export class ZcashEngine extends CurrencyEngine<
   }
 
   async resyncBlockchain(): Promise<void> {
-    // Don't bother stopping and restarting the synchronizer for a resync
-    await super.killEngine()
-    await this.clearBlockchainCache()
-    await this.startEngine()
-    await this.synchronizer
-      ?.rescan()
-      .catch((e: any) => this.warn('resyncBlockchain failed: ', e))
+    // Ignore progress reports until the rewind has actually happened. The
+    // synchronizer is deliberately left running across a resync and every call
+    // below awaits, so anything it reports in the meantime describes the wallet
+    // this resync is discarding (see initSubscriptions). The window is bounded
+    // by this method rather than by the reports themselves: a stale report is
+    // indistinguishable from a fresh one - a wallet that was still syncing when
+    // the resync was requested emits sub-100 progress that looks exactly like
+    // early rescan progress - and a status transition cannot bound it either,
+    // since iOS suppresses the synchronizer's post-rescan SYNCED entirely.
+    this.rescanSettling = true
+    try {
+      // Don't bother stopping and restarting the synchronizer for a resync
+      await super.killEngine()
+      await this.clearBlockchainCache()
+      await this.startEngine()
+      try {
+        await this.synchronizer?.rescan()
+      } catch (e: any) {
+        this.warn('resyncBlockchain failed: ', e)
+      }
+    } finally {
+      // Unconditionally, including the paths that never reach the rewind: a
+      // throw from the calls above, or no synchronizer to rescan. Leaving this
+      // armed would swallow every report for the rest of the session.
+      this.rescanSettling = false
+    }
     this.initData()
     this.synchronizerStatus = 'SYNCING'
   }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes half of [ZEC - resync shows failed transactions and incorrect sync status](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1217193939491690) — the half where the wallet reads as fully synced while a resync is still rescanning "behind the scenes".

**Root cause.** `resyncBlockchain` deliberately does not stop and restart the synchronizer, so the sync tracker is reset while the synchronizer keeps running and keeps emitting. The rewind then races the event stream: a progress report sampled while the wallet still looked synced (`scanProgress === 100`) can be delivered *after* `syncTracker.resetSync()`.

`ZcashSyncTracker` treats a first-seen 100 as trustworthy — that is the login shortcut for wallets that are already synced — so it latches `lastTotalRatio = 1`. Its don't-go-backwards ratchet then discards every genuine progress report for the rest of the rescan:

```ts
// ZcashSyncTracker.ts
if (!seenFirstUpdate) {
  seenFirstUpdate = true
  if (progressPercent !== 100) return   // a stale 100 gets through, and latches
}
...
if (status.totalRatio <= lastTotalRatio) return   // everything real is now discarded
```

**Fix.** Ignore progress reports for the span of the resync — armed before the engine is torn down, cleared in a `finally` once the rewind has actually happened.

The window is bounded by the method rather than by what the synchronizer reports, because no report can mark that boundary. A stale sub-100 is indistinguishable from early rescan progress, and a wallet that was still syncing when the resync was requested is a common case — being stuck syncing is a reason people resync — so keying off report values lets the ratchet latch a pre-rewind ratio for the whole rescan. A status transition cannot bound it either: `rescan` sets `restart` on iOS and `updateSyncStatus` then swallows the following `SYNCED`, so a rescan that finishes without ever reporting `syncing` emits no status event at all.

Clearing in a `finally` also covers the paths that never reach a rewind — a throw from the teardown calls, or no synchronizer to rescan. Leaving the flag armed there would ignore every report for the rest of the session, a worse failure than the bug being fixed. The inner catch around `rescan()` is kept separate so setup failures still propagate to the caller rather than being swallowed.

One residual race remains: a report already in flight when the rewind completes. It is bounded by the gap between the rewind finishing and the promise settling, rather than by the whole teardown. Closing it entirely would need to gate on an observed `SYNCING` transition, which iOS does not reliably deliver.

No changes to `ZcashSyncTracker` itself, so the ordinary login path — instant 100% for an already-synced wallet — is untouched. Piratechain is not affected: its tracker is block-height based and has no first-update-100 heuristic.

**Verification.**

- `verify-repo.sh` passed: eslint on changed files, plus the full test suite.

**Device-verified** on a Pixel 10 Pro emulator against a real funded wallet, by syncing to 100% and then resyncing from the wallet menu. On confirming the resync the wallet immediately reported `Sync in Progress — 0% Complete`, and the ratio then climbed monotonically from zero:

```
0.014 → 0.025 → 0.036 → 0.044 → 0.054 → … → 0.214 → …
```

Before this change the tracker latched on a stale 100 delivered after `resetSync()` and its ratchet discarded every one of those readings, leaving the wallet displayed as fully synced for the entire rescan. The wallet returned to synced normally once the rescan finished.

That run predates the rework above, which was prompted by review. The behaviour it demonstrates is unchanged — the ratio resets and climbs — but the boundary that produces it moved, so it is worth re-running before merge. In particular the resync-while-syncing case, which the earlier design got wrong and no test here covered.

The other half of the task (every transaction showing "Failed" during the rescan) is an Android-native bug, fixed in companion PR EdgeApp/react-native-zcash#73. The two are independent and can land in either order; the native fix reaches the app through a later `react-native-zcash` version bump, not through this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Zcash resync/sync-progress handling; logic is localized but resync is a sensitive user path and stale vs fresh progress cannot be distinguished without this gate.
> 
> **Overview**
> Fixes **incorrect “fully synced” UI** during a Zcash wallet resync when the synchronizer keeps running and can deliver **pre-rewind** `scanProgress` after the sync tracker has been reset.
> 
> `ZcashEngine` now sets **`rescanSettling`** for the whole `resyncBlockchain` flow (engine kill, cache clear, restart, and `rescan()`), and the synchronizer **`update`** handler **skips** `syncTracker.updateProgress` while that flag is set. The flag is cleared in a **`finally`** block so a failed resync does not leave progress updates suppressed for the rest of the session.
> 
> **`ZcashSyncTracker`** is unchanged, so the normal login shortcut (first-seen 100% for an already-synced wallet) stays intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6c44df28a0b065cd396c2aff24a1306db608e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217341748716939
