### PR TITLE
Include the declared gas fee in MAYAChain/THORChain fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fixed: (MAYAChain/THORChain) A max send now leaves the wallet. The signer pays the chain's flat network fee AND the transaction's declared gas fee, but only the flat fee was reported, so a max send came out exactly one base unit over the balance. The chain accepted it at CheckTx and then reverted it as `insufficient funds`, which surfaced as a successful send in the app with nothing moving on-chain.
+- fixed: (MAYAChain) A max send now leaves the wallet. mayanode collects the transaction's declared gas fee on top of the chain's flat network fee, but only the flat fee was reported, so a max send came out exactly one base unit over the balance. The chain accepted it at CheckTx and then reverted it as `insufficient funds`, which surfaced as a successful send in the app with nothing moving on-chain. The reported fee now covers both, and the fee recorded for a send that syncs back from Midgard matches it.
 
 ## 4.87.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (MAYAChain/THORChain) A max send now leaves the wallet. The signer pays the chain's flat network fee AND the transaction's declared gas fee, but only the flat fee was reported, so a max send came out exactly one base unit over the balance. The chain accepted it at CheckTx and then reverted it as `insufficient funds`, which surfaced as a successful send in the app with nothing moving on-chain.
+
 ## 4.87.0 (2026-08-02)
 
 - added: (Sui) `rpcNodes`, `rpcNodesArchival`, and `maxRequestsPerSecond` to the info payload, so nodes can be changed without a client release. Transaction sweeps start on an archival node, since the walk begins at the wallet's oldest transaction and a pruned node rejects a cursor older than its retention window.

--- a/src/cosmos/engine/MayachainEngine.ts
+++ b/src/cosmos/engine/MayachainEngine.ts
@@ -9,7 +9,13 @@ import { CosmosFee, SafeCosmosWalletInfo } from '../cosmosTypes'
 import { rpcWithApiKey } from '../cosmosUtils'
 import { MidgardNetworkInfo } from '../midgardTypes'
 import { asMayachainConstants } from '../thorchainTypes'
-import { MidgardEngine } from './MidgardEngine'
+import { MIDGARD_DECLARED_GAS_FEE, MidgardEngine } from './MidgardEngine'
+
+/**
+ * The chain's flat `NativeTransactionFee`, used to reconstruct the fee of a send
+ * that syncs back from Midgard. `calculateFee` reads the live constant instead.
+ */
+const NATIVE_TRANSACTION_FEE = '2000000000'
 
 /**
  * Mayachain (Cacao) engine that uses Midgard for transaction history
@@ -33,7 +39,9 @@ export class MayachainEngine extends MidgardEngine {
       amount: [
         {
           denom: this.networkInfo.nativeDenom,
-          amount: '2000000000'
+          // Both halves of what a send costs the signer, so history agrees with
+          // what `calculateFee` reported at spend time.
+          amount: add(NATIVE_TRANSACTION_FEE, MIDGARD_DECLARED_GAS_FEE)
         }
       ],
       gasLimit: BigInt(0),
@@ -71,6 +79,10 @@ export class MayachainEngine extends MidgardEngine {
       }
     }
 
-    return this.makeMidgardFee(networkFee)
+    // mayanode runs the stock cosmos-sdk `DeductFeeDecorator`, so the declared
+    // gas fee is collected on top of the flat fee. Leaving it out of the total
+    // put a max send one base unit over the balance, which the chain accepted
+    // at CheckTx and then reverted as `insufficient funds`.
+    return this.makeMidgardFee(add(networkFee, MIDGARD_DECLARED_GAS_FEE))
   }
 }

--- a/src/cosmos/engine/MayachainEngine.ts
+++ b/src/cosmos/engine/MayachainEngine.ts
@@ -1,5 +1,4 @@
 import { EncodeObject } from '@cosmjs/proto-signing'
-import { coin } from '@cosmjs/stargate'
 import { add } from 'biggystring'
 import { Fee } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { EdgeCurrencyEngineOptions } from 'edge-core-js/types'
@@ -72,10 +71,6 @@ export class MayachainEngine extends MidgardEngine {
       }
     }
 
-    return {
-      gasFeeCoin: coin('1', this.networkInfo.nativeDenom),
-      gasLimit: '60000000',
-      networkFee
-    }
+    return this.makeMidgardFee(networkFee)
   }
 }

--- a/src/cosmos/engine/MidgardEngine.ts
+++ b/src/cosmos/engine/MidgardEngine.ts
@@ -1,5 +1,5 @@
-import { Event } from '@cosmjs/stargate'
-import { abs, div, max } from 'biggystring'
+import { coin, Event } from '@cosmjs/stargate'
+import { abs, add, div, max } from 'biggystring'
 import { Fee } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { EdgeCurrencyEngineOptions } from 'edge-core-js/types'
 
@@ -10,6 +10,7 @@ import { CosmosTools } from '../CosmosTools'
 import {
   asCosmosWalletOtherData,
   CosmosCoin,
+  CosmosFee,
   CosmosWalletOtherData,
   SafeCosmosWalletInfo
 } from '../cosmosTypes'
@@ -25,6 +26,14 @@ import {
 import { CosmosEngine } from './CosmosEngine'
 
 const QUERY_POLL_MILLISECONDS = getRandomDelayMs(20000)
+
+/**
+ * MAYAChain and THORChain price a transaction by a flat network fee rather than
+ * by gas, so the declared gas fee only has to be non-zero for the ante handler
+ * to accept the transaction.
+ */
+const MIDGARD_GAS_FEE = '1'
+const MIDGARD_GAS_LIMIT = '60000000'
 
 /**
  * Midgard reports a reverted operation two ways: a reverted send is a normal
@@ -263,6 +272,25 @@ export class MidgardEngine extends CosmosEngine {
 
     this.syncTracker.setHistoryRatios([null, ...this.enabledTokenIds], 1)
     this.sendTransactionEvents()
+  }
+
+  /**
+   * Builds the `CosmosFee` for a chain that charges a flat network fee.
+   *
+   * The signer pays BOTH the flat fee the chain quotes and the gas fee the
+   * transaction declares, so `networkFee` has to cover both. Reporting the flat
+   * fee alone puts a max spend exactly `MIDGARD_GAS_FEE` over the balance: the
+   * ante handler collects the declared gas fee first, which leaves the message
+   * short, and the chain accepts the transaction at CheckTx and then reverts it
+   * as `insufficient funds`.
+   */
+  protected makeMidgardFee(networkFee: string): CosmosFee {
+    const gasFeeCoin = coin(MIDGARD_GAS_FEE, this.networkInfo.nativeDenom)
+    return {
+      gasFeeCoin,
+      gasLimit: MIDGARD_GAS_LIMIT,
+      networkFee: add(networkFee, gasFeeCoin.amount)
+    }
   }
 
   /**

--- a/src/cosmos/engine/MidgardEngine.ts
+++ b/src/cosmos/engine/MidgardEngine.ts
@@ -1,5 +1,5 @@
 import { coin, Event } from '@cosmjs/stargate'
-import { abs, add, div, max } from 'biggystring'
+import { abs, div, max } from 'biggystring'
 import { Fee } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { EdgeCurrencyEngineOptions } from 'edge-core-js/types'
 
@@ -29,10 +29,14 @@ const QUERY_POLL_MILLISECONDS = getRandomDelayMs(20000)
 
 /**
  * MAYAChain and THORChain price a transaction by a flat network fee rather than
- * by gas, so the declared gas fee only has to be non-zero for the ante handler
- * to accept the transaction.
+ * by gas, so we declare a token gas fee. Whether the chain then COLLECTS it
+ * differs, which is why each subclass reports its own total:
+ * - MAYAChain runs the stock cosmos-sdk `DeductFeeDecorator` and charges it on
+ *   top of the flat fee (a send emits `tx {fee: 1cacao}` at ante level).
+ * - THORChain's ante chain has no `DeductFeeDecorator`, so the declared fee is
+ *   ignored; live sends declare an empty fee and are accepted.
  */
-const MIDGARD_GAS_FEE = '1'
+export const MIDGARD_DECLARED_GAS_FEE = '1'
 const MIDGARD_GAS_LIMIT = '60000000'
 
 /**
@@ -275,21 +279,17 @@ export class MidgardEngine extends CosmosEngine {
   }
 
   /**
-   * Builds the `CosmosFee` for a chain that charges a flat network fee.
+   * Builds the `CosmosFee` shape shared by the flat-fee Midgard chains.
    *
-   * The signer pays BOTH the flat fee the chain quotes and the gas fee the
-   * transaction declares, so `networkFee` has to cover both. Reporting the flat
-   * fee alone puts a max spend exactly `MIDGARD_GAS_FEE` over the balance: the
-   * ante handler collects the declared gas fee first, which leaves the message
-   * short, and the chain accepts the transaction at CheckTx and then reverts it
-   * as `insufficient funds`.
+   * `networkFee` is the TOTAL the signer pays, which the subclass computes:
+   * whether the declared gas fee is collected on top of the chain's flat fee is
+   * chain-specific (see `MIDGARD_DECLARED_GAS_FEE`).
    */
   protected makeMidgardFee(networkFee: string): CosmosFee {
-    const gasFeeCoin = coin(MIDGARD_GAS_FEE, this.networkInfo.nativeDenom)
     return {
-      gasFeeCoin,
+      gasFeeCoin: coin(MIDGARD_DECLARED_GAS_FEE, this.networkInfo.nativeDenom),
       gasLimit: MIDGARD_GAS_LIMIT,
-      networkFee: add(networkFee, gasFeeCoin.amount)
+      networkFee
     }
   }
 

--- a/src/cosmos/engine/ThorchainEngine.ts
+++ b/src/cosmos/engine/ThorchainEngine.ts
@@ -1,5 +1,4 @@
 import { EncodeObject } from '@cosmjs/proto-signing'
-import { coin } from '@cosmjs/stargate'
 import { add } from 'biggystring'
 import { Fee } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { EdgeCurrencyEngineOptions } from 'edge-core-js/types'
@@ -75,10 +74,6 @@ export class ThorchainEngine extends MidgardEngine {
       }
     }
 
-    return {
-      gasFeeCoin: coin('1', this.networkInfo.nativeDenom),
-      gasLimit: '60000000',
-      networkFee
-    }
+    return this.makeMidgardFee(networkFee)
   }
 }

--- a/src/cosmos/engine/ThorchainEngine.ts
+++ b/src/cosmos/engine/ThorchainEngine.ts
@@ -74,6 +74,8 @@ export class ThorchainEngine extends MidgardEngine {
       }
     }
 
+    // thornode's ante chain has no `DeductFeeDecorator`, so the fee the
+    // transaction declares is ignored and the flat fee is the whole cost.
     return this.makeMidgardFee(networkFee)
   }
 }

--- a/test/cosmos/midgardCalculateFee.test.ts
+++ b/test/cosmos/midgardCalculateFee.test.ts
@@ -1,42 +1,70 @@
+import { EncodeObject } from '@cosmjs/proto-signing'
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
 
 import { CosmosFee } from '../../src/cosmos/cosmosTypes'
-import { MidgardEngine } from '../../src/cosmos/engine/MidgardEngine'
+import { MayachainEngine } from '../../src/cosmos/engine/MayachainEngine'
+import { ThorchainEngine } from '../../src/cosmos/engine/ThorchainEngine'
 
-// `makeMidgardFee` is protected, so reach it the same way the engine's
-// subclasses do — through the prototype, with only the state it touches.
-const makeMidgardFee = (nativeDenom: string, networkFee: string): CosmosFee =>
-  // eslint-disable-next-line @typescript-eslint/dot-notation
-  MidgardEngine.prototype['makeMidgardFee'].call(
-    { networkInfo: { nativeDenom } },
-    networkFee
-  )
+const MSG_SEND: EncodeObject = { typeUrl: '/types.MsgSend', value: {} }
 
-describe('makeMidgardFee', function () {
-  it('adds the declared gas fee to the chain fee so a max spend fits', function () {
-    // MAYAChain's NativeTransactionFee for a MsgSend:
-    const fee = makeMidgardFee('cacao', '2000000000')
+interface FeeCalculator {
+  calculateFee: (opts: { messages: EncodeObject[] }) => Promise<CosmosFee>
+}
 
-    // The signer pays the flat fee AND the declared gas fee. Reporting only
-    // the flat 2000000000 put a max spend one base unit over the balance,
-    // which the chain accepted at CheckTx and then reverted as
-    // "insufficient funds" while the app reported success.
+/**
+ * Calls an engine's `calculateFee` with only the state it touches: the network
+ * info, the init options `rpcWithApiKey` cleans, and a fetch that answers with
+ * the chain's constants endpoint payload.
+ */
+const calculateFee = async (
+  enginePrototype: object,
+  nativeDenom: string,
+  constants: unknown
+): Promise<CosmosFee> => {
+  // Created FROM the prototype so the inherited `makeMidgardFee` resolves.
+  const engine: FeeCalculator = Object.assign(Object.create(enginePrototype), {
+    networkInfo: {
+      nativeDenom,
+      transactionFeeConnectionInfo: { url: 'https://example.test', headers: {} }
+    },
+    tools: { initOptions: {} },
+    engineFetch: async () => ({
+      status: 200,
+      json: async () => constants
+    })
+  })
+  return await engine.calculateFee({ messages: [MSG_SEND] })
+}
+
+describe('Midgard calculateFee', function () {
+  it('MAYAChain adds the declared gas fee it actually collects', async function () {
+    const fee = await calculateFee(MayachainEngine.prototype, 'cacao', {
+      int_64_values: {
+        NativeTransactionFee: 2000000000,
+        OutboundTransactionFee: 2000000000
+      }
+    })
+
+    // mayanode runs the stock cosmos-sdk `DeductFeeDecorator`, so the signer
+    // pays the flat fee AND the declared gas fee. Reporting the flat fee alone
+    // put a max send one base unit over the balance, which the chain accepted
+    // and then reverted as "insufficient funds".
     assert.equal(fee.networkFee, '2000000001')
     assert.deepEqual(fee.gasFeeCoin, { denom: 'cacao', amount: '1' })
     assert.equal(fee.gasLimit, '60000000')
   })
 
-  it('uses the wallet denom for the gas fee coin', function () {
-    const fee = makeMidgardFee('rune', '2000000')
+  it('THORChain reports the flat fee alone, since the declared fee is ignored', async function () {
+    const fee = await calculateFee(ThorchainEngine.prototype, 'rune', {
+      native_outbound_fee_rune: '2000000',
+      native_tx_fee_rune: '2000000'
+    })
 
-    assert.equal(fee.networkFee, '2000001')
+    // thornode's ante chain has no `DeductFeeDecorator`; live sends declare an
+    // empty fee and are accepted. Adding the declared unit here would
+    // over-report the fee and leave a base unit behind on a max send.
+    assert.equal(fee.networkFee, '2000000')
     assert.deepEqual(fee.gasFeeCoin, { denom: 'rune', amount: '1' })
-  })
-
-  it('still reports the gas fee when the chain quotes no flat fee', function () {
-    const fee = makeMidgardFee('cacao', '0')
-
-    assert.equal(fee.networkFee, '1')
   })
 })

--- a/test/cosmos/midgardCalculateFee.test.ts
+++ b/test/cosmos/midgardCalculateFee.test.ts
@@ -1,0 +1,42 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { CosmosFee } from '../../src/cosmos/cosmosTypes'
+import { MidgardEngine } from '../../src/cosmos/engine/MidgardEngine'
+
+// `makeMidgardFee` is protected, so reach it the same way the engine's
+// subclasses do — through the prototype, with only the state it touches.
+const makeMidgardFee = (nativeDenom: string, networkFee: string): CosmosFee =>
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  MidgardEngine.prototype['makeMidgardFee'].call(
+    { networkInfo: { nativeDenom } },
+    networkFee
+  )
+
+describe('makeMidgardFee', function () {
+  it('adds the declared gas fee to the chain fee so a max spend fits', function () {
+    // MAYAChain's NativeTransactionFee for a MsgSend:
+    const fee = makeMidgardFee('cacao', '2000000000')
+
+    // The signer pays the flat fee AND the declared gas fee. Reporting only
+    // the flat 2000000000 put a max spend one base unit over the balance,
+    // which the chain accepted at CheckTx and then reverted as
+    // "insufficient funds" while the app reported success.
+    assert.equal(fee.networkFee, '2000000001')
+    assert.deepEqual(fee.gasFeeCoin, { denom: 'cacao', amount: '1' })
+    assert.equal(fee.gasLimit, '60000000')
+  })
+
+  it('uses the wallet denom for the gas fee coin', function () {
+    const fee = makeMidgardFee('rune', '2000000')
+
+    assert.equal(fee.networkFee, '2000001')
+    assert.deepEqual(fee.gasFeeCoin, { denom: 'rune', amount: '1' })
+  })
+
+  it('still reports the gas fee when the chain quotes no flat fee', function () {
+    const fee = makeMidgardFee('cacao', '0')
+
+    assert.equal(fee.networkFee, '1')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/1/9976422036640/project/1201386023359434/task/1214062657363212

A CACAO max send never left the wallet. The app reported "Transaction Success"
and wrote a sent transaction into history, but nothing moved on-chain.

mayanode runs the stock cosmos-sdk `DeductFeeDecorator`, so a MAYAChain sender
pays the transaction's DECLARED gas fee on top of the chain's flat
`NativeTransactionFee`. Only the flat fee was reported as `networkFee`, and since
the cosmos plugin has no `getMaxSpendable`, edge-core-js binary-searches
`makeSpend` and `checkBalances` only enforces `amount + networkFee <= balance`. A
max send therefore landed on `balance - flatFee`, whose real cost is
`balance + 1`. The chain accepted it at CheckTx and then reverted it in
DeliverTx as `insufficient funds`.

`MayachainEngine.calculateFee` now adds the declared fee, and
`getMidgardTransactionFee` reports the same total so the fee recorded when the
send syncs back from Midgard matches what was quoted at spend time.

#### Why this is per-engine and not shared

THORChain looks identical in code but behaves differently, which @peachbits
verified against mainnet and I reproduced. thornode's ante chain has no
`DeductFeeDecorator`: [`56B30BD2…`](https://viewblock.io/thorchain/tx/56B30BD2C54C03DF832663826905334436CDF4FA596616EE3C425DD791EFC090)
declares an EMPTY fee, lands `code 0`, debits only the flat `2000000rune` plus
the send amount, and emits no `tx.fee` event. MAYAChain's
[`051A9C…`](https://www.mayascan.org/tx/051A9C297A4C309E7123FBE317F2FA936071890AEBC3F8E3229F161321A74748)
declares `1cacao` and carries an ante-level `tx {fee: 1cacao, fee_payer: …}`.

So `makeMidgardFee` is a plain shape-builder taking the total, `MayachainEngine`
adds the declared fee, and `ThorchainEngine` reports the flat fee alone. RUNE
comes out exactly as it does on master; a shared `+1` would have over-reported it
and left a base unit behind on every RUNE max send.

#### Verification

Driven in the app on the iOS simulator with this branch baked in via `updot`,
sending between two CACAO wallets on `edge-funds`.

| | before | after |
| --- | --- | --- |
| MAX amount offered | 10.15 CACAO | 10.1499999998 CACAO |
| fee shown | 0.2 | 0.2000000001 |
| on-chain result | [`BFBC11AF…`](https://www.mayascan.org/tx/BFBC11AF870494A03F16332808B3B205BFA2969EBBC1C8131B8A1A57FF1CA0E3) `code 1`, `insufficient funds` | [`544BA17E…`](https://www.mayascan.org/tx/544BA17E2553F5B09ED551FCABFA4FFFC9188F9EDC0BA28EE55E072045C165A3) `code 0` |
| sender balance | unchanged apart from the 1-unit gas fee | emptied to 0 |
| recipient balance | unchanged | +101499999998 exactly |

An ordinary non-max send also lands `code 0`
([`051A9C29…`](https://www.mayascan.org/tx/051A9C297A4C309E7123FBE317F2FA936071890AEBC3F8E3229F161321A74748)),
with the sender debited `amount + 2000000000 + 1`.

`test/cosmos/midgardCalculateFee.test.ts` asserts the per-chain totals through
the real `calculateFee`: `2000000001` for CACAO, `2000000` for RUNE.
`verify-repo.sh` passes (install, prepare, eslint, mocha).

#### Re-test after the per-engine split

The CACAO total is unchanged by the split, and the rebuilt app confirms it:
against a balance of `812940000000` it offered `81.0939999999` + a
`0.2000000001` fee, which sums to the balance exactly. That broadcast could not
settle, because MAYAChain is under a global halt right now (mimir
`HALTCHAINGLOBAL=1`) and rejected it with
`unable to use MsgSend while chain is halted`. The reverted transaction still
debited exactly `1cacao`, which is one more confirmation that mayanode collects
the declared fee. The `code 0` row above is from the same arithmetic before the
halt began.

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="3" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-currency-accountbased/pull/1084/commits/2e667be662bbd0a2d49d01c5c15a675d8e0b735b"><code>2e667be</code></a><br><sub>Include the declared gas fee in MAYAChain/THORChain fees</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-01-max-amount-and-fee.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-01-max-amount-and-fee.png" width="200"></a><br><sub>max amount and fee</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-02-tx-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-02-tx-success.png" width="200"></a><br><sub>tx success</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-03-postfix-max-amount-and-fee.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-03-postfix-max-amount-and-fee.png" width="200"></a><br><sub>postfix max amount and fee</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-04-postfix-tx-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-04-postfix-tx-success.png" width="200"></a><br><sub>postfix tx success</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-05-postfix-txid-detail.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-05-postfix-txid-detail.png" width="200"></a><br><sub>postfix txid detail</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-06-postfix-wallet-emptied.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-06-postfix-wallet-emptied.png" width="200"></a><br><sub>postfix wallet emptied</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-07-postfix-normal-send-success.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260810-130854-agent-proof-1214062657363212-07-postfix-normal-send-success.png" width="200"></a><br><sub>postfix normal send success</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260828-154026-agent-proof-1214062657363212-08-per-engine-max-amount-and-fee.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260828-154026-agent-proof-1214062657363212-08-per-engine-max-amount-and-fee.png" width="200"></a><br><sub>per engine max amount and fee</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260828-154026-agent-proof-1214062657363212-09-app-success-modal-while-chain-halted.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-accountbased/pr-1084/20260828-154026-agent-proof-1214062657363212-09-app-success-modal-while-chain-halted.png" width="200"></a><br><sub>app success modal while chain halted</sub></td>
</tr>
</table>
<!-- agent-test-evidence:end -->