### PR TITLE
Fix Avalanche transaction history sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Avalanche) Restore transaction history sync. All three configured evmscan servers had stopped answering: Etherscan V2 gates chain 43114 behind a paid plan, `api.avascan.info` no longer resolves, and `api.snowscan.xyz` serves only the retired V1 API. Since the RPC adapter still covered balances, nonce, block height and broadcast, wallets looked healthy while their history stayed blank. Replaced with Routescan's etherscan-compatible endpoint, already used for Botanix and HyperEVM.
+
 ## 4.87.0 (2026-08-02)
 
 - added: (Sui) `rpcNodes`, `rpcNodesArchival`, and `maxRequestsPerSecond` to the info payload, so nodes can be changed without a client release. Transaction sweeps start on an archival node, since the walk begins at the wallet's oldest transaction and a pruned node rejects a cursor older than its retention window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Robinhood Chain support (`robinhood`, EVM chain 4663), an Arbitrum Nitro L2 with ETH as its gas token. Transaction history comes from the chain's Blockscout instance, since Etherscan V2 does not cover this chain, and fees use the Arbitrum `NodeInterface` L1-component estimate. Built-in tokens are USDC, USDT, USDG, WBTC, WETH, CASHCAT and PONS.
+- fixed: (Avalanche) Remove unreachable avascan and snowscan evmscan servers
 
 ## 4.90.1 (2026-08-28)
 

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -196,12 +196,18 @@ const networkInfo: EthereumNetworkInfo = {
       ethBalCheckerContract: '0xd023d153a0dfa485130ecfde2faa7e612ef94818'
     },
     {
+      // Routescan is the only working etherscan-compatible source for
+      // Avalanche C-Chain. Etherscan V2 gates chain 43114 behind a paid plan,
+      // api.avascan.info no longer resolves, and api.snowscan.xyz only serves
+      // the retired V1 API.
+      //
+      // gastracker is intentionally left off: Routescan's gasoracle reports
+      // wei, but fetchFeesFromEvmScan assumes the Etherscan convention of gwei
+      // and multiplies by 1e9. Avalanche derives its gas price from the RPC
+      // adapter instead.
       type: 'evmscan',
-      gastrackerSupport: true,
       servers: [
-        'https://api.etherscan.io',
-        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan',
-        'https://api.snowscan.xyz'
+        'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan'
       ]
     }
   ],

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -196,13 +196,20 @@ const networkInfo: EthereumNetworkInfo = {
       ethBalCheckerContract: '0xd023d153a0dfa485130ecfde2faa7e612ef94818'
     },
     {
+      // Etherscan V2 covers chain 43114 only on a paid plan. A free-tier key
+      // answers "Free API access is not supported for this chain", which reads
+      // as a dead server and leaves history blank; the etherscanApiKey shipped
+      // for Avalanche has to be a paid one.
+      //
+      // api.avascan.info and api.snowscan.xyz used to sit alongside Etherscan
+      // here, and both are dead: avascan.info's API host resolves to a
+      // CloudFront distribution that no longer exists, and snowscan.xyz answers
+      // every request with "You are using a deprecated V1 endpoint". Neither
+      // comes back with a different key or plan, and a dead server in this list
+      // costs a failed request on every waterfall pass.
       type: 'evmscan',
       gastrackerSupport: true,
-      servers: [
-        'https://api.etherscan.io',
-        'https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan',
-        'https://api.snowscan.xyz'
-      ]
+      servers: ['https://api.etherscan.io']
     }
   ],
   uriNetworks: ['avalanche'],


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216409263474102/f)

Asana: https://app.asana.com/1/9976422036640/project/1200382638405084/task/1216409263474102

AVAX wallets showed balances and sent fine while transaction history never synced. The RPC adapter covers balance, nonce, block height and broadcast, so a wallet looked healthy with a blank history. Only the evmscan adapter fetches transactions.

The API key was the bug. Etherscan V2 gates chain coverage by plan, and the shared key this app shipped is free tier ("selected chains"), which is why chain 43114 answered `"Free API access is not supported for this chain. Please upgrade your api plan for full chain coverage."` A funded Professional-tier key is now in `env.json`, and `api.etherscan.io` returns real `txlist` data for 43114 with it. The key swap is what restores the sync, and it needs no code change.

This PR prunes the other two configured servers, which are dead independent of any key or plan.

| configured server | state | verdict |
|---|---|---|
| `https://api.etherscan.io` | works with the funded key (`status 1 OK`, real `txlist`) | kept |
| `https://api.avascan.info/v2/network/mainnet/evm/43114/etherscan` | CNAME target `d3rhlnpz39fui8.cloudfront.net` has no address records; `curl` exits 6 | removed |
| `https://api.snowscan.xyz` | `status 0 NOTOK`, "You are using a deprecated V1 endpoint" | removed |

`gastrackerSupport: true` stays. Etherscan's `gastracker/gasoracle` for 43114 returned `SafeGasPrice 0.112072016` against an RPC `eth_gasPrice` of `0x60f894c` (101,684,556 wei = 0.1017 gwei). It reports gwei, and the `WEI_MULTIPLIER` assumption in `fetchFeesFromEvmScan` holds.

#### Info server

`EthereumTools.updateInfoPayload` runs `mergeDeeply(networkInfo, infoPayload)`, and `mergeDeeply` replaces arrays. The info server's `networkAdapterConfigs` therefore overrides the plugin default on existing installs. The live payload is `[rpc, evmscan[etherscan], evmscan[avascan]]`, and `EthereumNetwork.check()` waterfalls in array order. With the funded key, etherscan answers first and the dead avascan entry is never reached. Production recovers with whatever build ships the new key. Pruning that dead entry from the info-server document is worth doing eventually; nothing is blocked on it.

#### Testing

- `verify-repo.sh` passes: CHANGELOG check, install, prepare, eslint on changed files, and 490 mocha tests.
- Network layer, with the funded key: `txlist` for 43114 returns real transactions, `gasoracle` returns the gwei value above, and both removed hosts fail as the table describes.
- In-app on the iOS simulator, on a build carrying this change and with no info-payload hack: resynced an AVAX wallet on `edge-funds` and its history repopulated. `resyncBlockchain` runs `killEngine` then `clearBlockchainCache`, which resets `transactionList`, `txIdList` and `txIdMap` and persists them. The list that came back was refetched. The storage layer confirms it: the wallet's `txEngineFolder/transactionList.json` was rewritten seconds after the confirm tap with 15 native AVAX transactions, and `walletLocalData.json` recorded `lastTransactionDate` at the same moment.

#### Also fixed by the key swap alone, with no code change

Base (8453), BNB (56), Optimism (10) and Celo (42220) were failing on the same free-tier gate and answer normally with the funded key. Holesky (17000) and zkSync (324) still answer `"Missing or unsupported chainid parameter"` because they are not on Etherscan V2 at all, which no key changes.

#### Known limitation, unchanged by this PR

An address with more than 10,000 transactions still fails to page: Etherscan V2 returns `Result window is too large, PageNo x Offset size must be less than or equal to 10000`. That is a pre-existing `EvmScanAdapter` pagination limit affecting every EVM chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Avalanche explorer server list and docs; no auth or send-path logic, though history stays empty if the Etherscan key remains free-tier.
> 
> **Overview**
> **Avalanche transaction history** no longer tries dead Blockscout-style endpoints on every sync waterfall pass. The `evmscan` adapter in `avalancheInfo.ts` now lists only `https://api.etherscan.io`, with comments noting that Etherscan V2 for chain **43114** needs a **paid** API key and that **avascan** / **snowscan** hosts are permanently broken (missing CloudFront, deprecated V1).
> 
> **CHANGELOG** records the fix under Unreleased. Restoring history for users still depends on shipping a funded Etherscan key (outside this diff); this change removes noise and latency from guaranteed failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947095f362d5bf8bd88aedf6e9be0ecae8fb4721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->