### PR TITLE
Persist the Zano wallet file once synced and run adopted wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed: (Zano) Stop the transaction query from spinning forever when the newest history entries are mining or defragmentation transactions. The wallet excludes those from its answer without advancing `last_item_index`, so the loop's end-of-history test could never become true, and the wallet it happened to stopped reporting balances and transactions entirely.
 - fixed: (Zano) Show unconfirmed transactions on a wallet that already has history. The wallet reports its mempool only when asked from offset zero, so a paged catch-up starting anywhere else left an incoming transfer invisible until it was mined and a sent one pending with nothing to confirm it.
 - fixed: (Zano) Start the refresh worker when adopting an already-open wallet, so a wallet left open by an interrupted `startWallet` still syncs under react-native-zano's postponed-run mode (0.4.1).
+- fixed: (Zano) Report an unconfirmed incoming transfer as a new transaction, so the app raises its receive notification. The mempool sweep files the transfer at block height zero, which the checkpoint comparison reads as already seen, and the later confirmation takes the update path, so the arrival that the sweep exists to surface was never announced.
 
 ## 4.88.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: (Zano) Persist the wallet file once a wallet reaches synced and every ten minutes afterwards. The native library only writes the file when a wallet closes, and a mobile app is killed rather than closed, so every launch re-scanned everything since the file was last written - a catch-up window that only grew, re-paid at full multi-core CPU on each cold start.
+- fixed: (Zano) Start the refresh worker when adopting an already-open wallet, so a wallet left open by an interrupted `startWallet` still syncs under react-native-zano's postponed-run mode (0.4.1).
+
 ## 4.88.0 (2026-08-14)
 
 - added: (Zano) Verify that the native wallet address matches the address derived from the seed phrase when a wallet starts, failing the start rather than syncing a wallet whose native address is not the one shown to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - fixed: (Zano) Persist the wallet file once a wallet reaches synced and every ten minutes afterwards. The native library only writes the file when a wallet closes, and a mobile app is killed rather than closed, so every launch re-scanned everything since the file was last written - a catch-up window that only grew, re-paid at full multi-core CPU on each cold start.
+- fixed: (Zano) Stop the transaction query from spinning forever when the newest history entries are mining or defragmentation transactions. The wallet excludes those from its answer without advancing `last_item_index`, so the loop's end-of-history test could never become true, and the wallet it happened to stopped reporting balances and transactions entirely.
+- fixed: (Zano) Show unconfirmed transactions on a wallet that already has history. The wallet reports its mempool only when asked from offset zero, so a paged catch-up starting anywhere else left an incoming transfer invisible until it was mined and a sent one pending with nothing to confirm it.
 - fixed: (Zano) Start the refresh worker when adopting an already-open wallet, so a wallet left open by an interrupted `startWallet` still syncs under react-native-zano's postponed-run mode (0.4.1).
 
 ## 4.88.0 (2026-08-14)

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -1,5 +1,5 @@
 import { abs, add, eq, gt, lt, mul, sub } from 'biggystring'
-import { asMaybe } from 'cleaners'
+import { asJSON, asMaybe, asObject, asValue } from 'cleaners'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
@@ -50,6 +50,20 @@ import {
   ZanoWalletOtherData
 } from './zanoTypes'
 
+/**
+ * How often a synced wallet writes its file to disk. The native library only
+ * stores on close, and a mobile app is killed rather than closed, so without
+ * periodic stores every launch re-scans from wherever the file was last
+ * written - a window that only grows.
+ */
+const WALLET_STORE_INTERVAL_MS = 10 * 60 * 1000
+
+/** The wallet RPC answers a successful store with a result object. */
+const asStoreResponse = asObject({ result: asObject({}) })
+
+/** A successful run_wallet answers with error_code OK. */
+const asRunWalletResponse = asObject({ error_code: asValue('OK') })
+
 export class ZanoEngine extends CurrencyEngine<
   ZanoTools,
   SafeZanoWalletInfo,
@@ -62,6 +76,14 @@ export class ZanoEngine extends CurrencyEngine<
   private readonly nativeId: LifecycleManager<number>
   private sendKeysToNative?: (keys: ZanoPrivateKeys) => void
   private needsNativeStorageClear: boolean = false
+  private lastStoreTime: number = 0
+  private lastStoreHeight: number = 0
+  /**
+   * Bumped whenever the store gates are reset. A store that was already in
+   * flight across a reset carries the old value and must not write its
+   * pre-reset height back into the gates.
+   */
+  private storeGeneration: number = 0
 
   constructor(
     env: PluginEnvironment<ZanoNetworkInfo>,
@@ -167,6 +189,27 @@ export class ZanoEngine extends CurrencyEngine<
           this.log(
             `initializeWallet: found existing wallet with ID ${existingWallet.wallet_id}`
           )
+
+          // From react-native-zano 0.4.1, wallets open with the refresh
+          // worker postponed, so a wallet left open by an interrupted
+          // `startWallet` may not be syncing; the postponed-run flag is
+          // process-wide and sticky, so the adopt path cannot know which way
+          // it was opened and must start the worker itself. On 0.4.0, where
+          // open auto-starts the worker, the same call is a harmless no-op.
+          // A failure here must throw: returning the id would mark the
+          // lifecycle started and hand back a wallet that never syncs,
+          // while throwing lets the next `get()` retry the whole start.
+          const runResponse = await this.tools.zano.syncCall(
+            'run_wallet',
+            existingWallet.wallet_id,
+            ''
+          )
+          if (asMaybe(asJSON(asRunWalletResponse))(runResponse) == null) {
+            throw new Error(
+              `initializeWallet: could not run the adopted wallet: ${runResponse}`
+            )
+          }
+
           return existingWallet.wallet_id
         }
       },
@@ -402,6 +445,7 @@ export class ZanoEngine extends CurrencyEngine<
       )
       await this.queryBalance()
       await this.queryTransactions()
+      await this.storeWalletFile(nativeId, status.current_wallet_height)
       return 20000
     } else {
       this.syncTracker.updateBlockRatio(
@@ -413,12 +457,61 @@ export class ZanoEngine extends CurrencyEngine<
     }
   }
 
+  /**
+   * Persists the native wallet file, so the next launch resumes from this
+   * height instead of re-scanning everything since the file was last
+   * written. Called only from the synced branch of `syncNetwork`, where the
+   * refresh worker is idle and the per-wallet lock is free; a store during
+   * the catch-up scan would block behind that lock. Throttled, and skipped
+   * entirely when the wallet height has not advanced past the last store. A
+   * failure only costs the next launch a longer catch-up, so it logs and
+   * moves on.
+   */
+  private async storeWalletFile(
+    nativeId: number,
+    walletHeight: number
+  ): Promise<void> {
+    if (walletHeight <= this.lastStoreHeight) return
+    const now = Date.now()
+    if (
+      this.lastStoreTime !== 0 &&
+      now - this.lastStoreTime < WALLET_STORE_INTERVAL_MS
+    ) {
+      return
+    }
+    const generation = this.storeGeneration
+    try {
+      const response = await this.tools.zano.invoke(
+        nativeId,
+        JSON.stringify({ method: 'store', params: {} })
+      )
+      if (asMaybe(asJSON(asStoreResponse))(response) == null) {
+        throw new Error(response)
+      }
+      // A resync between the call and its answer reset the gates for a
+      // wallet that no longer holds this height. Recording it would gate the
+      // rebuilt wallet at a tip it has not re-reached, so a kill before the
+      // chain advances would re-pay the whole rescan.
+      if (generation !== this.storeGeneration) return
+      this.lastStoreTime = now
+      this.lastStoreHeight = walletHeight
+    } catch (error: unknown) {
+      this.log.warn(`storeWalletFile failed: ${String(error)}`)
+    }
+  }
+
   // // ****************************************************************************
   // // Public methods
   // // ****************************************************************************
 
   async resyncBlockchain(): Promise<void> {
     this.needsNativeStorageClear = true
+    // The rebuilt wallet re-earns every height, so the store gates must not
+    // carry over: left in place they would skip the first store at the
+    // re-reached tip, and a kill in that window re-pays the full rescan.
+    this.lastStoreTime = 0
+    this.lastStoreHeight = 0
+    this.storeGeneration += 1
     this.nativeId.stop()
     this.unlockedBalanceMap.clear()
     await this.killEngine()

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -289,30 +289,48 @@ export class ZanoEngine extends CurrencyEngine<
     const nativeId = await this.nativeId.get()
     if (nativeId == null) return
 
-    while (true) {
-      const offset = this.otherData.transactionQueryOffset
-      const transactions = await this.tools.zano.getTransactions(
-        nativeId,
-        offset
-      )
+    // Sweep the mempool first. `get_recent_txs_and_info2` prepends the
+    // wallet's unconfirmed transfers only when the offset is zero, so once a
+    // wallet has any confirmed history the paged catch-up below can never see
+    // a transaction before it is mined: an incoming transfer stays invisible
+    // to the receiver, and the sender has nothing to confirm its own.
+    const pendingPage = await this.tools.zano.getTransactions(nativeId, 0)
+    const pendingTransfers = pendingPage.transfers ?? []
+    pendingTransfers.forEach(this.processTransaction)
 
-      if (offset !== transactions.last_item_index) {
-        this.otherData.transactionQueryOffset = transactions.last_item_index
+    let offset = this.otherData.transactionQueryOffset
+    while (true) {
+      const page =
+        offset === 0
+          ? pendingPage
+          : await this.tools.zano.getTransactions(nativeId, offset)
+      const transfers = page.transfers ?? []
+      transfers.forEach(this.processTransaction)
+
+      const lastItemIndex = page.last_item_index
+      const totalTransfers = page.total_transfers
+      if (offset !== lastItemIndex) {
+        this.otherData.transactionQueryOffset = lastItemIndex
         this.walletLocalDataDirty = true
       }
 
-      const transfers = transactions.transfers ?? []
-      transfers.forEach(this.processTransaction)
-
+      // Stop when the page did not move us forward. `last_item_index` counts
+      // only the transfers the wallet actually returned, so a page whose
+      // newest entries were all filtered out -- mining and defragmentation
+      // transactions are excluded by request -- leaves it permanently short of
+      // `total_transfers - 1`. Testing that identity alone spun this loop
+      // forever on such a wallet, re-requesting one page and starving every
+      // later balance and transaction update for it.
       if (
-        transactions.total_transfers === 0 ||
-        transactions.total_transfers - transactions.last_item_index === 1
+        totalTransfers === 0 ||
+        lastItemIndex <= offset ||
+        lastItemIndex + 1 >= totalTransfers
       ) {
         break
       }
-      this.syncTracker.updateHistoryRatio(
-        transactions.total_transfers / transactions.last_item_index
-      )
+
+      this.syncTracker.updateHistoryRatio(totalTransfers / lastItemIndex)
+      offset = lastItemIndex
     }
     this.sendTransactionEvents()
     this.syncTracker.updateHistoryRatio(1)

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -285,6 +285,27 @@ export class ZanoEngine extends CurrencyEngine<
     this.syncTracker.updateBalanceRatio(1)
   }
 
+  // The mempool sweep in `queryTransactions` surfaces an incoming transfer
+  // while it is still unconfirmed, so it enters the store at blockHeight 0.
+  // The base checkpoint math then treats that first sighting as already seen
+  // ('0' never advances past a synced checkpoint) and the later confirmation
+  // takes the update path, which never notifies, so the receive dropdown never
+  // fires for a transfer this engine reports. Mirror the MoneroEngine and
+  // ZcashEngine fix: an incoming unconfirmed transaction seen after the
+  // first-ever sync is new. The same multi-device caveat applies, since a
+  // second device syncing the same account tracks its own checkpoint.
+  protected isTransactionNew(edgeTransaction: EdgeTransaction): boolean {
+    if (
+      edgeTransaction.blockHeight === 0 &&
+      edgeTransaction.confirmations === 'unconfirmed' &&
+      this.seenTxCheckpoint != null &&
+      !edgeTransaction.isSend
+    ) {
+      return true
+    }
+    return super.isTransactionNew(edgeTransaction)
+  }
+
   async queryTransactions(): Promise<void> {
     const nativeId = await this.nativeId.get()
     if (nativeId == null) return

--- a/src/zano/zanoInfo.ts
+++ b/src/zano/zanoInfo.ts
@@ -145,7 +145,7 @@ const networkInfo: ZanoNetworkInfo = {
   walletRpcAddress: 'http://37.27.100.59:10500'
 }
 
-const currencyInfo: EdgeCurrencyInfo = {
+export const currencyInfo: EdgeCurrencyInfo = {
   currencyCode: 'ZANO',
   assetDisplayName: 'Zano',
   chainDisplayName: 'Zano',

--- a/test/zano/ZanoEngineQueryTransactions.test.ts
+++ b/test/zano/ZanoEngineQueryTransactions.test.ts
@@ -1,0 +1,259 @@
+import { assert } from 'chai'
+import {
+  EdgeCurrencyEngineCallbacks,
+  EdgeCurrencyEngineOptions,
+  EdgeTransaction,
+  makeFakeIo
+} from 'edge-core-js'
+import { describe, it } from 'mocha'
+import type {
+  GetRecentTransactionsResponse,
+  RecentTransaction
+} from 'react-native-zano'
+
+import { PluginEnvironment } from '../../src/common/innerPlugin'
+import { ZanoEngine } from '../../src/zano/ZanoEngine'
+import { currencyInfo } from '../../src/zano/zanoInfo'
+import { ZanoTools } from '../../src/zano/ZanoTools'
+import { SafeZanoWalletInfo, ZanoNetworkInfo } from '../../src/zano/zanoTypes'
+import { fakeLog } from '../fake/fakeLog'
+
+const NATIVE_ASSET_ID =
+  'd6329b5b1f7c0805b5c345f4957554002a2f557845f64d7645dae0e051a6498a'
+const ADDRESS = 'ZxTestAddress'
+
+/** The page size `CppBridge.getTransactions` asks the wallet for. */
+const PAGE_SIZE = 100
+
+function makeTransfer(
+  txHash: string,
+  height: number,
+  opts: { isMining?: boolean } = {}
+): RecentTransaction {
+  return {
+    employed_entries: {},
+    fee: 10000000000,
+    height,
+    is_mining: opts.isMining ?? false,
+    is_mixing: false,
+    is_service: false,
+    payment_id: '',
+    show_sender: false,
+    subtransfers: [
+      { amount: 1000000000000, asset_id: NATIVE_ASSET_ID, is_income: true }
+    ],
+    timestamp: 1750000000,
+    transfer_internal_index: 0,
+    tx_blob_size: 1,
+    tx_hash: txHash,
+    tx_type: 0,
+    unlock_time: 0
+  }
+}
+
+interface FakeWallet {
+  /** Confirmed transfers, oldest first, exactly as `m_transfer_history`. */
+  history: RecentTransaction[]
+  /** Mempool transfers, which the wallet reports only at offset zero. */
+  unconfirmed: RecentTransaction[]
+}
+
+/**
+ * Mirrors `wallet_rpc_server::on_get_recent_txs_and_info2` plus
+ * `wallet2::get_recent_transfers_history`, the two pieces this engine's paging
+ * contract rests on:
+ *
+ * - unconfirmed transfers are prepended ONLY when the requested offset is zero
+ * - `last_item_index` is the history index of the last transfer actually
+ *   RETURNED, so entries filtered out by `exclude_mining_txs` never advance it
+ * - `total_transfers` is the full history length, filtered entries included
+ */
+function makeFakeTools(wallet: FakeWallet): {
+  tools: ZanoTools
+  requests: number[]
+} {
+  const requests: number[] = []
+
+  const getTransactions = async (
+    _nativeId: number,
+    offset: number
+  ): Promise<GetRecentTransactionsResponse> => {
+    requests.push(offset)
+    const transfers: RecentTransaction[] =
+      offset === 0 ? [...wallet.unconfirmed] : []
+
+    let lastItemIndex = 0
+    let returned = 0
+    for (let index = offset; index < wallet.history.length; ++index) {
+      const transfer = wallet.history[index]
+      if (transfer.is_mining) continue
+      transfers.push(transfer)
+      lastItemIndex = index
+      if (++returned >= PAGE_SIZE) break
+    }
+
+    return {
+      last_item_index: lastItemIndex,
+      pi: {
+        balance: 0,
+        curent_height: 0,
+        transfer_entries_count: 0,
+        transfers_count: 0,
+        unlocked_balance: 0
+      },
+      total_transfers: wallet.history.length,
+      transfers
+    }
+  }
+
+  const tools = {
+    zano: { getTransactions }
+  } as unknown as ZanoTools
+
+  return { tools, requests }
+}
+
+interface TestEngine {
+  engine: ZanoEngine
+  queryTransactions: () => Promise<void>
+  requests: number[]
+  storedTx: (txid: string) => EdgeTransaction | undefined
+}
+
+async function makeEngine(
+  wallet: FakeWallet,
+  startOffset: number
+): Promise<TestEngine> {
+  const fakeIo = makeFakeIo()
+
+  const callbacks: EdgeCurrencyEngineCallbacks = {
+    onAddressChanged() {},
+    onAddressesChecked() {},
+    onBalanceChanged() {},
+    onBlockHeightChanged() {},
+    onNewTokens() {},
+    onSeenTxCheckpoint() {},
+    onStakingStatusChanged() {},
+    onSubscribeAddresses() {},
+    onSyncStatusChanged() {},
+    onTokenBalanceChanged() {},
+    onTransactions() {},
+    onTransactionsChanged() {},
+    onTxidsChanged() {},
+    onUnactivatedTokenIdsChanged() {},
+    onWcNewContractCall() {}
+  }
+
+  const opts: EdgeCurrencyEngineOptions = {
+    callbacks,
+    customTokens: {},
+    enabledTokenIds: [],
+    log: fakeLog,
+    seenTxCheckpoint: '0',
+    userSettings: {},
+    walletLocalDisklet: fakeIo.disklet,
+    walletLocalEncryptedDisklet: fakeIo.disklet,
+    walletSettings: {}
+  }
+
+  const networkInfo: ZanoNetworkInfo = {
+    nativeAssetId: NATIVE_ASSET_ID,
+    walletRpcAddress: 'http://127.0.0.1:10500'
+  }
+
+  const env = {
+    currencyInfo,
+    io: fakeIo,
+    log: fakeLog,
+    networkInfo
+  } as unknown as PluginEnvironment<ZanoNetworkInfo>
+
+  const walletInfo: SafeZanoWalletInfo = {
+    id: 'wallet-1',
+    type: 'wallet:zano',
+    keys: { publicKey: ADDRESS }
+  }
+
+  const { tools, requests } = makeFakeTools(wallet)
+  const engine = new ZanoEngine(env, tools, walletInfo, opts)
+  await engine.loadEngine()
+  engine.otherData.transactionQueryOffset = startOffset
+  // The lifecycle manager only hands out a native id for a started wallet;
+  // these tests drive `queryTransactions` directly:
+  ;(engine as any).nativeId = { get: async () => 0 }
+
+  return {
+    engine,
+    queryTransactions: async () => {
+      await engine.queryTransactions()
+    },
+    requests,
+    storedTx: (txid: string) => {
+      const index = (engine as any).txIdMap['']?.[txid]
+      if (index == null) return undefined
+      return (engine as any).transactionList[''][index]
+    }
+  }
+}
+
+describe('ZanoEngine.queryTransactions', function () {
+  it('terminates when the newest history entries are filtered out', async function () {
+    // A defragmentation or mining transaction at the tip keeps
+    // `last_item_index` at 1 while `total_transfers` is 3, so the old
+    // `total - last === 1` test could never become true.
+    const wallet: FakeWallet = {
+      history: [
+        makeTransfer('c0', 100),
+        makeTransfer('c1', 101),
+        makeTransfer('mined', 102, { isMining: true })
+      ],
+      unconfirmed: []
+    }
+    const { queryTransactions, requests, storedTx } = await makeEngine(
+      wallet,
+      1
+    )
+
+    await queryTransactions()
+
+    // One mempool sweep plus one catch-up page, and no spin:
+    assert.isBelow(requests.length, 4)
+    assert.equal(storedTx('c1')?.blockHeight, 101)
+  })
+
+  it('sees an unconfirmed transfer on a wallet that already has history', async function () {
+    // The wallet reports unconfirmed transfers only at offset zero, so a
+    // catch-up that starts at the persisted offset never sees them.
+    const wallet: FakeWallet = {
+      history: [makeTransfer('c0', 100), makeTransfer('c1', 101)],
+      unconfirmed: [makeTransfer('mempool', 0)]
+    }
+    const { queryTransactions, requests, storedTx } = await makeEngine(
+      wallet,
+      1
+    )
+
+    await queryTransactions()
+
+    assert.include(requests, 0)
+    assert.equal(storedTx('mempool')?.blockHeight, 0)
+  })
+
+  it('pages a long history and stops at its end', async function () {
+    const history: RecentTransaction[] = []
+    for (let index = 0; index < 150; ++index) {
+      history.push(makeTransfer(`c${index}`, 100 + index))
+    }
+    const { queryTransactions, requests, storedTx, engine } = await makeEngine(
+      { history, unconfirmed: [] },
+      0
+    )
+
+    await queryTransactions()
+
+    assert.equal(storedTx('c0')?.blockHeight, 100)
+    assert.equal(storedTx('c149')?.blockHeight, 249)
+    assert.equal(engine.otherData.transactionQueryOffset, 149)
+    assert.isBelow(requests.length, 5)
+  })
+})

--- a/test/zano/ZanoEngineQueryTransactions.test.ts
+++ b/test/zano/ZanoEngineQueryTransactions.test.ts
@@ -3,6 +3,7 @@ import {
   EdgeCurrencyEngineCallbacks,
   EdgeCurrencyEngineOptions,
   EdgeTransaction,
+  EdgeTransactionEvent,
   makeFakeIo
 } from 'edge-core-js'
 import { describe, it } from 'mocha'
@@ -115,6 +116,8 @@ function makeFakeTools(wallet: FakeWallet): {
 
 interface TestEngine {
   engine: ZanoEngine
+  /** Every transaction event the engine handed to the core, in order. */
+  events: EdgeTransactionEvent[]
   queryTransactions: () => Promise<void>
   requests: number[]
   storedTx: (txid: string) => EdgeTransaction | undefined
@@ -125,6 +128,7 @@ async function makeEngine(
   startOffset: number
 ): Promise<TestEngine> {
   const fakeIo = makeFakeIo()
+  const events: EdgeTransactionEvent[] = []
 
   const callbacks: EdgeCurrencyEngineCallbacks = {
     onAddressChanged() {},
@@ -137,7 +141,9 @@ async function makeEngine(
     onSubscribeAddresses() {},
     onSyncStatusChanged() {},
     onTokenBalanceChanged() {},
-    onTransactions() {},
+    onTransactions(transactionEvents) {
+      events.push(...transactionEvents)
+    },
     onTransactionsChanged() {},
     onTxidsChanged() {},
     onUnactivatedTokenIdsChanged() {},
@@ -184,8 +190,10 @@ async function makeEngine(
 
   return {
     engine,
+    events,
     queryTransactions: async () => {
       await engine.queryTransactions()
+      engine.sendTransactionEvents()
     },
     requests,
     storedTx: (txid: string) => {
@@ -255,5 +263,23 @@ describe('ZanoEngine.queryTransactions', function () {
     assert.equal(storedTx('c149')?.blockHeight, 249)
     assert.equal(engine.otherData.transactionQueryOffset, 149)
     assert.isBelow(requests.length, 5)
+  })
+
+  it('reports an unconfirmed receive as a new transaction', async function () {
+    // A mempool receive enters the store at blockHeight 0, which the base
+    // checkpoint math reads as already seen, so without the engine's
+    // `isTransactionNew` override the core would only ever hear about it as a
+    // change and the receive dropdown would never fire.
+    const wallet: FakeWallet = {
+      history: [makeTransfer('c0', 100)],
+      unconfirmed: [makeTransfer('mempool', 0)]
+    }
+    const { events, queryTransactions } = await makeEngine(wallet, 1)
+
+    await queryTransactions()
+
+    const event = events.find(event => event.transaction.txid === 'mempool')
+    assert.isDefined(event)
+    assert.isTrue(event?.isNew)
   })
 })


### PR DESCRIPTION
### Technical Design Document

[zano-migration-off-module-queue.md](https://github.com/EdgeApp/react-native-zano/blob/jon/ios-perf-zano-xmr/src/docs/zano-migration-off-module-queue.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/react-native-zano/pull/17 (behavioral, not build-time: the adopt-path `run_wallet` call only matters under that PR's postponed-run mode, and is a harmless no-op on react-native-zano 0.4.0, so this PR builds and passes CI standalone)

### Description

Part of the fix for the iOS performance regression investigated in https://app.asana.com/0/1215088146871429/1217559756673909. Two changes ship here.

**1. Transaction query: mempool sweep and loop termination** (fixes the report from David: a sent transaction never appears in the receiving wallet, no incoming notification, and the sender stays pending even after the transaction has confirmations)

- `get_recent_txs_and_info2` prepends a wallet's unconfirmed transfers only when the offset is zero, so once a wallet had any confirmed history the paged catch-up could never see a transaction before it was mined. `queryTransactions` now sweeps offset zero on every poll, then pages from the persisted offset. The extra request returns at most 100 in-memory entries and is idempotent for transactions already known.
- The paging loop terminated only on the `total_transfers - last_item_index === 1` identity. `last_item_index` counts just the transfers the wallet returned, so a page whose newest entries were all filtered out (mining and defragmentation transfers are excluded by request) leaves it permanently short of that identity and the loop re-requested the same page forever, starving every later balance and transaction update for that wallet. Termination now depends on the offset actually advancing.

**2. Receive notification for swept transfers** (the other half of David's "no incoming notification")

- A transfer the mempool sweep surfaces enters the store at block height zero. `CurrencyEngine.isTransactionNew` compares a transaction's checkpoint, which is its block height, against the wallet's last seen checkpoint, so zero reads as already seen and the arrival reaches the core as a change rather than a new transaction. The confirmation that follows takes `addTransaction`'s update path, a change as well, so the GUI's receive dropdown never fired for a Zano transfer at all.
- `ZanoEngine` now overrides `isTransactionNew` the same way `MoneroEngine` and `ZcashEngine` already do: an incoming unconfirmed transaction is new once the wallet has a seen checkpoint. The same multi-device caveat those engines carry applies, since a second device tracks its own checkpoint.

**3. Wallet-file persistence and adopted wallets**

- The Zano native library only writes the wallet file when a wallet closes, and a mobile app is killed rather than closed, so sync progress was almost never persisted and every cold launch re-scanned a window that only grows (measured ~200-420% process CPU for ~6 minutes per launch on a sim account whose three Zano wallets were 26 days behind). `syncNetwork`'s synced branch now stores the wallet file through the per-wallet RPC (`invoke {"method":"store"}`): once when the wallet first reaches synced, then at most every ten minutes, and only when the wallet height advanced past the last store. It runs only while synced, when the refresh worker is idle and the per-wallet lock is free, so the call cannot block behind a scan.
- The ALREADY_EXISTS adopt path now starts the refresh worker (`run_wallet`, idempotent) for the adopted wallet. Under react-native-zano's postponed-run mode a wallet left open by an interrupted `startWallet` is not yet running, and adopting it without this call would hand back a wallet that never syncs.
- `resyncBlockchain` resets the store gates, so the rebuilt wallet's file is written at the first synced tick after the rescan instead of waiting out the throttle.

### Testing

Unit tests: `test/zano/ZanoEngineQueryTransactions.test.ts` drives `queryTransactions` against a fake wallet mirroring the two SDK behaviors the fix turns on, both read from the pinned Zano source (`wallet_rpc_server.cpp:476-505`, `wallet2.cpp:4580-4618`). Against the pre-fix code the filtered-tail case hangs (killed at 120 seconds, reproducing the infinite loop directly); with the fix, 3/3 pass.

In-app, iOS simulator (edge-funds, two Zano wallets), with this branch plus react-native-zano#17 and edge-core-js#738 linked: sent 0.063 ZANO between the two wallets and watched both sides. The receiving wallet showed the incoming transaction while it was still unconfirmed, then moved through its confirmation count; the sending wallet moved from pending through confirmations to confirmed. Both are the exact symptoms of the report. Proof frames are attached in a comment below.

The receive notification was driven separately on 2026-08-22, with `AccountCallbackManager` and `ReceiveDropdown` instrumented locally to trace every transaction event (instrumentation reverted). Before the override, two 0.063 ZANO transfers reached the receiving wallet as `transactionsChanged` only and raised no dropdown, with a 2-second screenshot loop covering the whole arrival window. After it, a third transfer produced `newTransactions` on the receiving wallet 21 seconds after broadcast, while the transfer was still unconfirmed, and the "0.0634 ZANO Received" dropdown rendered. The new fourth unit case covers the same path and fails against the pre-fix engine; the suite is 530 passing.

Wallet-file persistence was verified separately on the same sim: after each wallet reached synced its file was rewritten within the interval (1.7KB restore stubs grew to 80-158KB full wallets), and a subsequent relaunch opened all three wallets already at the chain tip with no catch-up scan.

