### PR TITLE
Update react-native-zano to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: (Zano) Update react-native-zano to ^0.5.0, which delivers payment ids per destination under HF6, starts wallets with the refresh worker postponed, and refuses to run when iOS cannot protect the wallet directory.
 - fixed: (Zano) Count confirmations from the chain tip. The wallet status reports the daemon's block count next to a block height, and the engine took the larger of the two, so every wallet sat one block past the tip: a fresh transfer opened at "2 of 10 Confirmations" and reached confirmed a block early.
 - fixed: (Zano) Payment ids reach the recipient again under HF6. The node now rejects the request-level payment id, so a payment id memo is delivered by folding it into the destination instead: a plain address plus an 8-byte id becomes the matching integrated address on the user's behalf, an integrated destination requires the supplied id to agree with the embedded one, and an id no integrated address can encode is refused with clear guidance rather than padded or silently dropped. The payment id memo field now requires exactly 8 bytes, the fixed size of an HF6 intrinsic payment id.
 - fixed: (Zano) Persist the wallet file once a wallet reaches synced and every ten minutes afterwards. The native library only writes the file when a wallet closes, and a mobile app is killed rather than closed, so every launch re-scanned everything since the file was last written -- a catch-up window that only grew, re-paid at full multi-core CPU on each cold start.

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "querystring": "^0.2.1",
         "react-native-monero": "0.5.0",
         "react-native-piratechain": "0.5.0",
-        "react-native-zano": "^0.4.0",
+        "react-native-zano": "^0.5.0",
         "react-native-zcash": "0.13.1",
         "rimraf": "^3.0.2",
         "shell-quote": "^1.8.1",
@@ -132,7 +132,7 @@
       "peerDependencies": {
         "react-native-monero": "^0.5.0",
         "react-native-piratechain": "v0.5.0",
-        "react-native-zano": "^0.4.0",
+        "react-native-zano": "^0.5.0",
         "react-native-zcash": "^0.13.1"
       }
     },
@@ -15635,13 +15635,14 @@
       }
     },
     "node_modules/react-native-zano": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-zano/-/react-native-zano-0.4.0.tgz",
-      "integrity": "sha512-kbh+EYJ8MkNnLyWXlnb5tYz/eMlxRk1mEKRmMtJD7fnkxZtrNQ8N3KERNagWLewhXBAMaOXAVUx2OvuV0adT3A==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-zano/-/react-native-zano-0.5.0.tgz",
+      "integrity": "sha512-kxBSIVoKoRpOXoEyowoztIwueUKDbQ82K9T8SqHtR17rVB4Cd7tRXvp80nedym5rQXFv5ak3haV1DyyG90vUXQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "cleaners": "^0.3.17",
+        "rfc4648": "^1.5.4",
         "tweetnacl": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "querystring": "^0.2.1",
     "react-native-monero": "0.5.0",
     "react-native-piratechain": "0.5.0",
-    "react-native-zano": "^0.4.0",
+    "react-native-zano": "^0.5.0",
     "react-native-zcash": "0.13.1",
     "rimraf": "^3.0.2",
     "shell-quote": "^1.8.1",
@@ -188,7 +188,7 @@
   "peerDependencies": {
     "react-native-monero": "^0.5.0",
     "react-native-piratechain": "v0.5.0",
-    "react-native-zano": "^0.4.0",
+    "react-native-zano": "^0.5.0",
     "react-native-zcash": "^0.13.1"
   },
   "overrides": {

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -1,5 +1,5 @@
 import { abs, add, eq, gt, lt, mul, sub } from 'biggystring'
-import { asJSON, asMaybe, asObject, asValue } from 'cleaners'
+import { asJSON, asMaybe, asObject } from 'cleaners'
 import {
   EdgeCurrencyEngine,
   EdgeCurrencyEngineOptions,
@@ -69,9 +69,6 @@ const CATCHUP_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000
 
 /** The wallet RPC answers a successful store with a result object. */
 const asStoreResponse = asObject({ result: asObject({}) })
-
-/** A successful run_wallet answers with error_code OK. */
-const asRunWalletResponse = asObject({ error_code: asValue('OK') })
 
 /**
  * Converts the wallet status' `current_daemon_height` into a block height.
@@ -225,25 +222,14 @@ export class ZanoEngine extends CurrencyEngine<
             `initializeWallet: found existing wallet with ID ${existingWallet.wallet_id}`
           )
 
-          // Newer react-native-zano opens wallets with the refresh
-          // worker postponed, so a wallet left open by an interrupted
-          // `startWallet` may not be syncing; the postponed-run flag is
-          // process-wide and sticky, so the adopt path cannot know which way
-          // it was opened and must start the worker itself. On 0.4.0, where
-          // open auto-starts the worker, the same call is a harmless no-op.
-          // A failure here must throw: returning the id would mark the
-          // lifecycle started and hand back a wallet that never syncs,
-          // while throwing lets the next `get()` retry the whole start.
-          const runResponse = await this.tools.zano.syncCall(
-            'run_wallet',
-            existingWallet.wallet_id,
-            ''
-          )
-          if (asMaybe(asJSON(asRunWalletResponse))(runResponse) == null) {
-            throw new Error(
-              `initializeWallet: could not run the adopted wallet: ${runResponse}`
-            )
-          }
+          // `startWallet` opens wallets with the refresh worker postponed,
+          // so a wallet left open by an interrupted start may not be
+          // syncing; the adopt path must start the worker itself.
+          // `runWallet` is idempotent, and a failure here must throw:
+          // returning the id would mark the lifecycle started and hand back
+          // a wallet that never syncs, while throwing lets the next `get()`
+          // retry the whole start.
+          await this.tools.zano.runWallet(existingWallet.wallet_id)
 
           return existingWallet.wallet_id
         }

--- a/src/zano/zanoTypes.ts
+++ b/src/zano/zanoTypes.ts
@@ -91,8 +91,7 @@ export const asZanoTransferParams = asObject<TransferParams>({
   ),
 
   comment: asOptional(asString),
-  fee: asNumber,
-  paymentId: asOptional(asString)
+  fee: asNumber
 })
 
 export const createZanoTokenId = (token: EdgeToken): string => {

--- a/test/builtinTokens.test.ts
+++ b/test/builtinTokens.test.ts
@@ -18,7 +18,11 @@ const fakePluginOptions: EdgeCorePluginOptions = {
       zcash: {}
     },
     monero: {},
-    zano: {}
+    // Mirrors a healthy native module: react-native-zano >=0.5.0 fails
+    // closed at construction when the iOS side reports no document
+    // directory, since that means the wallet directory could not be
+    // created or excluded from device backups.
+    zano: { documentDirectory: '/fake/documents' }
   },
   pluginDisklet: fakeIo.disklet
 }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none — consumes react-native-zano 0.5.0, now published.

### Description

The merge step promised on EdgeApp/edge-currency-accountbased#1092: bump the
`react-native-zano` pin to the 0.5.0 release that EdgeApp/react-native-zano#18
produced, and adopt what it exports.

**Pin `^0.4.0` → `^0.5.0`** (dependencies and peerDependencies).

**Drop `paymentId` from `asZanoTransferParams`.** 0.5.0 removed the field from
`TransferParams` — since HF6 the node rejects the request-level payment id
outright, and this engine already folds a payment id memo into an integrated
destination address instead. A stale id smuggled through `otherParams` now
fails the clean rather than reaching the wire.

**Adopt path uses the exported `runWallet`.** Replaces the raw
`syncCall('run_wallet', ...)` and the local `error_code` cleaner, so the
run_wallet response contract — including the native quirk where one failure
path answers with a bare return-code string — lives in one repo. Closes the
remaining thread from the #1092 review.

**`builtinTokens` fake models a healthy native module.** 0.5.0's bridge fails
closed at construction when the iOS module reports no document directory (the
signature of a wallet directory that could not be created or excluded from
device backups), so the test's `zano: {}` stub gains a `documentDirectory`.
Behavior note for reviewers: on a device where directory protection fails,
the Zano plugin now fails at tools construction rather than at engine start —
loud and early, and nothing Zano could safely do there anyway.

### Testing

`tsc`, eslint, and the full suite (550 passing) against the installed 0.5.0.
The only runtime break the upgrade surfaced was the fail-closed constructor
meeting the incomplete test stub, addressed above; the compile break was the
removed `paymentId` field.
