### PR TITLE
Disable Zano catch-up checkpoints on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: (Zano) Disable catch-up checkpointing on Android, where the native library's close-during-scan lock inversion deadlocks the wallet subsystem permanently -- the freeze QA hit about seven minutes after login. Android trades mid-catch-up persistence for never deadlocking until the SDK fix lands; iOS checkpointing is unchanged.
+- fixed: (Zano) Run at most one checkpoint close/reopen cycle at a time across wallets. Every wallet baselines its checkpoint clock at login, so first cycles all fired together; a deferred wallet retries on its next tick.
+
 ## 4.89.0 (2026-08-25)
 
 - changed: (Zano) Update react-native-zano to ^0.5.0, which delivers payment ids per destination under HF6, starts wallets with the refresh worker postponed, and refuses to run when iOS cannot protect the wallet directory.

--- a/src/zano/ZanoEngine.ts
+++ b/src/zano/ZanoEngine.ts
@@ -116,6 +116,36 @@ export class ZanoEngine extends CurrencyEngine<
    * defers while this is set.
    */
   private spendPending: boolean = false
+  /**
+   * True on Android, where catch-up checkpointing is disabled outright.
+   *
+   * The native `close_wallet` holds the manager's global wallets lock
+   * exclusively while it waits for the per-wallet lock, and the refresh
+   * worker -- which holds that per-wallet lock for the whole scan -- takes
+   * the same global lock shared down its own callstack (the SDK warns about
+   * exactly this ordering at wallets_manager.cpp:2159). Whether that
+   * becomes a deadlock depends on the platform's reader-writer lock policy:
+   * a waiting writer blocks new readers on Android's implementation but not
+   * on iOS's, so an identical close-during-scan deadlocks Zano permanently
+   * on Android devices (reproduced twice at first checkpoint collision;
+   * matches QA's freeze at ~7 minutes) while iOS has run hundreds of
+   * checkpoint cycles clean. Until the SDK reorders close_wallet, Android
+   * trades mid-catch-up persistence for never deadlocking: a scan killed
+   * partway re-pays the whole catch-up, exactly the pre-checkpoint cost.
+   * Detected by the native module's document directory, which only Android
+   * roots under /data.
+   */
+  private readonly checkpointUnsafe: boolean
+  /**
+   * True while any wallet's checkpoint close/reopen cycle is in flight,
+   * shared across every Zano engine in this context. Overlapping cycles
+   * multiply the close-during-scan windows -- every wallet baselines its
+   * checkpoint clock at login, so without this gate all wallets fire their
+   * first cycle nearly simultaneously. Deliberately never cleared if a
+   * cycle hangs: piling further closes into a stuck wallets_manager only
+   * stacks more blocked native calls.
+   */
+  private static checkpointInFlight: boolean = false
 
   constructor(
     env: PluginEnvironment<ZanoNetworkInfo>,
@@ -125,6 +155,12 @@ export class ZanoEngine extends CurrencyEngine<
   ) {
     super(env, tools, walletInfo, opts, makeWeightedSyncTracker)
     this.networkInfo = env.networkInfo
+
+    const zanoModule = env.nativeIo?.zano as
+      | { documentDirectory?: string }
+      | undefined
+    this.checkpointUnsafe =
+      zanoModule?.documentDirectory?.startsWith('/data') ?? false
 
     this.unlockedBalanceMap = new Map()
 
@@ -566,6 +602,7 @@ export class ZanoEngine extends CurrencyEngine<
       this.lastCheckpointHeight = walletHeight
       return
     }
+    if (this.checkpointUnsafe) return
     if (now - this.lastCheckpointTime < CATCHUP_CHECKPOINT_INTERVAL_MS) return
     if (walletHeight <= this.lastCheckpointHeight) return
     // A broadcast in flight holds the native id it already resolved, and
@@ -573,6 +610,10 @@ export class ZanoEngine extends CurrencyEngine<
     // without touching the gates, so the checkpoint fires on the first tick
     // after the spend clears rather than waiting out another interval:
     if (this.spendPending) return
+    // One cycle at a time across all wallets; a deferred wallet retries on
+    // its next tick rather than waiting out a fresh interval:
+    if (ZanoEngine.checkpointInFlight) return
+    ZanoEngine.checkpointInFlight = true
 
     this.log(
       `checkpointCatchup: persisting catch-up progress at height ${walletHeight}`
@@ -580,6 +621,7 @@ export class ZanoEngine extends CurrencyEngine<
     const generation = this.storeGeneration
     this.nativeId.stop()
     const nativeId = await this.nativeId.get()
+    ZanoEngine.checkpointInFlight = false
     // A resync between the stop and the reopen reset the gates for a wallet
     // that no longer holds this height. Writing them back would gate the
     // rebuilt wallet at a tip it has not re-reached, disabling checkpoints

--- a/test/fake/fakeZanoEngine.ts
+++ b/test/fake/fakeZanoEngine.ts
@@ -24,12 +24,18 @@ export const FAKE_ZANO_ADDRESS = 'ZxTestAddress'
  */
 export async function makeFakeZanoEngine(
   opts: {
+    /** Injected as `env.nativeIo`, e.g. to model a platform's native module. */
+    nativeIo?: unknown
     /** Receives every transaction event the engine hands to the core. */
     onTransactions?: (events: EdgeTransactionEvent[]) => void
     tools?: ZanoTools
   } = {}
 ): Promise<ZanoEngine> {
-  const { onTransactions = () => {}, tools = {} as unknown as ZanoTools } = opts
+  const {
+    nativeIo,
+    onTransactions = () => {},
+    tools = {} as unknown as ZanoTools
+  } = opts
   const fakeIo = makeFakeIo()
 
   const callbacks: EdgeCurrencyEngineCallbacks = {
@@ -73,6 +79,7 @@ export async function makeFakeZanoEngine(
     currencyInfo,
     io: fakeIo,
     log: fakeLog,
+    nativeIo,
     networkInfo
   } as unknown as PluginEnvironment<ZanoNetworkInfo>
 

--- a/test/zano/ZanoEngineCheckpoint.test.ts
+++ b/test/zano/ZanoEngineCheckpoint.test.ts
@@ -13,8 +13,12 @@ interface TestEngine {
   restarts: () => number
 }
 
-async function makeEngine(): Promise<TestEngine> {
-  const engine = await makeFakeZanoEngine()
+async function makeEngine(
+  opts: { nativeIo?: unknown } = {}
+): Promise<TestEngine> {
+  const engine = await makeFakeZanoEngine(opts)
+  // The single-flight gate is shared across engines; isolate each test:
+  ;(ZanoEngine as any).checkpointInFlight = false
 
   // A recording lifecycle stub: `stop` then `get` is one checkpoint cycle.
   let stops = 0
@@ -145,6 +149,54 @@ describe('ZanoEngine.checkpointCatchup', () => {
       ;(t.engine as any).resetCatchupCheckpoint()
       await t.checkpoint(9000)
       assert.equal(t.restarts(), 0)
+    })
+  })
+
+  it('never checkpoints when the native module is Android', async () => {
+    // Android's reader-writer lock policy turns the SDK's close-during-scan
+    // lock inversion into a permanent deadlock, so catch-up checkpointing
+    // is disabled there until the SDK reorders close_wallet.
+    await withClock(async advance => {
+      const t = await makeEngine({
+        nativeIo: {
+          zano: { documentDirectory: '/data/user/0/co.edgesecure.app/files' }
+        }
+      })
+      await t.checkpoint(100)
+      advance(INTERVAL_MS + 1000)
+      await t.checkpoint(5000)
+      advance(INTERVAL_MS + 1000)
+      await t.checkpoint(9000)
+      assert.equal(t.restarts(), 0)
+    })
+  })
+
+  it('runs one checkpoint cycle at a time across engines', async () => {
+    // Every wallet baselines its clock at login, so first cycles land
+    // together. While one engine's reopen is still pending, another
+    // engine's due checkpoint defers -- and retries on its next tick once
+    // the gate clears, without waiting out a fresh interval.
+    await withClock(async advance => {
+      const a = await makeEngine()
+      const b = await makeEngine()
+      // Make A's reopen hang, holding the shared gate:
+      let releaseA: (value: number) => void = () => {}
+      ;(a.engine as any).nativeId.get = async () =>
+        await new Promise<number>(resolve => {
+          releaseA = resolve
+        })
+      await a.checkpoint(100)
+      await b.checkpoint(100)
+      advance(INTERVAL_MS + 1000)
+      const pending = a.checkpoint(5000) // fires, hangs in reopen
+      await b.checkpoint(5000) // due, but deferred by the gate
+      assert.equal(b.restarts(), 0)
+
+      releaseA(0)
+      await pending
+      await b.checkpoint(6000) // next tick: gate clear, fires immediately
+      assert.equal(b.restarts(), 1)
+      assert.equal(a.restarts(), 1)
     })
   })
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none — companion to EdgeApp/react-native-zano#20, but each lands
independently. #20 contains the app-wide blast radius on Android; this PR
removes the deadlock trigger there.

### Description

Fixes the Android freeze QA reported at ~7 minutes after login (frozen sync
banner, dead buttons, working scroll/drawer, permanent until restart) at its
trigger: the catch-up checkpoint's close-during-scan.

**The deadlock.** `close_wallet` holds the SDK's global wallets lock
exclusively while waiting for the per-wallet lock; the refresh worker holds
that per-wallet lock for the whole scan and takes the same global lock shared
down its own callstack (`wallets_manager.cpp:2159` documents the ordering
hazard). Whether the circle closes depends on the platform's rwlock policy:
iOS lets waiting readers through — hundreds of clean checkpoint cycles across
this effort's device testing — while Android's writer preference blocks them.
On an API 35 emulator with checkpoints tortured to 30s intervals, the first
collision deadlocked Zano permanently in 2 of 2 runs (a call stuck in
`callZanoJNI` for 10+ minutes, checkpoint writes never resuming). QA hits it
at ~7 minutes because every wallet baselines its checkpoint clock at login,
so all wallets fire their first cycle nearly simultaneously at the 5-minute
mark.

**The change, two parts:**

1. **Android skips catch-up checkpointing** (detected via the native module's
   document directory under `/data`). The trade is explicit: a scan killed
   partway on Android re-pays the whole catch-up — exactly the
   pre-checkpoint status quo — and never deadlocks. iOS checkpointing is
   unchanged. This is containment, not the fix; it reverts cleanly once the
   SDK reorders `close_wallet` so it no longer holds the global lock while
   waiting on the wallet lock (upstream ask to follow).
2. **Checkpoint cycles are single-flight across wallets**, so the
   login-synchronized first round staggers across ticks instead of piling
   closes into the native layer together. A cycle that hangs deliberately
   quarantines checkpointing rather than stacking more blocked native calls.
   Note this alone cannot prevent the deadlock — the inversion is between
   one wallet's close and its own worker — which is why Android needs part 1.

### Testing

Two new tests: Android never checkpoints across multiple due intervals, and a
hung cycle on one engine defers another engine's due checkpoint, which then
fires on its next tick after release. Both mutation-verified (removing either
gate fails exactly its test). Checkpoint suite 10/10; full suite passing.
Sync-progress persistence for synced wallets (the 10-minute store) is
untouched on both platforms — it does not close during a scan.
