### PR TITLE
Robinhood Chain: keyed transaction history via Alchemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-- added: Robinhood Chain support (`robinhood`, EVM chain 4663), an Arbitrum Nitro L2 with ETH as its gas token. Transaction history comes from the chain's Blockscout instance, since Etherscan V2 does not cover this chain, and fees use the Arbitrum `NodeInterface` L1-component estimate. Built-in tokens are USDC, USDT, USDG, WBTC, WETH, CASHCAT and PONS.
+- added: Robinhood Chain support (`robinhood`, EVM chain 4663)
+- added: (EVM) Alchemy and Blockscout network adapters
+- added: (Robinhood Chain) Transaction history and token balances from Alchemy, with Blockscout as fallback
 - fixed: (Avalanche) Remove unreachable avascan and snowscan evmscan servers
 - fixed: (HyperEVM) Tokens are detected automatically
+- fixed: (EVM) Blockscout "Too many requests" replies are recognized as rate limits
 
 ## 4.90.1 (2026-08-28)
 

--- a/src/docs/robinhood-chain.md
+++ b/src/docs/robinhood-chain.md
@@ -106,24 +106,34 @@ sequenceDiagram
 
 The plugin is one new file plus a two-line registration.
 
-[`src/ethereum/info/robinhoodInfo.ts`](https://github.com/EdgeApp/edge-currency-accountbased/blob/b821eb39fd62922dbf2c5412a5cbaaa70a702300/src/ethereum/info/robinhoodInfo.ts)
+[`src/ethereum/info/robinhoodInfo.ts`](https://github.com/EdgeApp/edge-currency-accountbased/blob/master/src/ethereum/info/robinhoodInfo.ts)
 ```ts
 const networkInfo: EthereumNetworkInfo = {
   // Blocks arrive about every 96ms, so this is the usual ~2 minute overlap
   addressQueryLookbackBlocks: 1250,
   networkAdapterConfigs: [
     {
+      // Keyed history source. Alchemy does not serve the `internal` category
+      // on this network, so ETH paid out to the wallet from inside a contract
+      // call is only seen while the Blockscout fallback below is answering.
+      type: 'alchemy',
+      servers: ['https://robinhood-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}']
+    },
+    {
       type: 'rpc',
       servers: [
         'https://rpc.mainnet.chain.robinhood.com',
-        'https://robinhood-rpc.publicnode.com'
-      ]
+        'https://robinhood-rpc.publicnode.com',
+        'https://robinhood-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}'
+      ],
+      ethBalCheckerContract: '0x8950F12786CAE64F94a02733A260ca6FecDaeD7f'
     },
     {
-      // Etherscan V2 does not support chain 4663, so transaction history comes
-      // from the chain's Blockscout instance, which has no gastracker module.
-      type: 'evmscan',
-      gastrackerSupport: false,
+      // Etherscan V2 does not support chain 4663. The chain's public Blockscout
+      // instance (300 requests per minute per IP) supplies the internal
+      // transactions Alchemy lacks here, merged into every native-asset sync,
+      // and is the history fallback when Alchemy fails.
+      type: 'blockscout',
       servers: ['https://robinhoodchain.blockscout.com']
     }
   ],
@@ -152,7 +162,15 @@ const networkInfo: EthereumNetworkInfo = {
 
 `arbitrumRollupParams` is what selects the L1-component fee path in `EthereumEngine`. `hdPathCoinType: 60` puts wallets on the standard Ethereum derivation path, so one seed produces the same address here as on mainnet, which is what a bridged user expects.
 
-No `ethBalCheckerContract` is set. Every one of the five [eth-balance-checker](#eth-balance-checker) addresses that other Edge plugins use returns empty code on this chain, so `RpcAdapter.fetchTokenBalances` is left undefined and token balances resolve through per-token calls, as they do on `hyperevm` and `botanix`.
+### History source
+
+`EthereumNetwork.check` runs the adapters that implement a method through `asyncWaterfall`: the first adapter starts alone, the next one starts when the current one fails or has not resolved within 5 seconds, and from then on the outstanding adapters race, with the first successful result winning the call and the loser's result discarded while its request runs to completion. `fetchInternalTxs` goes through the same `check`, so `mergeInternalTxs` has the same behavior. With `alchemy` listed first, transaction history and token balances come from Alchemy's `alchemy_getAssetTransfers` and `alchemy_getTokenBalances`, keyed by the plugin's `alchemyApiKey` init option, and the public [Blockscout](#blockscout) instance only wins those calls while Alchemy is failing or slower than the 5-second start delay. Internal transactions are the exception: `fetchInternalTxs` is its own adapter method, the `blockscout` adapter is the only one here that implements it, and `EthereumNetwork.acquireTxs` asks for it on every native-asset sync whose `fetchTxs` rows did not already carry internal transfers (the tuple's `includesInternal` flag), merging the rows with `mergeEdgeTransactions` before the engine sees them. The merge has to happen inside one pass because `addTransaction` replaces a known transaction whose amount changed, so the external and internal halves of one transaction must arrive as a single row. The key reaches the plugin through `ROBINHOOD_INIT.alchemyApiKey` in the app's `env.json`; the `AlchemyAdapter` constructor drops a server whose placeholder has no init option, so a build without the key simply falls back to Blockscout.
+
+`AlchemyAdapter` lives in `src/ethereum/networkAdapters/AlchemyAdapter.ts` and is written for any network Alchemy serves. Asset transfers are value movements rather than transactions and carry no gas data, so the adapter completes the wallet's own spends with `eth_getTransactionByHash` and `eth_getTransactionReceipt` from the same endpoint, then folds the rows per transaction hash with the amount and fee conventions of `processEvmScanTransaction`. Native-asset queries ask for `external` and `internal` together; Alchemy rejects the `internal` category on this network (`-32602 The 'internal' category is not supported for this network`), so the adapter remembers the rejection per endpoint, re-queries with `external` alone, and leaves internal transfers to `fetchInternalTxs`. On a network where Alchemy does serve the category the same code returns them and marks the tuple `includesInternal`, and no Blockscout adapter is needed. A failed transaction moves no value, so a reverted send only shows up through Blockscout's `txlist` while Blockscout is winning the `fetchTxs` call.
+
+`BlockscoutAdapter` (`type: 'blockscout'`) extends `EvmScanAdapter` for the places Blockscout differs from Etherscan: block height from `module=block&action=eth_block_number`, no gastracker module, internal transactions through `fetchInternalTxs` (`txlistinternal`) instead of folded into `fetchTxs`, and a `status: "2"` reply, "Some internal transactions within this block range have not yet been processed", accepted as a success carrying the rows indexed so far (the 1250-block lookback re-covers the rest on the next sync). The public instance allows 300 requests per minute per client IP; past that it answers `{"message":"Too many requests. Increase limits now at https://dev.blockscout.com","result":null,"status":"0"}`, which `isEvmScanRateLimitResponse` classifies as a `RateLimitError` so `serialServers` backs off. Cloudflare in front of this instance also answers a managed challenge page (HTTP 403, `cf-mitigated: challenge`) to every request whose user agent is not browser-like, from any IP: measured on 2026-09-03 from the build host and from a phone on mobile data, the app's CFNetwork and OkHttp agents got the challenge and a Chrome agent string got the JSON, while `eth.blockscout.com` answered every agent. The adapter therefore sends a browser user agent on its `/api` requests, the same workaround `BlockbookAdapter` applies to Trezor's Blockbook servers.
+
+`ethBalCheckerContract` points at an [eth-balance-checker](#eth-balance-checker) deployed to `0x8950F12786CAE64F94a02733A260ca6FecDaeD7f` in block 52107662 on 2026-09-01, byte-for-byte the runtime that Edge's other EVM plugins use at `0x7263…`. `RpcAdapter.fetchTokenBalances` is therefore defined and sits behind Alchemy's `alchemy_getTokenBalances` in the waterfall, so token balances stay batched even when Alchemy is unavailable.
 
 ### Fees
 
@@ -291,6 +309,9 @@ That asymmetry is itself worth fixing: a chain added to `coingeckoPlatformIdMapp
 12. **Rates, local instance of the branch.** Against local CouchDB and Redis, with the real provider code path and nothing stubbed: seeding the databases wrote `robinhood` into all eight documents, confirming the fresh-deploy path. Stripping `robinhood` back out of all eight, so the local database matched an existing deployment, left the patched server still returning no rate, which is what proves the stored document wins over the code default at runtime. Running the `tokenMapping` engine once then added `robinhood: {id: 'ethereum'}` to `coingecko:automated` while `coingecko:platforms`, `tokenTypes` and `platformPriority` stayed empty, exactly as the template semantics predict, and the native rate resolved at 1878.73 against `ethereum` at 1878.73.
 13. **Rates, cross-chain remap in isolation.** Sentinel rates were seeded in `constantrates` on the Ethereum token keys only, USDC 111.111, USDT 222.222 and WBTC 333.333. Querying the Robinhood Chain token ids returned each sentinel, a value reachable only through the remap, and an unmapped Robinhood Chain address returned no rate, which rules out a blanket fallthrough.
 14. **Rates, in-app.** With the app pointed at that local instance, the wallet list rendered ETH on Robinhood Chain at `$1,877` per unit and `-0.14%`, and My Robinhood Chain's `0.005247 ETH` as `$9.85`. The same rows had rendered `$0` throughout phases 1 and 2.
+15. **Unit, history source.** `test/ethereum/network/alchemyTxProcessing.test.ts` folds captured `alchemy_getAssetTransfers` rows into EdgeTransactions for a receive, a spend, a self-send seen from both query directions, a zero-value contract call, a token receive, a token spend, and a token pull the wallet did not sign, and checks the amounts, fees and `parentNetworkFee` against the evmscan conventions. `test/ethereum/network/evmScanRateLimit.test.ts` feeds the captured Blockscout throttle reply and the Etherscan variants to `isEvmScanRateLimitResponse`.
+16. **In-app, history from Alchemy.** With the plugin linked into the app on the iOS simulator and three Robinhood Chain wallets of one account syncing at once, the engine log reports `processEthereumNetworkUpdate tokenTxs robinhood-mainnet.g.alchemy.com won` and the same for `tokenBal` on every sync, with no Blockscout request and no throttle reply in the log. The wallet's transaction list rendered the earlier sends and receives, and a real send of 0.0005389 ETH to `0xeC892dfb84B3c0567Cc2A7118A0885aC6D109Cf3` reached the "Transaction Success" scene; transaction `0xe2be5265fa03f9704960c31d7aa8bbe5fb839a82d7d9c280690be49fc0d21419` is in block 52101999.
+17. **Balance checker, on chain.** After deployment, `eth_getCode` at the new address returns the 2234-byte runtime that the Sonic and Celo checkers hold, and `balances([0x9488ee…], [USDC, 0x0])` answers `[0, <wallet balance in wei>]` through the same `ETH_BAL_CHECKER_ABI` call `RpcAdapter.fetchTokenBalances` makes.
 
 ## 10. Phase history
 
@@ -418,6 +439,14 @@ So neither direction owed anything: every token the rates PR tracks is already a
 
 Scope added in this phase: none.
 
+### Phase 8: keyed transaction history
+
+The cheese re-test of phase 7 ran two simulators on one IP and lost wallet history: Blockscout's public API allows 300 requests per minute per client IP, and past that it answered every history call with `{"message":"Too many requests…","result":null,"status":"0"}`. The engine did not recognize that reply as throttling, so it never backed off, the transaction list stayed empty, one send sat at unconfirmed, and the send slider stayed blocked with "Pending Transaction" until a wallet resync. Balances were unaffected because they come from RPC.
+
+No other Edge-held key covers chain 4663 (Etherscan V2's chain list lacks it; Blockchair, NowNodes, Amberdata and Routescan do not serve it; dRPC, QuickNode and Pocket serve RPC only), and a Blockscout Pro key is shared by every app install, so the chain was enabled on the Alchemy app the user base already runs on for every other EVM chain. This phase added the `alchemy` network adapter and put it first, taught `EvmScanAdapter` to classify Blockscout's throttle reply as a rate limit, deployed the eth-balance-checker to the chain, and corrected the retrospective's claim that a Blockscout key would have removed the limit without a code change. Review of the first PR round caught that "Blockscout stays the source of internal transactions" was false under waterfall dispatch (Blockscout is never asked while Alchemy answers), so the phase grew a `fetchInternalTxs` adapter method, a `blockscout` adapter that implements it, and the engine-side merge that folds those rows into each native-asset sync; the Alchemy adapter now asks for `internal` too and remembers when a network rejects the category.
+
+Scope added in this phase: `AlchemyAdapter`, reusable on any Alchemy-served chain; `BlockscoutAdapter` and the `fetchInternalTxs` adapter method; the `apiKeyTemplate` helper shared with `RpcAdapter`; the balance checker at `0x8950F12786CAE64F94a02733A260ca6FecDaeD7f`.
+
 ## 11. Decisions
 
 ### Decision 1: pluginId is `robinhood`
@@ -430,9 +459,9 @@ Rejected: `hood`, from the task title. HOOD is Robinhood's stock ticker and this
 
 Reopens if: Edge adds a Robinhood brokerage ramp or swap plugin. `corePlugins.ts` merges `currencyPlugins` and `swapPlugins` into one ID space, so that plugin would have to pick a different name.
 
-### Decision 2: history comes from Blockscout, not Etherscan V2
+### Decision 2: history comes from Alchemy, internal transactions from Blockscout
 
-Chosen because it is the only Etherscan-compatible API that answers for this chain. Its `account` module serves `balance`, `txlist` and `tokentx`, and `EvmScanAdapter` already special-cases [Blockscout](#blockscout) for `eth_blockNumber`.
+Chosen because Alchemy is the one keyed provider that serves the chain on a plan the user base already runs on, and its per-key quota is not shared with every other client behind an IP. Verified on `robinhood-mainnet.g.alchemy.com`: `eth_chainId` `0x1237`, `alchemy_getAssetTransfers` for `external` and `erc20` with `pageKey` pagination and `withMetadata` timestamps, `alchemy_getTokenBalances` and `alchemy_getTokenMetadata`. Phase 1 chose Blockscout as the only Etherscan-compatible API that answers for this chain; it now serves internal transactions through the `blockscout` adapter's `fetchInternalTxs` on every native sync (one `txlistinternal` call per wallet per sync instead of the nine calls of a full Blockscout sync) and stays second in the waterfall for everything else.
 
 Rejected: Etherscan V2. `GET /v2/api?chainid=4663` returns `Missing or unsupported chainid parameter`, and 4663 is absent from the 64 chains its `/v2/chainlist` lists.
 
@@ -440,15 +469,21 @@ Rejected: Routescan. `api.routescan.io/v2/network/mainnet/evm/4663` returns `cha
 
 Rejected: HoodScan, the second explorer `chainid.network` lists. It is a web application with no Etherscan-compatible `/api`.
 
-Reopens if: Etherscan adds chain 4663, which would also bring gas-oracle support and let `gastrackerSupport` flip to true.
+Rejected: a Blockscout API key. Per-instance keys are retired; a Blockscout Pro key is shared by every app install and its free tier is about 5,000 requests per day for the whole user base.
 
-### Decision 3: no `ethBalCheckerContract`
+Rejected: Alchemy's Data API `transactions/history/by-address`, which does not support this network.
 
-Chosen because nothing is deployed to check against. `eth_getCode` returns empty for all five balance-checker addresses in use across Edge's [EVM](#evm) plugins.
+Reopens if: Alchemy adds the `internal` category for this network, which the adapter would pick up on its own and which would make the `blockscout` entry a pure fallback; or Etherscan adds chain 4663, which would also bring gas-oracle support.
+
+### Decision 3: `ethBalCheckerContract` is a fresh deployment
+
+Chosen in phase 8, reopening phase 1's "nothing is deployed to check against": `eth_getCode` returned empty for all twelve balance-checker addresses in use across Edge's [EVM](#evm) plugins, so the checker was deployed. The runtime bytecode is the one the Sonic and Celo checkers hold at `0x7263…`, copied with `eth_getCode` and wrapped in a twelve-byte `CODECOPY`/`RETURN` init stub (the contract has no constructor and no immutables), and sent from a key generated for the purpose and funded by the phase's in-app test send. The address differs from `0x7263…` because that address came from a deployer key this work did not hold.
 
 Rejected: Multicall3 at `0xcA11bde05977b3631167028862bE2a173976CA11`, which is deployed here (7,618 bytes). `RpcAdapter.fetchTokenBalances` calls `balances(address[],address[])` from the [eth-balance-checker](#eth-balance-checker) [ABI](#abi), which Multicall3 does not implement, so pointing at it would fail every call.
 
-Reopens if: someone deploys eth-balance-checker to the chain.
+Rejected: leaving the checker out now that Alchemy batches token balances. Alchemy is first in the waterfall, but the checker keeps balances batched when it is unavailable, and the twelve-checker convention is what every other EVM plugin follows.
+
+Reopens if: the deployer of `0x7263…` deploys to this chain, in which case the shared address is preferable to a one-off one.
 
 ### Decision 4: built-in token addresses come from the gateway router
 
@@ -558,7 +593,7 @@ Optimism's rollup framework, used by Base, opBNB and others. Its fee model diffe
 
 ### What held
 
-The plugin needed no engine changes. `arbitrumRollupParams`, `supportsEIP1559` and the `evmscan` adapter's existing Blockscout branch covered the chain as configured, and the HTTP 429 path already raises `RateLimitError` and retries with exponential backoff, so no rate-limit handling had to be written.
+The plugin needed no engine changes in phases 1 through 7. `arbitrumRollupParams`, `supportsEIP1559` and the `evmscan` adapter's existing Blockscout branch covered the chain as configured. The claim that no rate-limit handling had to be written did not hold: the HTTP 429 path raises `RateLimitError`, but Blockscout's per-IP throttle answers HTTP 200 with the text in `message`, which nothing classified until phase 8.
 
 ### Verification highlights
 
@@ -570,4 +605,4 @@ The plugin needed no engine changes. `arbitrumRollupParams`, `supportsEIP1559` a
 - The funding swap delivered 6248511112300593 wei against a quoted 0.006243 ETH, slightly above quote, and the app rendered the figure to the wei once the engine's next balance poll landed. The poll is the lag to expect after any receive: the balance arrived on chain before the wallet scene showed it, and no resync was needed.
 - The send's destination was the `abandon abandon … about` test vector, whose private key is public. It was credited by the transaction above and drained to zero shortly after, so a destination-balance delta is not a usable check there. The transaction receipt is.
 - The public Blockscout instance returns HTTP 429 after a small number of requests from one egress address and recovers after about three minutes. During this run the simulator's own polling and the verification probes competed for that budget, so the transaction list was verified by forcing the response instead: `fetchGetEtherscan` was temporarily stubbed to return the address's two real rows, leaving the cleaner, `processEvmScanTransaction` and the list component untouched. The stub was reverted afterwards.
-- Its v2 API (`/api/v2/addresses/<addr>/transactions`) has a SEPARATE quota from the Etherscan-compatible `/api` and answered while the latter was still returning 429. That is where the real row data above came from. No Edge-held provider key covers chain 4663: Etherscan V2 does not serve it, the dRPC key is deactivated account-wide, nowNodes and quiknode have no endpoint for it, and Alchemy supports the network but answers `ROBINHOOD_MAINNET is not enabled for this app`. Enabling it on the Alchemy app, or provisioning a Blockscout API key (which `EvmScanAdapter` already appends as `&apikey=`), removes the limit without a code change.
+- Its v2 API (`/api/v2/addresses/<addr>/transactions`) has a SEPARATE quota from the Etherscan-compatible `/api` and answered while the latter was still returning 429. That is where the real row data above came from. No Edge-held provider key covered chain 4663 at the time: Etherscan V2 does not serve it, the dRPC key is deactivated account-wide, nowNodes and quiknode have no endpoint for it, and Alchemy supported the network but answered `ROBINHOOD_MAINNET is not enabled for this app`. This retrospective originally concluded that enabling the Alchemy app, or a Blockscout API key, would remove the limit without a code change. Neither was true: per-instance Blockscout keys are retired and a Pro key is shared across every install, and Alchemy's history API is `alchemy_getAssetTransfers`, not an Etherscan-compatible `txlist`, so using it needed the adapter phase 8 added.

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -13,6 +13,7 @@ import { normalizeAddress } from '../common/utils'
 import { WEI_MULTIPLIER } from './ethereumConsts'
 import { EthereumEngine } from './EthereumEngine'
 import { DecoyAddressConfig, EthereumNetworkInfo } from './ethereumTypes'
+import { AlchemyAdapter } from './networkAdapters/AlchemyAdapter'
 import { AmberdataAdapter } from './networkAdapters/AmberdataAdapter'
 import { BlockbookAdapter } from './networkAdapters/BlockbookAdapter'
 import { BlockbookWsAdapter } from './networkAdapters/BlockbookWsAdapter'
@@ -699,6 +700,8 @@ const makeNetworkAdapter = (
   ethEngine: EthereumEngine
 ): NetworkAdapter => {
   switch (config.type) {
+    case 'alchemy':
+      return new AlchemyAdapter(ethEngine, config)
     case 'amberdata-rpc':
       return new AmberdataAdapter(ethEngine, config)
     case 'blockbook':

--- a/src/ethereum/EthereumNetwork.ts
+++ b/src/ethereum/EthereumNetwork.ts
@@ -19,9 +19,14 @@ import { BlockbookAdapter } from './networkAdapters/BlockbookAdapter'
 import { BlockbookWsAdapter } from './networkAdapters/BlockbookWsAdapter'
 import { BlockchairAdapter } from './networkAdapters/BlockchairAdapter'
 import { BlockcypherAdapter } from './networkAdapters/BlockcypherAdapter'
-import { EvmScanAdapter } from './networkAdapters/EvmScanAdapter'
+import { BlockscoutAdapter } from './networkAdapters/BlockscoutAdapter'
+import {
+  EvmScanAdapter,
+  mergeEdgeTransactions
+} from './networkAdapters/EvmScanAdapter'
 import { FilfoxAdapter } from './networkAdapters/FilfoxAdapter'
 import {
+  GetTxsParams,
   NetworkAdapter,
   NetworkAdapterConfig,
   NetworkAdapterUpdateMethod
@@ -58,6 +63,19 @@ type NotNull<T> = { [P in keyof T]: Exclude<T[P], null> }
 export interface EdgeTransactionsBlockHeightTuple {
   blockHeight: number
   edgeTransactions: EdgeTransaction[]
+  /**
+   * Set by a native-asset `fetchTxs` whose rows already carry internal
+   * transactions, so the engine skips `fetchInternalTxs` for that pass
+   * instead of counting the same value twice.
+   */
+  includesInternal?: boolean
+  /**
+   * Set when the internal-transaction source failed for this pass. The rows
+   * are external-only, so the engine applies just the ones it has never seen
+   * (or still holds as unconfirmed) and keeps the query window open, letting
+   * a later complete pass re-cover the range with merged rows.
+   */
+  partial?: boolean
 }
 
 export interface EthereumNetworkUpdate {
@@ -343,7 +361,54 @@ export class EthereumNetwork {
     }
 
     const update = await this.check('fetchTxs', params)
+    if (tokenId == null) await this.mergeInternalTxs(update, params)
     return this.processEthereumNetworkUpdate(update)
+  }
+
+  /**
+   * Adds internal transactions from a `fetchInternalTxs` adapter to a
+   * native-asset history update whose source did not include them.
+   *
+   * The merge has to happen inside one pass: the engine's addTransaction
+   * replaces a known transaction whose amount changed, so the external and
+   * internal parts of one transaction must reach it as a single row, the way
+   * `EvmScanAdapter` merges txlist and txlistinternal itself.
+   */
+  private async mergeInternalTxs(
+    update: EthereumNetworkUpdate,
+    params: GetTxsParams
+  ): Promise<void> {
+    const tuple = update.tokenTxs?.get(null)
+    if (tuple == null || tuple.includesInternal === true) return
+    if (this.qualifyNetworkAdapters('fetchInternalTxs').length === 0) return
+
+    let internalUpdate: EthereumNetworkUpdate
+    try {
+      internalUpdate = await this.check('fetchInternalTxs', params)
+    } catch (error: unknown) {
+      // Keep the history the primary source delivered rather than stalling
+      // it; the window stays open until internal transactions come back.
+      this.ethEngine.warn(
+        `fetchInternalTxs failed, applying external rows only: ${String(error)}`
+      )
+      tuple.partial = true
+      return
+    }
+    const internalTuple = internalUpdate.tokenTxs?.get(null)
+    if (internalTuple == null) return
+
+    tuple.edgeTransactions = mergeEdgeTransactions([
+      ...tuple.edgeTransactions,
+      ...internalTuple.edgeTransactions
+    ])
+    tuple.includesInternal = true
+    update.blockHeight = Math.max(
+      update.blockHeight ?? 0,
+      internalUpdate.blockHeight ?? 0
+    )
+    if (internalUpdate.server != null) {
+      update.server = `${update.server ?? 'none'} + ${internalUpdate.server}`
+    }
   }
 
   needsLoop = async (): Promise<void> => {
@@ -474,15 +539,33 @@ export class EthereumNetwork {
       let highestTxBlockHeight = 0
       const syncedTokenIds: EdgeTokenId[] = []
       for (const [tokenId, tuple] of tokenTxs) {
+        const safeTokenId = tokenId ?? ''
+        highestTxBlockHeight = Math.max(highestTxBlockHeight, tuple.blockHeight)
+        if (tuple.partial === true) {
+          // External-only rows: a known confirmed transaction may already
+          // carry an internal component these rows lack, so leave it alone.
+          // The asset is not reported as synced either; that waits for a
+          // pass whose internal source answered.
+          for (const tx of tuple.edgeTransactions) {
+            const index =
+              this.ethEngine.txIdMap[safeTokenId]?.[normalizeAddress(tx.txid)]
+            const known =
+              index == null
+                ? undefined
+                : this.ethEngine.transactionList[safeTokenId]?.[index]
+            if (known == null || known.blockHeight === 0) {
+              this.ethEngine.addTransaction(tokenId, tx)
+            }
+          }
+          continue
+        }
         syncedTokenIds.push(tokenId)
         for (const tx of tuple.edgeTransactions) {
           this.ethEngine.addTransaction(tokenId, tx)
         }
-        const safeTokenId = tokenId ?? ''
         this.ethEngine.walletLocalData.lastTransactionQueryHeight[safeTokenId] =
           preUpdateBlockHeight
         this.ethEngine.walletLocalData.lastTransactionDate[safeTokenId] = now
-        highestTxBlockHeight = Math.max(highestTxBlockHeight, tuple.blockHeight)
       }
       this.ethEngine.walletLocalData.highestTxBlockHeight = Math.max(
         this.ethEngine.walletLocalData.highestTxBlockHeight,
@@ -712,6 +795,8 @@ const makeNetworkAdapter = (
       return new BlockchairAdapter(ethEngine, config)
     case 'blockcypher':
       return new BlockcypherAdapter(ethEngine, config)
+    case 'blockscout':
+      return new BlockscoutAdapter(ethEngine, config)
     case 'evmscan':
       return new EvmScanAdapter(ethEngine, config)
     case 'filfox':

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -118,6 +118,7 @@ export interface EthereumNetworkInfo {
 }
 
 const asNetworkAdaptorConfigType = asValue(
+  'alchemy',
   'amberdata-rpc',
   'blockbook',
   'blockbook-ws',

--- a/src/ethereum/ethereumTypes.ts
+++ b/src/ethereum/ethereumTypes.ts
@@ -124,6 +124,7 @@ const asNetworkAdaptorConfigType = asValue(
   'blockbook-ws',
   'blockchair',
   'blockcypher',
+  'blockscout',
   'evmscan',
   'filfox',
   'pulsechain-scan',

--- a/src/ethereum/info/robinhoodInfo.ts
+++ b/src/ethereum/info/robinhoodInfo.ts
@@ -19,7 +19,7 @@ import {
 // Bridged token addresses come from the canonical Arbitrum token bridge, via
 // L2GatewayRouter.calculateL2TokenAddress(l1Token). Robinhood Chain's explorer
 // lists many same-symbol imposters, so never source these from a token search.
-const builtinTokens: EdgeTokenMap = {
+export const builtinTokens: EdgeTokenMap = {
   '80e0e24718dbfcad49ecaa6f1e6c89a190586ca8': {
     currencyCode: 'USDC',
     displayName: 'Bridged USDC (Robinhood)',
@@ -152,7 +152,7 @@ const networkInfo: EthereumNetworkInfo = {
   }
 }
 
-const currencyInfo: EdgeCurrencyInfo = {
+export const currencyInfo: EdgeCurrencyInfo = {
   canReplaceByFee: true,
   currencyCode: 'ETH',
   evmChainId: 4663,

--- a/src/ethereum/info/robinhoodInfo.ts
+++ b/src/ethereum/info/robinhoodInfo.ts
@@ -116,17 +116,27 @@ const networkInfo: EthereumNetworkInfo = {
   addressQueryLookbackBlocks: 1250,
   networkAdapterConfigs: [
     {
+      // Keyed history source. Alchemy does not serve the `internal` category
+      // on this network; the `blockscout` adapter below supplies those rows,
+      // merged into every native-asset sync.
+      type: 'alchemy',
+      servers: ['https://robinhood-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}']
+    },
+    {
       type: 'rpc',
       servers: [
         'https://rpc.mainnet.chain.robinhood.com',
-        'https://robinhood-rpc.publicnode.com'
-      ]
+        'https://robinhood-rpc.publicnode.com',
+        'https://robinhood-mainnet.g.alchemy.com/v2/{{alchemyApiKey}}'
+      ],
+      ethBalCheckerContract: '0x8950F12786CAE64F94a02733A260ca6FecDaeD7f'
     },
     {
-      // Etherscan V2 does not support chain 4663, so transaction history comes
-      // from the chain's Blockscout instance, which has no gastracker module.
-      type: 'evmscan',
-      gastrackerSupport: false,
+      // Etherscan V2 does not support chain 4663. The chain's public Blockscout
+      // instance (300 requests per minute per IP) supplies the internal
+      // transactions Alchemy lacks here, merged into every native-asset sync,
+      // and is the history fallback when Alchemy fails.
+      type: 'blockscout',
       servers: ['https://robinhoodchain.blockscout.com']
     }
   ],

--- a/src/ethereum/networkAdapters/AlchemyAdapter.ts
+++ b/src/ethereum/networkAdapters/AlchemyAdapter.ts
@@ -1,0 +1,676 @@
+import { add, gt, mul, sub } from 'biggystring'
+import {
+  asArray,
+  asEither,
+  asMaybe,
+  asNull,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asUnknown
+} from 'cleaners'
+import { EdgeTokenId, EdgeTransaction, JsonObject } from 'edge-core-js/types'
+import parse from 'url-parse'
+
+import { asMaybeContractLocation } from '../../common/tokenHelpers'
+import { decimalToHex, hexToDecimal } from '../../common/utils'
+import { EthereumEngine } from '../EthereumEngine'
+import {
+  EdgeTransactionsBlockHeightTuple,
+  EthereumNetworkUpdate,
+  getFeeRateUsed
+} from '../EthereumNetwork'
+import { EthereumTxOtherParams } from '../ethereumTypes'
+import { resolveServerApiKey } from './apiKeyTemplate'
+import { TransactionProcessingContext } from './EvmScanAdapter'
+import { GetTxsParams, NetworkAdapter } from './networkAdapterTypes'
+
+/** Alchemy caps `maxCount` at 1000 transfers per page */
+const MAX_TRANSFERS_PER_PAGE = '0x3e8'
+
+/**
+ * Alchemy caps a JSON-RPC batch at 1000 entries; each spend needs two, so
+ * receipts are fetched in batches of this many transactions.
+ */
+const MAX_SPENDS_PER_BATCH = 400
+
+/**
+ * Endpoints (by hostname) that answered `alchemy_getAssetTransfers` with the
+ * "category is not supported for this network" error for `internal`.
+ * Shared across wallets so each chain learns the answer once per session.
+ */
+const internalCategoryUnsupported = new Set<string>()
+
+/** A JSON-RPC error entry returned inside an HTTP 200 batch reply */
+class AlchemyRpcError extends Error {
+  code: number
+
+  constructor(code: number, message: string) {
+    super(message)
+    this.name = 'AlchemyRpcError'
+    this.code = code
+  }
+}
+
+const isUnsupportedCategoryError = (error: unknown): boolean =>
+  error instanceof AlchemyRpcError &&
+  error.code === -32602 &&
+  /category is not supported/i.test(error.message)
+
+export interface AlchemyAdapterConfig {
+  type: 'alchemy'
+  /**
+   * Alchemy JSON-RPC endpoints for the chain, such as
+   * `https://<network>.g.alchemy.com/v2/{{alchemyApiKey}}`. A server whose
+   * placeholder has no init option is dropped, so a missing key only removes
+   * this adapter from the waterfall.
+   */
+  servers: string[]
+}
+
+/**
+ * Transaction history and token balances from Alchemy's enhanced APIs.
+ *
+ * `alchemy_getAssetTransfers` reports value movements rather than
+ * transactions, without gas data, so a wallet's outgoing transactions are
+ * completed with `eth_getTransactionByHash` and `eth_getTransactionReceipt`
+ * from the same endpoint. Native-asset queries ask for the `internal`
+ * category alongside `external`; Alchemy rejects that category on some
+ * networks, and the first such rejection is remembered per endpoint so the
+ * adapter keeps serving `external` transfers there without retrying it.
+ */
+export class AlchemyAdapter extends NetworkAdapter<AlchemyAdapterConfig> {
+  batchMulticastRpc = null
+  broadcast = null
+  connect = null
+  disconnect = null
+  fetchBlockheight = null
+  fetchNonce = null
+  fetchTokenBalance = null
+  getBaseFeePerGas = null
+  multicastRpc = null
+  subscribeAddressSync = null
+
+  constructor(ethEngine: EthereumEngine, config: AlchemyAdapterConfig) {
+    super(ethEngine, config)
+
+    this.config.servers = this.config.servers
+      .map((server): string | undefined => {
+        try {
+          return resolveServerApiKey(server, ethEngine)
+        } catch (error: unknown) {
+          ethEngine.warn(`Alchemy server dropped: ${String(error)}`)
+          return undefined
+        }
+      })
+      .filter((server): server is string => server != null)
+
+    // With no usable endpoint the adapter leaves the waterfall entirely,
+    // the way RpcAdapter gates fetchTokenBalances on its checker contract,
+    // instead of failing every sync with a confusing error.
+    if (this.config.servers.length === 0) {
+      this.fetchTokenBalances = null
+      this.fetchTxs = null
+    }
+  }
+
+  fetchTokenBalances: (() => Promise<EthereumNetworkUpdate>) | null =
+    async () => {
+      const { allTokensMap, walletLocalData } = this.ethEngine
+      const address = walletLocalData.publicKey
+
+      const contractAddresses: string[] = []
+      for (const token of Object.values(allTokensMap)) {
+        const location = asMaybeContractLocation(token.networkLocation)
+        if (location != null) contractAddresses.push(location.contractAddress)
+      }
+
+      const { result, server } = await this.serialServers(async baseUrl => {
+        const requests: Array<{ method: string; params: unknown[] }> = [
+          { method: 'eth_getBalance', params: [address, 'latest'] }
+        ]
+        // A chain with no tokens has nothing to ask getTokenBalances about
+        if (contractAddresses.length > 0) {
+          requests.push({
+            method: 'alchemy_getTokenBalances',
+            params: [address, contractAddresses]
+          })
+        }
+        const [rawBalance, rawTokenBalances] = await this.fetchBatchRpc(
+          baseUrl,
+          requests
+        )
+        return {
+          server: parse(baseUrl).hostname,
+          result: {
+            balance: asString(rawBalance),
+            tokenBalances:
+              rawTokenBalances == null
+                ? []
+                : asTokenBalancesResult(rawTokenBalances).tokenBalances
+          }
+        }
+      })
+
+      const tokenBal: EthereumNetworkUpdate['tokenBal'] = new Map()
+      const detectedTokenIds: string[] = []
+      tokenBal.set(null, hexToDecimal(result.balance))
+      for (const tokenBalance of result.tokenBalances) {
+        const tokenId = tokenBalance.contractAddress
+          .toLowerCase()
+          .replace('0x', '')
+        if (allTokensMap[tokenId] == null) {
+          this.logError(
+            'fetchTokenBalances',
+            new Error(
+              `Alchemy returned an unknown token: ${tokenBalance.contractAddress}`
+            )
+          )
+          continue
+        }
+        const balance = hexToDecimal(tokenBalance.tokenBalance ?? '0x0')
+        if (gt(balance, '0')) detectedTokenIds.push(tokenId)
+        tokenBal.set(tokenId, balance)
+      }
+
+      return { tokenBal, detectedTokenIds, server }
+    }
+
+  fetchTxs: ((params: GetTxsParams) => Promise<EthereumNetworkUpdate>) | null =
+    async params => {
+      const { startBlock, tokenId } = params
+      const address = this.ethEngine.walletLocalData.publicKey
+
+      let contractAddress: string | undefined
+      if (tokenId != null) {
+        const location = asMaybeContractLocation(
+          this.ethEngine.allTokensMap[tokenId]?.networkLocation
+        )
+        if (location == null) return {}
+        contractAddress = location.contractAddress
+      }
+
+      const { result, server } = await this.serialServers(async baseUrl => {
+        const hostname = parse(baseUrl).hostname
+        const [sent, received] = await Promise.all([
+          this.fetchAssetTransfers(baseUrl, {
+            startBlock,
+            contractAddress,
+            fromAddress: address
+          }),
+          this.fetchAssetTransfers(baseUrl, {
+            startBlock,
+            contractAddress,
+            toAddress: address
+          })
+        ])
+
+        // A native query that kept the `internal` category through both
+        // directions already carries internal transfers, so the engine must
+        // not merge a second source's copy of them. Should the two legs
+        // ever disagree, the internal rows are dropped so the tuple is
+        // consistently external-only and the engine fetches them elsewhere.
+        const includesInternal =
+          sent.includedInternal && received.includedInternal
+        const transfers = [...sent.transfers, ...received.transfers].filter(
+          transfer => includesInternal || transfer.category !== 'internal'
+        )
+
+        // Only the wallet's own outgoing transactions need gas data:
+        const spendTxids = new Set<string>()
+        for (const transfer of transfers) {
+          if (transfer.from.toLowerCase() === address.toLowerCase()) {
+            spendTxids.add(transfer.hash.toLowerCase())
+          }
+        }
+        const txDetails = await this.fetchTxDetails(baseUrl, [...spendTxids])
+
+        const edgeTransactions = [
+          ...processAlchemyTransfers(
+            {
+              allTokensMap: this.ethEngine.allTokensMap,
+              currencyInfo: this.ethEngine.currencyInfo,
+              forWhichAddress: address,
+              forWhichTokenId: tokenId,
+              forWhichWalletId: this.ethEngine.walletId
+            },
+            transfers,
+            txDetails
+          ),
+          ...(await this.fetchFailedSends(baseUrl, tokenId))
+        ]
+        return {
+          server: hostname,
+          result: { edgeTransactions, includesInternal }
+        }
+      })
+      const { edgeTransactions } = result
+
+      const edgeTransactionsBlockHeightTuple: EdgeTransactionsBlockHeightTuple =
+        {
+          blockHeight: startBlock,
+          edgeTransactions
+        }
+      const maxBlockHeight = edgeTransactions.reduce((max, tx) => {
+        return Math.max(max, tx.blockHeight)
+      }, 0)
+      return {
+        tokenTxs: new Map([[tokenId, edgeTransactionsBlockHeightTuple]]),
+        blockHeight: maxBlockHeight,
+        server
+      }
+    }
+
+  /**
+   * Pages through `alchemy_getAssetTransfers` for one direction of one asset.
+   * `includedInternal` reports whether the rows came from a query that kept
+   * the `internal` category.
+   */
+  private async fetchAssetTransfers(
+    baseUrl: string,
+    query: {
+      startBlock: number
+      contractAddress?: string
+      fromAddress?: string
+      toAddress?: string
+    }
+  ): Promise<{ transfers: AlchemyAssetTransfer[]; includedInternal: boolean }> {
+    const { startBlock, contractAddress, fromAddress, toAddress } = query
+    const hostname = parse(baseUrl).hostname
+    const withInternal =
+      contractAddress == null && !internalCategoryUnsupported.has(hostname)
+    const params: JsonObject = {
+      fromBlock: decimalToHex(startBlock.toString()),
+      toBlock: 'latest',
+      category:
+        contractAddress != null
+          ? ['erc20']
+          : withInternal
+          ? ['external', 'internal']
+          : ['external'],
+      withMetadata: true,
+      order: 'asc',
+      maxCount: MAX_TRANSFERS_PER_PAGE
+    }
+    if (fromAddress != null) params.fromAddress = fromAddress
+    if (toAddress != null) params.toAddress = toAddress
+    if (contractAddress != null) {
+      params.contractAddresses = [contractAddress]
+    } else if (fromAddress != null) {
+      // A plain contract call from the wallet moves no value but still costs
+      // gas, and belongs in the history the way an explorer's txlist shows it.
+      params.excludeZeroValue = false
+    }
+
+    const transfers: AlchemyAssetTransfer[] = []
+    let pageKey: string | undefined
+    while (true) {
+      let raw: unknown
+      try {
+        ;[raw] = await this.fetchBatchRpc(baseUrl, [
+          {
+            method: 'alchemy_getAssetTransfers',
+            params: [pageKey == null ? params : { ...params, pageKey }]
+          }
+        ])
+      } catch (error: unknown) {
+        if (!withInternal || !isUnsupportedCategoryError(error)) throw error
+        // This network has no internal transfers on Alchemy. Remember that
+        // and answer with external transfers only.
+        this.ethEngine.warn(
+          `${hostname} does not serve internal transfers; using external only`
+        )
+        internalCategoryUnsupported.add(hostname)
+        return await this.fetchAssetTransfers(baseUrl, query)
+      }
+      const page = asAssetTransfersResult(raw)
+      for (const rawTransfer of page.transfers) {
+        transfers.push(asAlchemyAssetTransfer(rawTransfer))
+      }
+      pageKey = page.pageKey
+      if (pageKey == null) break
+    }
+    return { transfers, includedInternal: withInternal }
+  }
+
+  /**
+   * Fetches the transaction and receipt for each txid in one batch, giving the
+   * sender, nonce and gas figures that asset transfers leave out.
+   */
+  private async fetchTxDetails(
+    baseUrl: string,
+    txids: string[]
+  ): Promise<Map<string, AlchemyTxDetails>> {
+    const txDetails = new Map<string, AlchemyTxDetails>()
+    for (let start = 0; start < txids.length; start += MAX_SPENDS_PER_BATCH) {
+      const batch = txids.slice(start, start + MAX_SPENDS_PER_BATCH)
+      const requests = batch.flatMap(txid => [
+        { method: 'eth_getTransactionByHash', params: [txid] },
+        { method: 'eth_getTransactionReceipt', params: [txid] }
+      ])
+      const results = await this.fetchBatchRpc(baseUrl, requests)
+
+      for (let i = 0; i < batch.length; i++) {
+        // A pending, reorged or not-yet-indexed hash answers null; leave its
+        // details out (the transfer still lists, without fee or nonce)
+        // rather than failing the whole page.
+        const tx = asMaybe(asAlchemyTransaction)(results[i * 2])
+        const receipt = asMaybe(asAlchemyReceipt)(results[i * 2 + 1])
+        if (tx == null || receipt == null) continue
+        const gasPrice = receipt.effectiveGasPrice ?? tx.gasPrice ?? '0x0'
+        txDetails.set(batch[i].toLowerCase(), {
+          from: tx.from,
+          to: tx.to,
+          nonce: hexToDecimal(tx.nonce),
+          gas: hexToDecimal(tx.gas),
+          gasPrice: hexToDecimal(gasPrice),
+          gasUsed: hexToDecimal(receipt.gasUsed),
+          blockHeight: parseInt(receipt.blockNumber, 16),
+          succeeded:
+            receipt.status == null ? undefined : receipt.status !== '0x0'
+        })
+      }
+    }
+    return txDetails
+  }
+
+  /**
+   * Alchemy's asset transfers omit a reverted transaction, since it moved no
+   * value, so a send the wallet broadcast that then failed would never come
+   * back from `fetchTxs` and its unconfirmed row would keep blocking further
+   * sends. The wallet's own still-unconfirmed rows are looked up by receipt
+   * and the failed ones reported with their fee.
+   */
+  private async fetchFailedSends(
+    baseUrl: string,
+    tokenId: EdgeTokenId
+  ): Promise<EdgeTransaction[]> {
+    const pending = (
+      this.ethEngine.transactionList[tokenId ?? ''] ?? []
+    ).filter(tx => tx.blockHeight === 0 && tx.isSend)
+    if (pending.length === 0) return []
+
+    const txDetails = await this.fetchTxDetails(
+      baseUrl,
+      pending.map(tx => tx.txid)
+    )
+    const failed: EdgeTransaction[] = []
+    for (const tx of pending) {
+      const details = txDetails.get(tx.txid.toLowerCase())
+      // Not mined yet, or mined fine (asset transfers report those):
+      if (details == null || details.succeeded !== false) continue
+      failed.push(makeFailedSend(tx, details))
+    }
+    return failed
+  }
+
+  /**
+   * Sends a JSON-RPC batch and returns the results in request order,
+   * throwing on the first error entry.
+   */
+  private async fetchBatchRpc(
+    baseUrl: string,
+    requests: Array<{ method: string; params: unknown[] }>
+  ): Promise<unknown[]> {
+    const body = requests.map((request, index) => ({
+      id: index + 1,
+      jsonrpc: '2.0',
+      method: request.method,
+      params: request.params
+    }))
+    const response = await this.ethEngine.engineFetch(baseUrl, {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+
+    const hostname = parse(baseUrl).hostname
+    if (!response.ok) {
+      const resBody = await response.text()
+      this.throwError(response, 'fetchBatchRpc', hostname, resBody)
+    }
+
+    const raw = await response.json()
+    const results = asArray(asRpcResponse)(Array.isArray(raw) ? raw : [raw])
+    // Pair replies with requests by id: positional pairing would silently
+    // attach one transaction's receipt to another if an entry went missing.
+    const byId = new Map(results.map(result => [result.id, result]))
+    return requests.map((request, index) => {
+      const result = byId.get(index + 1)
+      if (result == null) {
+        throw new Error(
+          `Batch RPC reply from ${hostname} is missing entry ${index + 1} (${
+            request.method
+          })`
+        )
+      }
+      if (result.error != null) {
+        this.ethEngine.error(
+          `Batch RPC error from ${hostname}: ${JSON.stringify(result.error)}`
+        )
+        throw new AlchemyRpcError(result.error.code, result.error.message)
+      }
+      return result.result
+    })
+  }
+}
+
+/**
+ * Sender, nonce and gas figures for one of the wallet's own transactions,
+ * as decimal strings.
+ */
+export interface AlchemyTxDetails {
+  from: string
+  to: string | null
+  nonce: string
+  gas: string
+  gasPrice: string
+  gasUsed: string
+  blockHeight: number
+  /** From the receipt status; undefined on a pre-Byzantium receipt */
+  succeeded: boolean | undefined
+}
+
+/**
+ * The row for a wallet send whose receipt shows a revert: the value stayed
+ * put, the fee was still paid, and the row keeps its pending metadata.
+ */
+export function makeFailedSend(
+  pending: EdgeTransaction,
+  details: AlchemyTxDetails
+): EdgeTransaction {
+  const fee = mul(details.gasPrice, details.gasUsed)
+  const tokenTx = pending.tokenId != null
+  return {
+    ...pending,
+    blockHeight: details.blockHeight,
+    confirmations: 'failed',
+    feeRateUsed: getFeeRateUsed(details.gasPrice, details.gas, details.gasUsed),
+    isSend: true,
+    nativeAmount: tokenTx ? '0' : sub('0', fee),
+    networkFee: tokenTx ? '0' : fee,
+    parentNetworkFee: tokenTx ? fee : undefined,
+    otherParams: {
+      ...pending.otherParams,
+      gasPrice: details.gasPrice,
+      gasUsed: details.gasUsed
+    }
+  }
+}
+
+/**
+ * Folds asset transfers into one EdgeTransaction per transaction hash, with
+ * the same amount and fee conventions as `processEvmScanTransaction`:
+ * a spend's nativeAmount includes the fee, a self-send nets to the fee alone,
+ * and a token spend carries the fee as parentNetworkFee.
+ *
+ * Transfers are deduplicated by uniqueId, since a transfer between two of the
+ * wallet's own addresses appears in both the fromAddress and toAddress
+ * queries. `txDetails` is keyed by lowercase txid and only needs entries for
+ * transactions the wallet sent.
+ */
+export function processAlchemyTransfers(
+  context: TransactionProcessingContext,
+  transfers: AlchemyAssetTransfer[],
+  txDetails: Map<string, AlchemyTxDetails>
+): EdgeTransaction[] {
+  const ourAddress = context.forWhichAddress.toLowerCase()
+  const tokenTx = context.forWhichTokenId != null
+  let currencyCode: string = context.currencyInfo.currencyCode
+  if (tokenTx) {
+    const knownToken = context.allTokensMap[context.forWhichTokenId ?? '']
+    // The engine only asks for tokens it knows, so this is unreachable in
+    // practice; an empty result keeps one stray tokenId from failing the sync.
+    if (knownToken == null) return []
+    currencyCode = knownToken.currencyCode
+  }
+
+  const seenUniqueIds = new Set<string>()
+  const transfersByTxid = new Map<string, AlchemyAssetTransfer[]>()
+  for (const transfer of transfers) {
+    if (seenUniqueIds.has(transfer.uniqueId)) continue
+    seenUniqueIds.add(transfer.uniqueId)
+    const txid = transfer.hash.toLowerCase()
+    const group = transfersByTxid.get(txid) ?? []
+    group.push(transfer)
+    transfersByTxid.set(txid, group)
+  }
+
+  const edgeTransactions: EdgeTransaction[] = []
+  for (const [txid, group] of transfersByTxid) {
+    let received = '0'
+    let sent = '0'
+    let fromUs = false
+    for (const transfer of group) {
+      const value = hexToDecimal(transfer.rawContract.value ?? '0x0')
+      if (transfer.from.toLowerCase() === ourAddress) {
+        fromUs = true
+        sent = add(sent, value)
+      }
+      if (transfer.to?.toLowerCase() === ourAddress) {
+        received = add(received, value)
+      }
+    }
+
+    // The wallet only paid the fee if it signed the transaction. A token
+    // transfer "from" the wallet can also be a third party pulling an
+    // approved allowance, and that party paid.
+    const details = txDetails.get(txid)
+    const paidFee =
+      fromUs && details != null && details.from.toLowerCase() === ourAddress
+    const fee = paidFee ? mul(details.gasPrice, details.gasUsed) : '0'
+
+    const netAmount = sub(received, sent)
+    let nativeAmount: string
+    let networkFee = '0'
+    let parentNetworkFee: string | undefined
+    if (tokenTx) {
+      nativeAmount = netAmount
+      if (paidFee) parentNetworkFee = fee
+    } else {
+      nativeAmount = sub(netAmount, fee)
+      networkFee = fee
+    }
+    const ourReceiveAddresses =
+      !fromUs && gt(received, '0') ? [context.forWhichAddress] : []
+
+    const first = group[0]
+    const otherParams: EthereumTxOtherParams = {
+      from: [details?.from ?? first.from],
+      to: [details?.to ?? first.to ?? ''],
+      gas: details?.gas ?? '0',
+      gasPrice: details?.gasPrice ?? '',
+      gasUsed: details?.gasUsed ?? '0',
+      isFromMakeSpend: false,
+      nonceUsed: details?.nonce
+    }
+
+    edgeTransactions.push({
+      blockHeight: parseInt(first.blockNum, 16),
+      currencyCode,
+      date: Math.floor(Date.parse(first.metadata.blockTimestamp) / 1000),
+      feeRateUsed:
+        details == null
+          ? undefined
+          : getFeeRateUsed(details.gasPrice, details.gas, details.gasUsed),
+      isSend: nativeAmount.startsWith('-'),
+      memos: [],
+      nativeAmount,
+      networkFee,
+      networkFees: [],
+      otherParams,
+      ourReceiveAddresses,
+      parentNetworkFee,
+      signedTx: '',
+      tokenId: context.forWhichTokenId,
+      txid: first.hash,
+      walletId: context.forWhichWalletId
+    })
+  }
+
+  return edgeTransactions
+}
+
+export type AlchemyAssetTransfer = ReturnType<typeof asAlchemyAssetTransfer>
+export const asAlchemyAssetTransfer = asObject({
+  blockNum: asString,
+  /** `<hash>:external` or `<hash>:log:<index>`, unique per value movement */
+  uniqueId: asString,
+  hash: asString,
+  /** `external`, `internal`, `erc20`, ... */
+  category: asString,
+  from: asString,
+  to: asEither(asString, asNull),
+  rawContract: asObject({
+    value: asEither(asString, asNull),
+    address: asEither(asString, asNull)
+  }),
+  metadata: asObject({
+    blockTimestamp: asString
+  })
+})
+
+const asAssetTransfersResult = asObject({
+  transfers: asArray(asUnknown),
+  pageKey: asOptional(asString)
+})
+
+const asTokenBalancesResult = asObject({
+  tokenBalances: asArray(
+    asObject({
+      contractAddress: asString,
+      tokenBalance: asEither(asString, asNull)
+    })
+  )
+})
+
+const asAlchemyTransaction = asObject({
+  from: asString,
+  to: asEither(asString, asNull),
+  nonce: asString,
+  gas: asString,
+  gasPrice: asOptional(asString)
+})
+
+const asAlchemyReceipt = asObject({
+  blockNumber: asString,
+  gasUsed: asString,
+  effectiveGasPrice: asOptional(asString),
+  /** `0x1` success, `0x0` reverted; absent before Byzantium */
+  status: asOptional(asString)
+})
+
+const asRpcResponse = asObject({
+  id: asNumber,
+  result: asUnknown,
+  error: asOptional(
+    asObject({
+      code: asNumber,
+      message: asString
+    })
+  )
+})

--- a/src/ethereum/networkAdapters/AlchemyAdapter.ts
+++ b/src/ethereum/networkAdapters/AlchemyAdapter.ts
@@ -81,6 +81,7 @@ export interface AlchemyAdapterConfig {
  * adapter keeps serving `external` transfers there without retrying it.
  */
 export class AlchemyAdapter extends NetworkAdapter<AlchemyAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   connect = null
@@ -245,12 +246,13 @@ export class AlchemyAdapter extends NetworkAdapter<AlchemyAdapterConfig> {
           result: { edgeTransactions, includesInternal }
         }
       })
-      const { edgeTransactions } = result
+      const { edgeTransactions, includesInternal } = result
 
       const edgeTransactionsBlockHeightTuple: EdgeTransactionsBlockHeightTuple =
         {
           blockHeight: startBlock,
-          edgeTransactions
+          edgeTransactions,
+          includesInternal
         }
       const maxBlockHeight = edgeTransactions.reduce((max, tx) => {
         return Math.max(max, tx.blockHeight)

--- a/src/ethereum/networkAdapters/AmberdataAdapter.ts
+++ b/src/ethereum/networkAdapters/AmberdataAdapter.ts
@@ -10,6 +10,7 @@ export interface AmberdataAdapterConfig {
 }
 
 export class AmberdataAdapter extends NetworkAdapter<AmberdataAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   connect = null

--- a/src/ethereum/networkAdapters/BlockbookAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockbookAdapter.ts
@@ -15,6 +15,7 @@ export interface BlockbookAdapterConfig {
 }
 
 export class BlockbookAdapter extends NetworkAdapter<BlockbookAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   connect = null
   disconnect = null

--- a/src/ethereum/networkAdapters/BlockbookWsAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockbookWsAdapter.ts
@@ -65,6 +65,7 @@ const BACKOFF_MAX_MS = 60000
 //
 
 export class BlockbookWsAdapter extends NetworkAdapter<BlockbookWsAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   fetchBlockheight = null

--- a/src/ethereum/networkAdapters/BlockchairAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockchairAdapter.ts
@@ -16,6 +16,7 @@ export interface BlockchairAdapterConfig {
 }
 
 export class BlockchairAdapter extends NetworkAdapter<BlockchairAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   connect = null

--- a/src/ethereum/networkAdapters/BlockcypherAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockcypherAdapter.ts
@@ -10,6 +10,7 @@ export interface BlockcypherAdapterConfig {
 }
 
 export class BlockcypherAdapter extends NetworkAdapter<BlockcypherAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   connect = null
   disconnect = null

--- a/src/ethereum/networkAdapters/BlockscoutAdapter.ts
+++ b/src/ethereum/networkAdapters/BlockscoutAdapter.ts
@@ -1,0 +1,165 @@
+import { EdgeTokenId } from 'edge-core-js/types'
+
+import {
+  EdgeTransactionsBlockHeightTuple,
+  EthereumNetworkUpdate
+} from '../EthereumNetwork'
+import { asEtherscanGetBlockHeight } from '../ethereumSchema'
+import {
+  asEvmScanInternalTransaction,
+  asEvmScanTokenTransaction,
+  asEvmScanTransaction,
+  EvmScanAdapter
+} from './EvmScanAdapter'
+import { GetTxsParams, RateLimitError } from './networkAdapterTypes'
+
+/**
+ * Per-instance moment (ms since epoch) before which `fetchInternalTxs` is
+ * skipped after a throttle reply, shared by every wallet on the same
+ * instance so one 429 pauses all of them instead of each rediscovering it.
+ */
+const internalTxsCooldownUntil = new Map<string, number>()
+const INTERNAL_TXS_COOLDOWN_MS = 60 * 1000
+
+/**
+ * Public Blockscout instances sit behind Cloudflare, and some of them (the
+ * Robinhood Chain one, measured 2026-09-03 from two unrelated IPs) answer a
+ * managed challenge page to every request whose user agent does not look
+ * like a browser: the app's own CFNetwork and OkHttp agents get HTTP 403,
+ * a browser string gets the JSON. Sending one is the same workaround
+ * `BlockbookAdapter` applies for Trezor's Blockbook servers.
+ */
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0 Safari/537.36'
+
+export interface BlockscoutAdapterConfig {
+  type: 'blockscout'
+  /** Blockscout instance origins, e.g. `https://eth.blockscout.com` */
+  servers: string[]
+}
+
+/**
+ * A Blockscout instance through its Etherscan-compatible `/api`.
+ *
+ * Blockscout differs from Etherscan in the places this adapter overrides:
+ * block height comes from `module=block&action=eth_block_number`, there is
+ * no gastracker module, a partially indexed range answers `status: "2"`,
+ * and the per-IP throttle reply carries its text in `message`. Internal
+ * transactions are served through `fetchInternalTxs` rather than folded into
+ * `fetchTxs`, so a chain whose primary history source cannot see them (the
+ * Alchemy adapter on networks without the `internal` category) still gets
+ * them merged into every native-asset sync by the engine.
+ */
+export class BlockscoutAdapter extends EvmScanAdapter<BlockscoutAdapterConfig> {
+  // A throttled public instance must not hold a native-asset sync open:
+  // after three retries (1s, 2s, 4s) the call throws, the engine marks the
+  // pass partial and keeps the query window open for the next attempt.
+  protected rateLimitRetries = 3
+  protected requestHeaders = { 'User-Agent': BROWSER_USER_AGENT }
+
+  fetchBlockheight = async (): Promise<EthereumNetworkUpdate> => {
+    const { result: jsonObj, server } = await this.serialServers(
+      async server => {
+        const response = await this.fetchGetEtherscan(
+          server,
+          '?module=block&action=eth_block_number'
+        )
+        if ('status' in response && response.status === '0') {
+          this.handledUnexpectedResponse(server, 'eth_block_number', response)
+        }
+        return { server, result: response }
+      }
+    )
+
+    const clean = asEtherscanGetBlockHeight(jsonObj)
+    return { blockHeight: clean.result, server }
+  }
+
+  fetchTxs = async (params: GetTxsParams): Promise<EthereumNetworkUpdate> => {
+    const { startBlock, tokenId } = params
+
+    let contractAddress: string | undefined
+    if (tokenId != null) {
+      const tokenInfo = this.ethEngine.allTokensMap[tokenId]
+      if (typeof tokenInfo?.networkLocation?.contractAddress !== 'string') {
+        return {}
+      }
+      contractAddress = tokenInfo.networkLocation.contractAddress
+    }
+
+    const { allTransactions, server } =
+      tokenId == null
+        ? await this.getAllTxsEthscan(startBlock, null, asEvmScanTransaction, {
+            searchRegularTxs: true
+          })
+        : await this.getAllTxsEthscan(
+            startBlock,
+            tokenId,
+            asEvmScanTokenTransaction,
+            { contractAddress }
+          )
+
+    return this.makeTxsUpdate(tokenId, startBlock, allTransactions, server, {
+      includesInternal: false
+    })
+  }
+
+  fetchInternalTxs = async (
+    params: GetTxsParams
+  ): Promise<EthereumNetworkUpdate> => {
+    const { startBlock } = params
+    const cooldownKey = this.config.servers.join(',')
+    const cooldownUntil = internalTxsCooldownUntil.get(cooldownKey) ?? 0
+    if (Date.now() < cooldownUntil) {
+      throw new Error(
+        `Blockscout internal transactions paused ${Math.ceil(
+          (cooldownUntil - Date.now()) / 1000
+        )}s after a rate limit`
+      )
+    }
+
+    let response: Awaited<ReturnType<typeof this.getAllTxsEthscan>>
+    try {
+      response = await this.getAllTxsEthscan(
+        startBlock,
+        null,
+        asEvmScanInternalTransaction,
+        { searchRegularTxs: false }
+      )
+    } catch (error: unknown) {
+      if (error instanceof RateLimitError) {
+        internalTxsCooldownUntil.set(
+          cooldownKey,
+          Date.now() + INTERNAL_TXS_COOLDOWN_MS
+        )
+      }
+      throw error
+    }
+    const { allTransactions, server } = response
+    return this.makeTxsUpdate(null, startBlock, allTransactions, server, {
+      includesInternal: true
+    })
+  }
+
+  private makeTxsUpdate(
+    tokenId: EdgeTokenId,
+    startBlock: number,
+    edgeTransactions: EdgeTransactionsBlockHeightTuple['edgeTransactions'],
+    server: string | undefined,
+    options: { includesInternal: boolean }
+  ): EthereumNetworkUpdate {
+    const tuple: EdgeTransactionsBlockHeightTuple = {
+      blockHeight: startBlock,
+      edgeTransactions,
+      includesInternal: options.includesInternal
+    }
+    const maxBlockHeight = edgeTransactions.reduce((max, tx) => {
+      return Math.max(max, tx.blockHeight)
+    }, 0)
+    return {
+      tokenTxs: new Map([[tokenId, tuple]]),
+      blockHeight: maxBlockHeight,
+      server: server ?? ''
+    }
+  }
+}

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -326,8 +326,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     if (
       'status' in cleanData &&
       cleanData.status === '0' &&
-      typeof cleanData.result === 'string' &&
-      cleanData.result.match(/Max calls|rate limit/) != null
+      isEvmScanRateLimitResponse(cleanData)
     ) {
       throw new RateLimitError(`fetchGetEtherscan rate limit for ${server}`)
     }
@@ -667,7 +666,26 @@ export function mergeEdgeTransactions(
   return Array.from(txidToTransaction.values())
 }
 
-interface EvmScanErrorResponse {
+/**
+ * Whether a `status: "0"` reply is the API throttling us rather than a real
+ * error. Etherscan puts the text in `result` ("Max calls per sec rate limit
+ * reached", "Max rate limit reached"); Blockscout answers with `result: null`
+ * and the text in `message` ("Too many requests. Increase limits now at
+ * https://dev.blockscout.com").
+ */
+export function isEvmScanRateLimitResponse(
+  response: EvmScanErrorResponse
+): boolean {
+  if (
+    typeof response.result === 'string' &&
+    /Max calls|rate limit/i.test(response.result)
+  ) {
+    return true
+  }
+  return /too many requests|rate limit/i.test(response.message)
+}
+
+export interface EvmScanErrorResponse {
   status: '0'
   message: string
   result: unknown

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -38,6 +38,7 @@ import {
   RpcResultString
 } from '../ethereumTypes'
 import { getEvmScanApiKey } from '../fees/feeProviders'
+import type { BlockscoutAdapterConfig } from './BlockscoutAdapter'
 import {
   GetTxsParams,
   NetworkAdapter,
@@ -64,7 +65,19 @@ export interface EvmScanAdapterConfig {
   gastrackerSupport?: boolean
 }
 
-export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
+export class EvmScanAdapter<
+  Config extends
+    | EvmScanAdapterConfig
+    | BlockscoutAdapterConfig = EvmScanAdapterConfig
+> extends NetworkAdapter<Config> {
+  /** Blockscout serves these separately; see `BlockscoutAdapter` */
+  fetchInternalTxs:
+    | ((params: GetTxsParams) => Promise<EthereumNetworkUpdate>)
+    | null = null
+
+  /** Extra headers on every `/api` request; subclasses set them per provider */
+  protected requestHeaders: Record<string, string> | undefined = undefined
+
   batchMulticastRpc = null
   connect = null
   disconnect = null
@@ -219,6 +232,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     const { startBlock, tokenId } = params
     let server: string
     let allTransactions
+    let includesInternal = false
 
     if (tokenId === null) {
       const txsRegularResp = await this.getAllTxsEthscan(
@@ -244,6 +258,8 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
         ...txsRegularResp.allTransactions,
         ...txsInternalResp.allTransactions
       ])
+      includesInternal =
+        this.ethEngine.networkInfo.disableEvmScanInternal !== true
     } else {
       const tokenInfo = this.ethEngine.allTokensMap[tokenId]
       if (
@@ -266,7 +282,8 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
 
     const edgeTransactionsBlockHeightTuple: EdgeTransactionsBlockHeightTuple = {
       blockHeight: startBlock,
-      edgeTransactions: allTransactions
+      edgeTransactions: allTransactions,
+      includesInternal
     }
     const maxBlockHeight = allTransactions.reduce((max, tx) => {
       return Math.max(max, tx.blockHeight)
@@ -279,7 +296,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
   }
 
   // TODO: Clean return type
-  private async fetchGetEtherscan(
+  protected async fetchGetEtherscan(
     server: string,
     cmd: string
   ): Promise<EvmScanResponse<unknown>> {
@@ -314,7 +331,10 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
       url = `${server}/api${cmd}`
     }
 
-    const response = await this.ethEngine.engineFetch(`${url}${apiKeyParam}`)
+    const response = await this.ethEngine.engineFetch(
+      `${url}${apiKeyParam}`,
+      this.requestHeaders == null ? undefined : { headers: this.requestHeaders }
+    )
 
     if (!response.ok) {
       const resBody = await response.text()
@@ -333,7 +353,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     return cleanData
   }
 
-  private async getAllTxsEthscan(
+  protected async getAllTxsEthscan(
     startBlock: number,
     tokenId: EdgeTokenId,
     asTransaction: Cleaner<
@@ -420,7 +440,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     return { allTransactions, server }
   }
 
-  private async getL1RollupFee(
+  protected async getL1RollupFee(
     tx:
       | EvmScanTransaction
       | EvmScanInternalTransaction
@@ -459,7 +479,7 @@ export class EvmScanAdapter extends NetworkAdapter<EvmScanAdapterConfig> {
     return l1RollupFee
   }
 
-  private handledUnexpectedResponse(
+  protected handledUnexpectedResponse(
     server: string,
     action: string,
     response: EvmScanErrorResponse
@@ -592,10 +612,13 @@ export function processEvmScanTransaction(
 export function mergeEdgeTransactions(
   transactions: EdgeTransaction[]
 ): EdgeTransaction[] {
-  // The Map key is the txid and tokenId concatenated
+  // The Map key is the txid and tokenId concatenated. The txid is compared
+  // case-insensitively because rows from two APIs may not agree on hex case.
   const txidToTransaction: Map<string, EdgeTransaction> = new Map()
   for (const transaction of transactions) {
-    const uniqueKey = `${transaction.txid}:${transaction.tokenId ?? ''}`
+    const uniqueKey = `${transaction.txid.toLowerCase()}:${
+      transaction.tokenId ?? ''
+    }`
     const existingTransaction = txidToTransaction.get(uniqueKey)
     if (existingTransaction == null) {
       txidToTransaction.set(uniqueKey, transaction)
@@ -697,7 +720,13 @@ const asEvmScanErrorResponse = asObject<EvmScanErrorResponse>({
 })
 
 interface EvmScanSuccessResponse<T> {
-  status: '1'
+  /**
+   * "1" is a complete answer. Blockscout answers "2" with the rows it has
+   * when part of the requested block range is still being indexed
+   * ("Some internal transactions within this block range have not yet been
+   * processed"); the lookback overlap on the next sync picks up the rest.
+   */
+  status: '1' | '2'
   message: string
   result: T
 }
@@ -705,7 +734,7 @@ const asEvmScanSuccessResponse =
   <T>(asT: Cleaner<T>): Cleaner<EvmScanSuccessResponse<T>> =>
   (raw: unknown) => {
     return asObject<EvmScanSuccessResponse<T>>({
-      status: asValue('1'),
+      status: asValue('1', '2'),
       message: asString,
       result: asT
     })(raw)
@@ -726,11 +755,11 @@ const asEvmScanProxyResponse =
     })(raw)
   }
 
-type EvmScanResponse<T> =
+export type EvmScanResponse<T> =
   | EvmScanSuccessResponse<T>
   | EvmScanProxyResponse<T>
   | EvmScanErrorResponse
-const asEvmScanResponse =
+export const asEvmScanResponse =
   <T>(asT: Cleaner<T>): Cleaner<EvmScanResponse<T>> =>
   (raw: unknown) => {
     return asEither(

--- a/src/ethereum/networkAdapters/FilfoxAdapter.ts
+++ b/src/ethereum/networkAdapters/FilfoxAdapter.ts
@@ -22,6 +22,7 @@ export interface FilfoxAdapterConfig {
 }
 
 export class FilfoxAdapter extends NetworkAdapter<FilfoxAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   connect = null

--- a/src/ethereum/networkAdapters/PulsechainScanAdapter.ts
+++ b/src/ethereum/networkAdapters/PulsechainScanAdapter.ts
@@ -20,6 +20,7 @@ export interface PulsechainScanAdapterConfig {
 }
 
 export class PulsechainScanAdapter extends NetworkAdapter<PulsechainScanAdapterConfig> {
+  fetchInternalTxs = null
   batchMulticastRpc = null
   broadcast = null
   connect = null

--- a/src/ethereum/networkAdapters/RpcAdapter.ts
+++ b/src/ethereum/networkAdapters/RpcAdapter.ts
@@ -25,6 +25,7 @@ export interface RpcAdapterConfig {
 }
 
 export class RpcAdapter extends NetworkAdapter<RpcAdapterConfig> {
+  fetchInternalTxs = null
   connect = null
   disconnect = null
   fetchTxs = null

--- a/src/ethereum/networkAdapters/RpcAdapter.ts
+++ b/src/ethereum/networkAdapters/RpcAdapter.ts
@@ -14,11 +14,8 @@ import ETH_BAL_CHECKER_ABI from '../abi/ETH_BAL_CHECKER_ABI.json'
 import { EthereumEngine } from '../EthereumEngine'
 import { BroadcastResults, EthereumNetworkUpdate } from '../EthereumNetwork'
 import { asEtherscanGetBlockHeight } from '../ethereumSchema'
-import {
-  asEthereumInitKeys,
-  asRpcResultString,
-  RpcResultString
-} from '../ethereumTypes'
+import { asRpcResultString, RpcResultString } from '../ethereumTypes'
+import { resolveServerApiKey } from './apiKeyTemplate'
 import { NetworkAdapter } from './networkAdapterTypes'
 
 export interface RpcAdapterConfig {
@@ -425,23 +422,7 @@ export class RpcAdapter extends NetworkAdapter<RpcAdapterConfig> {
         }
 
   private addRpcApiKey(url: string): string {
-    const regex = /{{(.*?)}}/g
-    const match = regex.exec(url)
-    if (match != null) {
-      const key = match[1]
-      const cleanKey = asEthereumInitKeys(key)
-      const apiKey = this.ethEngine.initOptions[cleanKey]
-      if (typeof apiKey === 'string') {
-        url = url.replace(match[0], apiKey)
-      } else if (apiKey == null) {
-        throw new Error(
-          `Missing ${cleanKey} in 'initOptions' for ${this.ethEngine.currencyInfo.pluginId}`
-        )
-      } else {
-        throw new Error('Incorrect apikey type for RPC')
-      }
-    }
-    return url
+    return resolveServerApiKey(url, this.ethEngine)
   }
 
   // TODO: Clean return type

--- a/src/ethereum/networkAdapters/apiKeyTemplate.ts
+++ b/src/ethereum/networkAdapters/apiKeyTemplate.ts
@@ -1,0 +1,28 @@
+import { EthereumEngine } from '../EthereumEngine'
+import { asEthereumInitKeys } from '../ethereumTypes'
+
+/**
+ * Replaces a `{{initOptionKey}}` placeholder in a server URL with the matching
+ * value from the engine's init options. Throws when the option is missing or
+ * not a string, so callers can drop that server from their list.
+ */
+export function resolveServerApiKey(
+  url: string,
+  ethEngine: EthereumEngine
+): string {
+  const regex = /{{(.*?)}}/g
+  const match = regex.exec(url)
+  if (match == null) return url
+
+  const cleanKey = asEthereumInitKeys(match[1])
+  const apiKey = ethEngine.initOptions[cleanKey]
+  if (typeof apiKey === 'string') {
+    return url.replace(match[0], apiKey)
+  }
+  if (apiKey == null) {
+    throw new Error(
+      `Missing ${cleanKey} in 'initOptions' for ${ethEngine.currencyInfo.pluginId}`
+    )
+  }
+  throw new Error('Incorrect apikey type for RPC')
+}

--- a/src/ethereum/networkAdapters/networkAdapterTypes.ts
+++ b/src/ethereum/networkAdapters/networkAdapterTypes.ts
@@ -15,6 +15,7 @@ import {
 } from '../../common/utils'
 import { EthereumEngine } from '../EthereumEngine'
 import { BroadcastResults, EthereumNetworkUpdate } from '../EthereumNetwork'
+import { AlchemyAdapterConfig } from './AlchemyAdapter'
 import { AmberdataAdapterConfig } from './AmberdataAdapter'
 import { BlockbookAdapterConfig } from './BlockbookAdapter'
 import { BlockbookWsAdapterConfig } from './BlockbookWsAdapter'
@@ -32,6 +33,7 @@ export interface GetTxsParams {
 }
 
 export type NetworkAdapterConfig =
+  | AlchemyAdapterConfig
   | AmberdataAdapterConfig
   | BlockbookAdapterConfig
   | BlockbookWsAdapterConfig

--- a/src/ethereum/networkAdapters/networkAdapterTypes.ts
+++ b/src/ethereum/networkAdapters/networkAdapterTypes.ts
@@ -21,6 +21,7 @@ import { BlockbookAdapterConfig } from './BlockbookAdapter'
 import { BlockbookWsAdapterConfig } from './BlockbookWsAdapter'
 import { BlockchairAdapterConfig } from './BlockchairAdapter'
 import { BlockcypherAdapterConfig } from './BlockcypherAdapter'
+import { BlockscoutAdapterConfig } from './BlockscoutAdapter'
 import { EvmScanAdapterConfig } from './EvmScanAdapter'
 import { FilfoxAdapterConfig } from './FilfoxAdapter'
 import { PulsechainScanAdapterConfig } from './PulsechainScanAdapter'
@@ -39,6 +40,7 @@ export type NetworkAdapterConfig =
   | BlockbookWsAdapterConfig
   | BlockchairAdapterConfig
   | BlockcypherAdapterConfig
+  | BlockscoutAdapterConfig
   | EvmScanAdapterConfig
   | FilfoxAdapterConfig
   | PulsechainScanAdapterConfig
@@ -47,6 +49,7 @@ export type NetworkAdapterConfig =
 export type NetworkAdapterUpdateMethod = keyof Pick<
   NetworkAdapter<NetworkAdapterConfig>,
   | 'fetchBlockheight'
+  | 'fetchInternalTxs'
   | 'fetchNonce'
   | 'fetchTokenBalance'
   | 'fetchTokenBalances'
@@ -60,6 +63,15 @@ export abstract class NetworkAdapter<
 > {
   config: Config
   ethEngine: EthereumEngine
+
+  /**
+   * How many times `serialServers` and `parallelServers` retry a call after
+   * a `RateLimitError` before giving up (1s, 2s, 4s, ... between attempts).
+   * Unbounded by default; an adapter whose failure the engine can absorb
+   * (a secondary source like `BlockscoutAdapter`) sets a small number so a
+   * throttled provider does not hold a sync open.
+   */
+  protected rateLimitRetries: number = Infinity
 
   constructor(engine: EthereumEngine, config: Config) {
     this.ethEngine = engine
@@ -75,6 +87,15 @@ export abstract class NetworkAdapter<
   abstract disconnect: (() => void) | null
 
   abstract fetchBlockheight:
+    | ((...args: any[]) => Promise<EthereumNetworkUpdate>)
+    | null
+
+  /**
+   * Native-asset value moved by contract calls (internal transactions).
+   * Only needed when `fetchTxs` cannot report them itself; the engine merges
+   * the rows into the native-asset history of the same sync pass.
+   */
+  abstract fetchInternalTxs:
     | ((...args: any[]) => Promise<EthereumNetworkUpdate>)
     | null
 
@@ -158,7 +179,12 @@ export abstract class NetworkAdapter<
     } catch (error) {
       if (error instanceof RateLimitError) {
         this.ethEngine.warn(error.message)
-        return await exponentialBackoff(async () => await callServers())
+        return await exponentialBackoff(
+          async () => await callServers(),
+          1000,
+          2,
+          this.rateLimitRetries
+        )
       }
       throw error
     }
@@ -181,7 +207,12 @@ export abstract class NetworkAdapter<
     } catch (error) {
       if (error instanceof RateLimitError) {
         this.ethEngine.warn(error.message)
-        return await exponentialBackoff(async () => await callServers())
+        return await exponentialBackoff(
+          async () => await callServers(),
+          1000,
+          2,
+          this.rateLimitRetries
+        )
       }
       throw error
     }

--- a/test/ethereum/network/alchemyTxProcessing.test.ts
+++ b/test/ethereum/network/alchemyTxProcessing.test.ts
@@ -1,0 +1,306 @@
+import { assert } from 'chai'
+import { EdgeTransaction } from 'edge-core-js'
+import { describe, it } from 'mocha'
+
+import {
+  builtinTokens,
+  currencyInfo
+} from '../../../src/ethereum/info/robinhoodInfo'
+import {
+  AlchemyAssetTransfer,
+  AlchemyTxDetails,
+  makeFailedSend,
+  processAlchemyTransfers
+} from '../../../src/ethereum/networkAdapters/AlchemyAdapter'
+import { TransactionProcessingContext } from '../../../src/ethereum/networkAdapters/EvmScanAdapter'
+
+const ourAddress = '0x9488eed0543De2A64Dd73d0E8e3bBd87915516B7'
+const otherAddress = '0x4ef026964fdec686efb7594835cb681faf44bc25'
+const usdcAddress = '0x80e0e24718dbFcad49ECAA6F1e6C89A190586cA8'
+const usdcTokenId = '80e0e24718dbfcad49ecaa6f1e6c89a190586ca8'
+const walletId = 'VWJmHu/i8kqi6Ru6/B0UQlTEy38jZJsgIp670NkeoxI='
+
+const nativeContext: TransactionProcessingContext = {
+  allTokensMap: builtinTokens,
+  currencyInfo,
+  forWhichAddress: ourAddress,
+  forWhichTokenId: null,
+  forWhichWalletId: walletId
+}
+const usdcContext: TransactionProcessingContext = {
+  ...nativeContext,
+  forWhichTokenId: usdcTokenId
+}
+
+// 21000 gas at 0.01 gwei:
+const spendDetails: AlchemyTxDetails = {
+  from: ourAddress.toLowerCase(),
+  to: otherAddress,
+  nonce: '2',
+  gas: '21000',
+  gasPrice: '10000000',
+  gasUsed: '21000',
+  blockHeight: 35308086,
+  succeeded: true
+}
+const spendFee = '210000000000'
+
+const makeTransfer = (
+  overrides: Partial<AlchemyAssetTransfer> & { hash: string }
+): AlchemyAssetTransfer => ({
+  blockNum: '0x21ac236',
+  uniqueId: `${overrides.hash}:external`,
+  category: 'external',
+  from: otherAddress,
+  to: ourAddress.toLowerCase(),
+  rawContract: { value: '0x38d7ea4c68000', address: null },
+  metadata: { blockTimestamp: '2026-08-13T10:10:41.000Z' },
+  ...overrides
+})
+
+describe('AlchemyAdapter transfer processing', function () {
+  it('reports an external receive without a fee', function () {
+    const hash =
+      '0x70e4950b5991c9419eff70ea2478c7ae55c5c58adcc3da237d5889394f8fdf62'
+    const [tx] = processAlchemyTransfers(
+      nativeContext,
+      [makeTransfer({ hash })],
+      new Map()
+    )
+    assert.equal(tx.txid, hash)
+    assert.equal(tx.nativeAmount, '1000000000000000')
+    assert.equal(tx.networkFee, '0')
+    assert.equal(tx.isSend, false)
+    assert.equal(tx.blockHeight, 35308086)
+    assert.equal(tx.date, Date.parse('2026-08-13T10:10:41.000Z') / 1000)
+    assert.equal(tx.currencyCode, 'ETH')
+    assert.deepEqual(tx.ourReceiveAddresses, [ourAddress])
+    assert.equal(tx.tokenId, null)
+    assert.equal(tx.walletId, walletId)
+    assert.isUndefined(tx.parentNetworkFee)
+    assert.isUndefined(tx.otherParams?.nonceUsed)
+  })
+
+  it('folds the fee into an external spend', function () {
+    const hash =
+      '0xd5fe57cead105a391eaba43e299d414945d04ab3be7f3d216c0e6c9fea899242'
+    const [tx] = processAlchemyTransfers(
+      nativeContext,
+      [
+        makeTransfer({
+          hash,
+          from: ourAddress.toLowerCase(),
+          to: otherAddress,
+          rawContract: { value: '0x2386f26fc10000', address: null }
+        })
+      ],
+      new Map([[hash, spendDetails]])
+    )
+    assert.equal(tx.nativeAmount, '-10000210000000000')
+    assert.equal(tx.networkFee, spendFee)
+    assert.equal(tx.isSend, true)
+    assert.deepEqual(tx.ourReceiveAddresses, [])
+    assert.equal(tx.otherParams?.nonceUsed, '2')
+    assert.equal(tx.otherParams?.gasUsed, '21000')
+    assert.deepEqual(tx.feeRateUsed, {
+      gasPrice: '0.01',
+      gasUsed: '21000',
+      gasLimit: '21000'
+    })
+  })
+
+  it('nets a self-send to the fee alone, seen from both directions', function () {
+    const hash =
+      '0x5a329ee023cb675d057ac3a0cf8404a40c6e3267287391ad04d6bdf2f3bc78ae'
+    const selfTransfer = makeTransfer({
+      hash,
+      from: ourAddress.toLowerCase(),
+      to: ourAddress.toLowerCase(),
+      rawContract: { value: '0x2386f26fc10000', address: null }
+    })
+    // The fromAddress and toAddress queries both return this transfer:
+    const txs = processAlchemyTransfers(
+      nativeContext,
+      [selfTransfer, { ...selfTransfer }],
+      new Map([[hash, { ...spendDetails, to: ourAddress.toLowerCase() }]])
+    )
+    assert.lengthOf(txs, 1)
+    assert.equal(txs[0].nativeAmount, `-${spendFee}`)
+    assert.equal(txs[0].networkFee, spendFee)
+    assert.equal(txs[0].isSend, true)
+    assert.deepEqual(txs[0].ourReceiveAddresses, [])
+  })
+
+  it('keeps a zero-value contract call as a fee-only spend', function () {
+    const hash =
+      '0x63395211dc9af5a8e0711d6e03f21c5f5733f39c8be7a72b6ece5339a925bf4a'
+    const [tx] = processAlchemyTransfers(
+      nativeContext,
+      [
+        makeTransfer({
+          hash,
+          from: ourAddress.toLowerCase(),
+          to: usdcAddress.toLowerCase(),
+          rawContract: { value: '0x0', address: null }
+        })
+      ],
+      new Map([[hash, { ...spendDetails, to: usdcAddress.toLowerCase() }]])
+    )
+    assert.equal(tx.nativeAmount, `-${spendFee}`)
+    assert.equal(tx.networkFee, spendFee)
+    assert.equal(tx.isSend, true)
+  })
+
+  it('reports a token receive under the token', function () {
+    const hash =
+      '0x69ac9c55f7af454eb6ab54991b29a0ed8f1349279ba00acea5d649cf3ed6df5e'
+    const [tx] = processAlchemyTransfers(
+      usdcContext,
+      [
+        makeTransfer({
+          hash,
+          uniqueId: `${hash}:log:40`,
+          rawContract: {
+            value: '0x5f5e100',
+            address: usdcAddress.toLowerCase()
+          }
+        })
+      ],
+      new Map()
+    )
+    assert.equal(tx.currencyCode, 'USDC')
+    assert.equal(tx.tokenId, usdcTokenId)
+    assert.equal(tx.nativeAmount, '100000000')
+    assert.equal(tx.networkFee, '0')
+    assert.isUndefined(tx.parentNetworkFee)
+    assert.equal(tx.isSend, false)
+    assert.deepEqual(tx.ourReceiveAddresses, [ourAddress])
+  })
+
+  it('carries the fee of a token spend as parentNetworkFee', function () {
+    const hash =
+      '0x4dbc35a0faf5bcac05aab891fbd0021867835c228321a4a9e25df000a6f16764'
+    const [tx] = processAlchemyTransfers(
+      usdcContext,
+      [
+        makeTransfer({
+          hash,
+          uniqueId: `${hash}:log:7`,
+          from: ourAddress.toLowerCase(),
+          to: otherAddress,
+          rawContract: {
+            value: '0x2faf080',
+            address: usdcAddress.toLowerCase()
+          }
+        })
+      ],
+      new Map([[hash, { ...spendDetails, to: usdcAddress.toLowerCase() }]])
+    )
+    assert.equal(tx.nativeAmount, '-50000000')
+    assert.equal(tx.networkFee, '0')
+    assert.equal(tx.parentNetworkFee, spendFee)
+    assert.equal(tx.isSend, true)
+  })
+
+  it('leaves the fee off a token pull the wallet did not sign', function () {
+    const hash =
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+    const [tx] = processAlchemyTransfers(
+      usdcContext,
+      [
+        makeTransfer({
+          hash,
+          uniqueId: `${hash}:log:3`,
+          from: ourAddress.toLowerCase(),
+          to: otherAddress,
+          rawContract: {
+            value: '0x2faf080',
+            address: usdcAddress.toLowerCase()
+          }
+        })
+      ],
+      new Map([[hash, { ...spendDetails, from: otherAddress }]])
+    )
+    assert.equal(tx.nativeAmount, '-50000000')
+    assert.isUndefined(tx.parentNetworkFee)
+    assert.equal(tx.isSend, true)
+  })
+
+  it('answers empty for a token the engine does not know', function () {
+    const hash =
+      '0x3333333333333333333333333333333333333333333333333333333333333333'
+    const txs = processAlchemyTransfers(
+      { ...nativeContext, forWhichTokenId: 'deadbeef' },
+      [makeTransfer({ hash, uniqueId: `${hash}:log:1` })],
+      new Map()
+    )
+    assert.deepEqual(txs, [])
+  })
+
+  it('reports a reverted pending send as failed with its fee', function () {
+    const hash =
+      '0x4444444444444444444444444444444444444444444444444444444444444444'
+    const pending: EdgeTransaction = {
+      blockHeight: 0,
+      currencyCode: 'ETH',
+      date: 1788472800,
+      isSend: true,
+      memos: [],
+      nativeAmount: '-10000210000000000',
+      networkFee: '210000000000',
+      networkFees: [],
+      otherParams: { nonceUsed: '3', isFromMakeSpend: true },
+      ourReceiveAddresses: [],
+      signedTx: '0xdead',
+      tokenId: null,
+      txid: hash,
+      walletId
+    }
+    const failed = makeFailedSend(pending, {
+      ...spendDetails,
+      blockHeight: 53700000,
+      succeeded: false,
+      gasUsed: '23000'
+    })
+    assert.equal(failed.confirmations, 'failed')
+    assert.equal(failed.blockHeight, 53700000)
+    assert.equal(failed.nativeAmount, '-230000000000')
+    assert.equal(failed.networkFee, '230000000000')
+    assert.equal(failed.date, pending.date)
+    assert.equal(failed.otherParams?.nonceUsed, '3')
+    const failedToken = makeFailedSend(
+      { ...pending, tokenId: usdcTokenId, currencyCode: 'USDC' },
+      { ...spendDetails, blockHeight: 53700001, succeeded: false }
+    )
+    assert.equal(failedToken.nativeAmount, '0')
+    assert.equal(failedToken.parentNetworkFee, spendFee)
+  })
+
+  it('sums several transfers of one transaction', function () {
+    const hash =
+      '0x2222222222222222222222222222222222222222222222222222222222222222'
+    const [tx] = processAlchemyTransfers(
+      usdcContext,
+      [
+        makeTransfer({
+          hash,
+          uniqueId: `${hash}:log:1`,
+          rawContract: {
+            value: '0x5f5e100',
+            address: usdcAddress.toLowerCase()
+          }
+        }),
+        makeTransfer({
+          hash,
+          uniqueId: `${hash}:log:2`,
+          rawContract: {
+            value: '0x5f5e100',
+            address: usdcAddress.toLowerCase()
+          }
+        })
+      ],
+      new Map()
+    )
+    assert.equal(tx.nativeAmount, '200000000')
+  })
+})

--- a/test/ethereum/network/evmScanRateLimit.test.ts
+++ b/test/ethereum/network/evmScanRateLimit.test.ts
@@ -1,0 +1,52 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { isEvmScanRateLimitResponse } from '../../../src/ethereum/networkAdapters/EvmScanAdapter'
+
+describe('EvmScanAdapter rate limit classification', function () {
+  it('classifies the public Blockscout throttle reply', function () {
+    // Captured 2026-09-01 from https://robinhoodchain.blockscout.com/api
+    // during a two-simulator sync on one IP:
+    const captured = {
+      message:
+        'Too many requests. Increase limits now at https://dev.blockscout.com',
+      result: null,
+      status: '0'
+    } as const
+    assert.isTrue(isEvmScanRateLimitResponse(captured))
+  })
+
+  it('classifies the Etherscan throttle replies', function () {
+    assert.isTrue(
+      isEvmScanRateLimitResponse({
+        message: 'NOTOK',
+        result: 'Max calls per sec rate limit reached (5/sec)',
+        status: '0'
+      })
+    )
+    assert.isTrue(
+      isEvmScanRateLimitResponse({
+        message: 'NOTOK',
+        result: 'Max rate limit reached',
+        status: '0'
+      })
+    )
+  })
+
+  it('leaves ordinary empty-result replies alone', function () {
+    assert.isFalse(
+      isEvmScanRateLimitResponse({
+        message: 'No transactions found',
+        result: [],
+        status: '0'
+      })
+    )
+    assert.isFalse(
+      isEvmScanRateLimitResponse({
+        message: 'NOTOK',
+        result: 'Error! Invalid address format',
+        status: '0'
+      })
+    )
+  })
+})

--- a/test/ethereum/network/evmScanResponse.test.ts
+++ b/test/ethereum/network/evmScanResponse.test.ts
@@ -1,0 +1,31 @@
+import { assert } from 'chai'
+import { asArray, asUnknown } from 'cleaners'
+import { describe, it } from 'mocha'
+
+import { asEvmScanResponse } from '../../../src/ethereum/networkAdapters/EvmScanAdapter'
+
+describe('EvmScanAdapter response cleaner', function () {
+  it("accepts Blockscout's partially indexed reply as a success", function () {
+    // Captured 2026-09-03 from robinhoodchain.blockscout.com txlistinternal:
+    const captured = {
+      message:
+        'Some internal transactions within this block range have not yet been processed',
+      result: [{ transactionHash: '0x7db4', value: '11497349198206467' }],
+      status: '2'
+    }
+    const clean = asEvmScanResponse(asArray(asUnknown))(captured)
+    if (!('status' in clean) || clean.status !== '2') {
+      assert.fail('expected the status "2" success shape')
+    }
+    assert.lengthOf(clean.result, 1)
+  })
+
+  it('keeps the error shape for status "0"', function () {
+    const clean = asEvmScanResponse(asArray(asUnknown))({
+      message: 'No transactions found',
+      result: [],
+      status: '0'
+    })
+    assert.isTrue('status' in clean && clean.status === '0')
+  })
+})

--- a/test/ethereum/network/evmScanTxMerging.test.ts
+++ b/test/ethereum/network/evmScanTxMerging.test.ts
@@ -292,3 +292,38 @@ describe(`mergeEdgeTransactions for token transactions`, function () {
     )
   })
 })
+
+describe('mergeEdgeTransactions across sources', function () {
+  it('merges rows whose txids differ only in hex case', function () {
+    const base = {
+      blockHeight: 100,
+      currencyCode: 'ETH',
+      date: 1,
+      memos: [],
+      networkFees: [],
+      ourReceiveAddresses: [],
+      signedTx: '',
+      tokenId: null,
+      walletId: 'w'
+    }
+    const merged = mergeEdgeTransactions([
+      {
+        ...base,
+        txid: '0xABCDEF',
+        isSend: true,
+        nativeAmount: '-1000210000000000',
+        networkFee: '210000000000'
+      },
+      {
+        ...base,
+        txid: '0xabcdef',
+        isSend: false,
+        nativeAmount: '400000000000000',
+        networkFee: '0'
+      }
+    ])
+    assert.lengthOf(merged, 1)
+    assert.equal(merged[0].nativeAmount, '-600210000000000')
+    assert.equal(merged[0].networkFee, '210000000000')
+  })
+})


### PR DESCRIPTION
### Technical Design Document

[robinhood-chain.md](https://github.com/EdgeApp/edge-currency-accountbased/blob/jon/robinhood-alchemy-history/src/docs/robinhood-chain.md)

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Runtime, not merge-order: [EdgeApp/edge-react-gui#6150](https://github.com/EdgeApp/edge-react-gui/pull/6150) declares `ROBINHOOD_INIT` in `envConfig.ts`, which is how `alchemyApiKey` reaches this plugin. On a gui build without it the `alchemy` adapter drops its server and Blockscout serves history exactly as before this PR. [EdgeApp/edge-currency-accountbased#1062](https://github.com/EdgeApp/edge-currency-accountbased/pull/1062) removes the `alchemyApiKey` init option and must be rescoped to BlockCypher-only before it lands.

### Description

Asana: https://app.asana.com/0/1215088146871429/1218075069562188

Robinhood Chain (pluginId `robinhood`, chain 4663) read transaction history from the public Blockscout instance alone. Blockscout allows 300 requests per minute per client IP, one wallet sync is 9 calls, and past the limit it answers HTTP 200 with `{"message":"Too many requests…","result":null,"status":"0"}`. `EvmScanAdapter` only looked for throttle text in `result`, so that reply fell through as an ordinary error: no `RateLimitError`, no backoff, history stayed empty, and a pending send blocked the slider until a resync.

The branch carries these commits:

1. **Classify Blockscout throttling as a rate limit.** `isEvmScanRateLimitResponse` recognizes the Blockscout reply (text in `message`, `result: null`) alongside the Etherscan variants, so `serialServers` backs off. Unit test with the captured JSON.
2. **Add an Alchemy network adapter.** `AlchemyAdapter` (type `alchemy`) serves `fetchTxs` from `alchemy_getAssetTransfers` (external for the native asset, erc20 with `contractAddresses` per token; `fromAddress` and `toAddress` queries; `pageKey` pagination; `withMetadata` timestamps) and `fetchTokenBalances` from `alchemy_getTokenBalances`. Asset transfers carry no gas data, so the wallet's own spends are completed with `eth_getTransactionByHash` and `eth_getTransactionReceipt` from the same endpoint in one batch, and rows are folded per transaction hash with the amount and fee conventions of `processEvmScanTransaction` (spend includes the fee, self-send nets to the fee, token spend carries `parentNetworkFee`). Written for any Alchemy-served chain. The `{{alchemyApiKey}}` placeholder resolves through a helper shared with `RpcAdapter`, and a server whose key is missing drops out of the waterfall. Eight unit tests cover receive, spend, self-send seen from both directions, zero-value contract call, token receive, token spend, a token pull the wallet did not sign, and multi-transfer folding.
3. **Add a Blockscout network adapter.** `BlockscoutAdapter` (type `blockscout`) extends the evmscan adapter for the places Blockscout differs: block height from `eth_block_number`, no gastracker, and a `status: "2"` partially-indexed reply accepted as a success (that reply was failing the cleaner before). Internal transactions get their own adapter method, `NetworkAdapter.fetchInternalTxs`, which `EthereumNetwork.acquireTxs` calls on every native-asset sync whose `fetchTxs` rows did not already carry internal transfers (`tuple.includesInternal`) and merges with `mergeEdgeTransactions` before `addTransaction`, since the engine replaces a known transaction on an amount change and needs the external and internal halves as one row. If the internal source fails, the pass is marked `partial`: only unknown or still-unconfirmed txids are applied and the query window stays open. The Blockscout adapter bounds its rate-limit retries (three, 1s/2s/4s) instead of the base adapter's unbounded backoff and pauses `fetchInternalTxs` for 60s after a throttle reply, so a throttled public instance costs one partial pass rather than holding the native-asset sync open.
4. **Robinhood Chain: history from Alchemy first.** `alchemy` leads `networkAdapterConfigs`, the Alchemy endpoint joins the RPC server list, `blockscout` replaces the `evmscan` entry (internal transactions merged into every native sync, history fallback for everything else), and `ethBalCheckerContract` points at the eth-balance-checker deployed to `0x8950F12786CAE64F94a02733A260ca6FecDaeD7f` in block 52107662 (same runtime bytecode as the checker other Edge plugins use at `0x7263…`, deployed from a key generated for this work). `src/docs/robinhood-chain.md` gets a phase 8 entry, decisions 2 and 3 reopened, and the retrospective line that claimed a Blockscout key would remove the limit without a code change corrected. The commit body's claim that Blockscout is the only source of internal transactions predates the fixup; the design doc and this description carry the corrected mechanism.

Adapter dispatch is `asyncWaterfall`: the first adapter to answer wins each call, so Blockscout is only queried for history while Alchemy is failing; `fetchInternalTxs` is the one call it serves on every sync. The Alchemy adapter asks for `['external', 'internal']` on native-asset queries and remembers, per endpoint, a `-32602 category is not supported` rejection, re-querying with `external` alone, so a chain where Alchemy serves internal transfers gets them from that adapter without a Blockscout entry.

Tested in the app on the iOS simulator with the plugin linked into the gui at PR 6150's head: three Robinhood Chain wallets of one account syncing at once, engine log showing `tokenTxs`/`tokenBal`/`blockHeight` won by `robinhood-mainnet.g.alchemy.com` on every sync and no throttle line; the wallet's transaction list rendered; a real send of 0.0005389 ETH reached "Transaction Success" (tx `0xe2be5265fa03f9704960c31d7aa8bbe5fb839a82d7d9c280690be49fc0d21419`); and with the Alchemy host made unreachable in the installed bundle, `tokenBal ethBalChecker won` took over balances and Blockscout's throttle was logged as `Rate limit exceeded` with backoff. Screenshots in the test-evidence comment.

Review round 1 (2026-09-03): with the linked plugin rebuilt, My Robinhood Chain 2 (an EIP-7702 delegate whose deposits are swept out by internal calls) now lists the LI.FI payout and the sweeps that only `txlistinternal` reports, and the engine log shows `tokenTxs robinhood-mainnet.g.alchemy.com + https://robinhoodchain.blockscout.com won` on each native sync alongside the one-time `does not serve internal transfers; using external only` line from the Alchemy adapter. Those frames were captured with a temporary `User-Agent` header on the Blockscout request. A follow-up measurement from a phone on mobile data showed the challenge is not IP-specific: `robinhoodchain.blockscout.com` answers a Cloudflare challenge page to every non-browser agent (the app's CFNetwork and OkHttp agents included) from any IP, while `eth.blockscout.com` answers all of them. The Blockscout adapter therefore now sends a browser user agent on its `/api` requests, the same workaround `BlockbookAdapter` applies to Trezor's Blockbook servers, and that header is product code in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the Ethereum wallet sync and history path (new adapters, internal-tx merge, and global Blockscout rate-limit handling), though Robinhood retains Blockscout/RPC fallbacks and the behavior is covered by targeted tests.
> 
> **Overview**
> Robinhood Chain (**`robinhood`**, chain 4663) no longer relies on the public Blockscout API alone for transaction history and token balances. The plugin now leads with a new **`AlchemyAdapter`** (`alchemy_getAssetTransfers`, `alchemy_getTokenBalances`, with RPC completion for fees on wallet sends) and falls back to a dedicated **`BlockscoutAdapter`** when Alchemy is missing or fails.
> 
> **Engine and explorer behavior:** Native-asset sync merges **internal transactions** from Blockscout via a new **`fetchInternalTxs`** adapter hook and **`mergeInternalTxs`** in **`EthereumNetwork`**, with **`partial`** passes when internal data fails so history is not overwritten incorrectly. **`EvmScanAdapter`** now treats Blockscout’s HTTP 200 “Too many requests” body as a **`RateLimitError`** (with backoff capped on Blockscout), accepts Blockscout **`status: "2"`** partial index replies, and merges txs case-insensitively across sources.
> 
> **Robinhood config:** **`robinhoodInfo`** registers **`alchemy`** first, swaps **`evmscan`** for **`blockscout`**, adds Alchemy to RPC servers, and sets **`ethBalCheckerContract`** for batched token balances when Alchemy is unavailable. Shared **`resolveServerApiKey`** replaces duplicated RPC placeholder logic.
> 
> Unit tests cover Alchemy transfer folding, rate-limit classification, and cross-source tx merging; docs and CHANGELOG describe phase 8 (keyed history).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b091e9a3fb172b40655761cb8d721956d4e60567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->