### PR TITLE
Show seed phrase for EVM and FIO wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: (EVM) Show the seed phrase rather than the hex private key
+- fixed: (FIO) Show the seed phrase rather than the FIO private key
+
 ## 4.91.0 (2026-09-08)
 
 - added: Robinhood Chain support (`robinhood`, EVM chain 4663)

--- a/src/ethereum/EthereumTools.ts
+++ b/src/ethereum/EthereumTools.ts
@@ -58,7 +58,9 @@ export class EthereumTools implements EdgeCurrencyTools {
   ): Promise<string> {
     const { pluginId } = this.currencyInfo
     const keys = asEthereumPrivateKeys(pluginId)(privateWalletInfo.keys)
-    return keys.privateKey
+    // Wallets imported from a raw hex key have no mnemonic, so the private
+    // key remains the fallback:
+    return keys.mnemonic ?? keys.privateKey
   }
 
   async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {

--- a/src/fio/FioTools.ts
+++ b/src/fio/FioTools.ts
@@ -93,7 +93,9 @@ export class FioTools implements EdgeCurrencyTools {
     privateWalletInfo: EdgeWalletInfo
   ): Promise<string> {
     const keys = asFioPrivateKeys(privateWalletInfo.keys)
-    return keys.fioKey
+    // Wallets imported from a raw private key have no mnemonic, so the FIO
+    // key remains the fallback:
+    return keys.mnemonic ?? keys.fioKey
   }
 
   async getDisplayPublicKey(publicWalletInfo: EdgeWalletInfo): Promise<string> {

--- a/src/fio/fioTypes.ts
+++ b/src/fio/fioTypes.ts
@@ -214,7 +214,8 @@ export const asSafeFioWalletInfo = asWalletInfo(
 
 export type FioPrivateKeys = ReturnType<typeof asFioPrivateKeys>
 export const asFioPrivateKeys = asObject({
-  fioKey: asString
+  fioKey: asString,
+  mnemonic: asOptional(asString)
 })
 
 export const comparisonFioNameString = (res: FioNamesResponse): string => {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/0/1215088146871429/1210071879529859

"Master Private Key" showed a hex private key instead of the seed phrase on
every EVM chain and on FIO, even when the mnemonic sat in the same keys object.
The core hands the plugin the same key data for both the raw-keys dump and the
display path; the EVM base class and FIO just picked the hex key.

`getDisplayPrivateKey` now prefers the mnemonic, which is what Solana already
does (`mnemonic ?? base58Key ?? privateKey`). The EVM base class covers the
whole reported chain list: ETH, ETHW, ETC, Pulse, Filecoin FEVM, Celo, Base,
Arbitrum, BOB, BSC, Avalanche, Polygon, Fantom, Sonic, Rootstock, Optimism.

A wallet imported from a raw hex key keeps showing that key. Mnemonic
derivation is one way, so no seed is stored and none can be computed; stored
keys are immutable, so this is read-time display logic only.

`asFioPrivateKeys` did not model the `mnemonic` that both `createPrivateKey`
and `importPrivateKey` write, so it is now an optional field.

### Consumer note

`edge-react-gui` used `account.getDisplayPrivateKey()` as an ethers signing key
in its uniswapV2 stake policies, and `ethers.Wallet` only accepts a private
key. That is fixed in the GUI PR linked on the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `getDisplayPrivateKey` output changes for EVM and FIO, so any caller that assumed a bare hex signing key could break until updated (noted for edge-react-gui); keys themselves are unchanged.
> 
> **Overview**
> **Master private key** display no longer defaults to the hex/FIO raw key when a mnemonic is stored. **EVM** wallets with a seed now return a labeled block with both the **seed phrase** and **hex private key**; hex-only imports and wallets where the mnemonic sits under another chain’s key name after a split still show **only the hex key**. **FIO** `getDisplayPrivateKey` now returns the **mnemonic** when present, with the FIO key as fallback for raw-key imports.
> 
> `asFioPrivateKeys` adds an optional **`mnemonic`** field so display parsing matches keys written at create/import time. **CHANGELOG** and unit tests cover the EVM display paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e691cfbae44c5d82a9cded7f80a26ca69f8afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->