### PR TITLE
Replace Monad RPC servers with official endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fixed: (Axelar) Replace the retired `axelar.tendermintrpc.lava.build` RPC node, which answers every request with HTTP 410 "This endpoint has been discontinued.", and the unreachable `axelar-archrpc.chainode.tech` archive node. Axelar wallets could reach neither balances nor transaction history, so their sync ratio sat at 0 forever with no visible error.
 - fixed: (Osmosis) Replace the `rpc.osmosis.zone` RPC node, which now returns HTTP 403 to every request. Osmosis wallets stalled partway through their sync ratio because the balance query never completed for enabled tokens.
+- fixed: (Monad) Wallets stuck at 50% sync with no balance
 
 ## 4.91.0 (2026-09-08)
 

--- a/src/ethereum/info/monadInfo.ts
+++ b/src/ethereum/info/monadInfo.ts
@@ -85,9 +85,11 @@ const networkInfo: EthereumNetworkInfo = {
     {
       type: 'rpc',
       servers: [
-        'https://monad.rpc.blxrbdn.com',
+        'https://rpc.monad.xyz',
+        'https://rpc1.monad.xyz',
         'https://rpc2.monad.xyz',
-        'https://monad-mainnet.drpc.org'
+        'https://rpc3.monad.xyz',
+        'https://rpc-mainnet.monadinfra.com'
       ],
       ethBalCheckerContract: '0x726391B6cA41761c4c332aa556Cf804A50279b52'
     },


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1218284982339426/f)

Monad wallets could sit at 50% sync with no balance. The rpc adapter reads balances through the eth-balance-checker `eth_call`, and two of the three configured servers could not serve it:

| Server | Result (2026-09-10) |
|---|---|
| `monad.rpc.blxrbdn.com` | DNS does not resolve |
| `monad-mainnet.drpc.org` | `eth_call` rejected with `-32601` |
| `rpc2.monad.xyz` | works |

This replaces the pool with the five public mainnet endpoints from https://docs.monad.xyz/developer-essentials/network-information: `rpc.monad.xyz`, `rpc1.monad.xyz`, `rpc2.monad.xyz`, `rpc3.monad.xyz` and `rpc-mainnet.monadinfra.com`. Each returned chain id 143 and answered the `balances()` call through ethers `JsonRpcProvider`, the same path `fetchTokenBalances` uses, in 255 to 710 ms.

`rpc-mainnet.monadinfra.com` rejects JSON-RPC batch requests. The only batch caller is the decoy-address lookup, which runs through `serialServers`. A rejected batch there falls through to the next server.

Tested on the iOS simulator with the rebuilt accountbased bundle in the app: the edge-funds Monad wallet loads its balance, and the network log shows no requests to the removed servers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Monad-only RPC URL changes with no auth or contract logic changes; batch rejection on one endpoint is mitigated by server failover.
> 
> **Overview**
> Fixes **Monad wallets stuck at ~50% sync with no balance** by swapping the RPC adapter’s server list for the five public mainnet endpoints from Monad’s network docs.
> 
> **Removed:** `monad.rpc.blxrbdn.com` (DNS failure) and `monad-mainnet.drpc.org` (`eth_call` for the eth-balance-checker rejected). **Added:** `rpc.monad.xyz`, `rpc1.monad.xyz`, `rpc3.monad.xyz`, and `rpc-mainnet.monadinfra.com` alongside the already-working `rpc2.monad.xyz`.
> 
> Balance sync still goes through the same `ethBalCheckerContract` `eth_call` path; more working fallbacks should let that step finish. One new endpoint rejects JSON-RPC batches (decoy-address lookup only); existing `serialServers` failover should cover that.
> 
> CHANGELOG **Unreleased** notes the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8529f26d2c245bc2f13b467f960cd3b7e6f68852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->