### PR TITLE
Restore webpack code splitting for plugin chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Restore webpack code splitting, so each plugin loads on demand instead of shipping in the initial bundle
+
 ## 4.91.0 (2026-09-08)
 
 - added: Robinhood Chain support (`robinhood`, EVM chain 4663)

--- a/src/algorand/algorandTestnetInfo.ts
+++ b/src/algorand/algorandTestnetInfo.ts
@@ -89,7 +89,7 @@ export const algorandtestnet = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "algorandtestnet" */
+      /* webpackChunkName: "algorand" */
       './AlgorandTools'
     )
   }

--- a/src/cardano/cardanoTestnetInfo.ts
+++ b/src/cardano/cardanoTestnetInfo.ts
@@ -53,6 +53,9 @@ export const cardanotestnet = makeOuterPlugin<
   },
 
   async getInnerPlugin() {
-    return await import('./CardanoTools')
+    return await import(
+      /* webpackChunkName: "cardano" */
+      './CardanoTools'
+    )
   }
 })

--- a/src/cosmos/info/axelarInfo.ts
+++ b/src/cosmos/info/axelarInfo.ts
@@ -80,7 +80,7 @@ export const axelar = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "axelar" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/coreumInfo.ts
+++ b/src/cosmos/info/coreumInfo.ts
@@ -203,7 +203,7 @@ export const coreum = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "coreum" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/cosmoshubInfo.ts
+++ b/src/cosmos/info/cosmoshubInfo.ts
@@ -73,7 +73,7 @@ export const cosmoshub = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "cosmoshub" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/mayachainInfo.ts
+++ b/src/cosmos/info/mayachainInfo.ts
@@ -84,7 +84,7 @@ export const mayachain = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "mayachain" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/nymInfo.ts
+++ b/src/cosmos/info/nymInfo.ts
@@ -82,7 +82,7 @@ export const nym = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "nym" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/osmosisInfo.ts
+++ b/src/cosmos/info/osmosisInfo.ts
@@ -106,7 +106,7 @@ export const osmosis = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "osmosis" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/thorchainruneInfo.ts
+++ b/src/cosmos/info/thorchainruneInfo.ts
@@ -109,7 +109,7 @@ export const thorchainrune = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "thorchainrune" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/cosmos/info/thorchainruneStagenetInfo.ts
+++ b/src/cosmos/info/thorchainruneStagenetInfo.ts
@@ -101,7 +101,7 @@ export const thorchainrunestagenet = makeOuterPlugin<
 
   async getInnerPlugin() {
     return await import(
-      /* webpackChunkName: "thorchainrunestagebet" */
+      /* webpackChunkName: "cosmos" */
       '../CosmosTools'
     )
   }

--- a/src/eos/info/telosInfo.ts
+++ b/src/eos/info/telosInfo.ts
@@ -57,6 +57,9 @@ export const telos = makeOuterPlugin<EosNetworkInfo, EosTools, EosInfoPayload>({
   otherMethodNames: eosOtherMethodNames,
 
   async getInnerPlugin() {
-    return await import('../EosTools')
+    return await import(
+      /* webpackChunkName: "eos" */
+      '../EosTools'
+    )
   }
 })

--- a/src/eos/info/waxInfo.ts
+++ b/src/eos/info/waxInfo.ts
@@ -53,6 +53,9 @@ export const wax = makeOuterPlugin<EosNetworkInfo, EosTools, EosInfoPayload>({
   otherMethodNames: eosOtherMethodNames,
 
   async getInnerPlugin() {
-    return await import('../EosTools')
+    return await import(
+      /* webpackChunkName: "eos" */
+      '../EosTools'
+    )
   }
 })

--- a/src/ethereum/info/abstractInfo.ts
+++ b/src/ethereum/info/abstractInfo.ts
@@ -118,6 +118,9 @@ export const abstract = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/amoyInfo.ts
+++ b/src/ethereum/info/amoyInfo.ts
@@ -129,6 +129,9 @@ export const amoy = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/arbitrumInfo.ts
+++ b/src/ethereum/info/arbitrumInfo.ts
@@ -226,6 +226,9 @@ export const arbitrum = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/avalancheInfo.ts
+++ b/src/ethereum/info/avalancheInfo.ts
@@ -275,6 +275,9 @@ export const avalanche = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/baseInfo.ts
+++ b/src/ethereum/info/baseInfo.ts
@@ -149,6 +149,9 @@ export const base = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/binancesmartchainInfo.ts
+++ b/src/ethereum/info/binancesmartchainInfo.ts
@@ -227,6 +227,9 @@ export const binancesmartchain = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/bobevmInfo.ts
+++ b/src/ethereum/info/bobevmInfo.ts
@@ -126,6 +126,9 @@ export const bobevm = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/botanixInfo.ts
+++ b/src/ethereum/info/botanixInfo.ts
@@ -122,6 +122,9 @@ export const botanix = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/celoInfo.ts
+++ b/src/ethereum/info/celoInfo.ts
@@ -144,6 +144,9 @@ export const celo = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/ethDevInfo.ts
+++ b/src/ethereum/info/ethDevInfo.ts
@@ -177,6 +177,9 @@ export const ethDev = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/ethereumclassicInfo.ts
+++ b/src/ethereum/info/ethereumclassicInfo.ts
@@ -169,6 +169,9 @@ export const ethereumclassic = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/ethereumpowInfo.ts
+++ b/src/ethereum/info/ethereumpowInfo.ts
@@ -140,6 +140,9 @@ export const ethereumpow = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/fantomInfo.ts
+++ b/src/ethereum/info/fantomInfo.ts
@@ -366,7 +366,10 @@ export const fantom = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })
 

--- a/src/ethereum/info/filecoinFevmCalibrationInfo.ts
+++ b/src/ethereum/info/filecoinFevmCalibrationInfo.ts
@@ -160,6 +160,9 @@ export const filecoinfevmcalibration = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/filecoinFevmInfo.ts
+++ b/src/ethereum/info/filecoinFevmInfo.ts
@@ -167,6 +167,9 @@ export const filecoinfevm = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/holeskyInfo.ts
+++ b/src/ethereum/info/holeskyInfo.ts
@@ -148,6 +148,9 @@ export const holesky = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/hyperEvmInfo.ts
+++ b/src/ethereum/info/hyperEvmInfo.ts
@@ -196,6 +196,9 @@ export const hyperevm = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/monadInfo.ts
+++ b/src/ethereum/info/monadInfo.ts
@@ -155,6 +155,9 @@ export const monad = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/opbnbInfo.ts
+++ b/src/ethereum/info/opbnbInfo.ts
@@ -136,6 +136,9 @@ export const opbnb = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/optimismInfo.ts
+++ b/src/ethereum/info/optimismInfo.ts
@@ -257,6 +257,9 @@ export const optimism = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/polygonInfo.ts
+++ b/src/ethereum/info/polygonInfo.ts
@@ -270,6 +270,9 @@ export const polygon = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/pulsechainInfo.ts
+++ b/src/ethereum/info/pulsechainInfo.ts
@@ -141,6 +141,9 @@ export const pulsechain = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/robinhoodInfo.ts
+++ b/src/ethereum/info/robinhoodInfo.ts
@@ -206,6 +206,9 @@ export const robinhood = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/rskInfo.ts
+++ b/src/ethereum/info/rskInfo.ts
@@ -128,6 +128,9 @@ export const rsk = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/sepoliaInfo.ts
+++ b/src/ethereum/info/sepoliaInfo.ts
@@ -146,6 +146,9 @@ export const sepolia = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/sonicInfo.ts
+++ b/src/ethereum/info/sonicInfo.ts
@@ -212,6 +212,9 @@ export const sonic = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/ethereum/info/zksyncInfo.ts
+++ b/src/ethereum/info/zksyncInfo.ts
@@ -166,6 +166,9 @@ export const zksync = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('../EthereumTools')
+    return await import(
+      /* webpackChunkName: "ethereum" */
+      '../EthereumTools'
+    )
   }
 })

--- a/src/hedera/hederaTestnetInfo.ts
+++ b/src/hedera/hederaTestnetInfo.ts
@@ -54,6 +54,9 @@ export const hederatestnet = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    return await import('./HederaTools')
+    return await import(
+      /* webpackChunkName: "hedera" */
+      './HederaTools'
+    )
   }
 })

--- a/src/piratechain/piratechainInfo.ts
+++ b/src/piratechain/piratechainInfo.ts
@@ -60,7 +60,9 @@ export const piratechain = makeOuterPlugin<
   networkInfo,
 
   async getInnerPlugin() {
-    /* webpackChunkName: "piratechain" */
-    return await import('./PiratechainTools')
+    return await import(
+      /* webpackChunkName: "piratechain" */
+      './PiratechainTools'
+    )
   }
 })

--- a/src/polkadot/info/liberlandInfo.ts
+++ b/src/polkadot/info/liberlandInfo.ts
@@ -74,6 +74,9 @@ export const liberland = makeOuterPlugin<
   },
 
   async getInnerPlugin() {
-    return await import('../PolkadotTools')
+    return await import(
+      /* webpackChunkName: "polkadot" */
+      '../PolkadotTools'
+    )
   }
 })

--- a/src/polkadot/info/liberlandTestnetInfo.ts
+++ b/src/polkadot/info/liberlandTestnetInfo.ts
@@ -71,6 +71,9 @@ export const liberlandtestnet = makeOuterPlugin<
   },
 
   async getInnerPlugin() {
-    return await import('../PolkadotTools')
+    return await import(
+      /* webpackChunkName: "polkadot" */
+      '../PolkadotTools'
+    )
   }
 })

--- a/src/sui/suitestnetInfo.ts
+++ b/src/sui/suitestnetInfo.ts
@@ -78,6 +78,9 @@ export const suitestnet = makeOuterPlugin<
   },
 
   async getInnerPlugin() {
-    return await import('./SuiTools')
+    return await import(
+      /* webpackChunkName: "sui" */
+      './SuiTools'
+    )
   }
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,14 @@ module.exports = {
         test: /\.ts$/,
         use: {
           loader: 'esbuild-loader',
-          options: { loader: 'ts', target: 'chrome55' }
+          options: {
+            loader: 'ts',
+            // Keep `import()` intact for webpack to turn into a chunk. The
+            // `chrome55` target predates dynamic import, so ESBuild would
+            // otherwise lower it to `require()` and inline every plugin.
+            supported: { 'dynamic-import': true },
+            target: 'chrome55'
+          }
         }
       }
     ]


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Technical design doc](https://github.com/EdgeApp/edge-currency-accountbased/blob/matthew/restore-chunk-splitting/src/docs/robinhood-chain.md)

Plugin code splitting has been dead since v4.57.0. Every plugin's tools module ships inside the initial bundle, so the plugin WebView parses 28.1 MB of JavaScript at startup before any wallet exists, and the two chunks we do emit are vendor chunks from `node_modules`.

#### Cause

[a28f61df](https://github.com/EdgeApp/edge-currency-accountbased/commit/a28f61df) set the ESBuild loader target to `chrome55`. Chrome gained dynamic import in 63, so for any target below that ESBuild rewrites `import(x)` into `Promise.resolve().then(() => require(x))` before webpack sees the module. Webpack reads that as a static CommonJS dependency and pulls the tools module into the importer's chunk, and the `webpackChunkName` comment disappears along with the `import()` it was attached to. Only `node_modules` keeps its chunks, because the loader rule excludes that path.

Nothing failed, which is why this went unnoticed for a year. The rewritten `require` still runs inside the `.then` callback, so inner plugins are still evaluated lazily. Only the chunk boundary was lost.

Published tarballs date it precisely:

| Release | Loader target | Chunk files shipped |
|---|---|---|
| v4.56.8 | ESBuild default `es2015` | 62 |
| v4.57.0 | `chrome55` | 2, both vendor |
| v4.91.0 | `chrome55` | 2, both vendor |

#### Fix

ESBuild's `supported` override keeps `import()` intact while `chrome55` still down-levels everything else, which is what the original commit wanted. This is the case ESBuild documents for the flag: transforming files individually for an old target while handing the output to a bundler.

Webpack then consumes the `import()` itself and emits its own script-tag loader, since `target` is `['web', 'es5']`. I confirmed zero literal native `import()` calls survive anywhere in the production output, so no new syntax reaches the WebView and old Android WebViews are unaffected.

| | Before | After |
|---|---|---|
| Initial bundle parsed at startup | 28.1 MB | 382 KB |
| Named plugin chunks | 0 | 21 |
| Vendor chunks | 2 | 47 |

#### Chunk names

The second commit reorganizes chunk names, which were assigned per plugin id even though the chunk boundary is the tools module a plugin imports, and sibling plugins share one.

- Eight Cosmos chains each named a chunk after themselves while all eight import `CosmosTools`, so webpack merged the eight chunk groups and kept whichever name it reached first. That was `axelar.chunk.js` in v4.56.8 and `nym.chunk.js` today.
- Thirty-four import sites carried no name at all and relied on that same merge to fold them into a named sibling.
- `piratechainInfo` put its magic comment above the `import()` call instead of inside the parentheses, where webpack cannot read it, so Piratechain landed in a numeric chunk despite being named.
- `thorchainruneStagenetInfo` said `thorchainrunestagebet`, against a `thorchainrunestagenet` plugin id.

Every `getInnerPlugin` now names its chunk for the tools module it imports, using the mainnet name where a testnet shares one, which is what Filecoin and Calibration already did. That leaves 21 names for 21 tools modules, so every emitted filename is predictable rather than a product of merge order. Binance keeps `bnb`, which does not match its `binance` plugin id but is unambiguous and unchanged.

#### Testing

Production webpack build of this branch: 0 errors, 68 chunks, and all 21 named chunks emit the filename they claim. `cosmos.chunk.js` replaces the arbitrary `nym.chunk.js`, and `piratechain.chunk.js` exists for the first time.

Full repo verification passes: `prepare` (which runs `clean`, `node`, `types` and `webpack`), eslint over the 45 changed files, and the test suite at 577 passing with 15 pending. `tsc` exits clean on its own too.

Native-module currencies are unaffected by design. Monero, Zcash, Piratechain and Zano reach native code through `nativeIo` on the plugin environment, which edge-core-js bridges in from React Native, so none of it travels through the webpack bundle. `monero.chunk.js` and `zcash.chunk.js` both emit cleanly.

Not yet verified on device. Chunk loading has not shipped since August 2025, and the artifact count goes from 3 files to 69, so this wants one run per platform before merge. Android serves chunks as siblings from `file:///android_asset/edge-currency-accountbased/`, and the podspec globs `*.js` into the iOS resource bundle, which `[name].chunk.js` matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes how the mobile WebView loads the currency bundle (many new chunk files); lazy loading behavior is restored but chunk fetch paths should be verified on Android/iOS before release.
> 
> **Overview**
> Restores **on-demand plugin loading** after esbuild had been rewriting every `getInnerPlugin()` `import()` into `require()`, which webpack treated as static deps and pulled all tools modules into the ~28 MB initial bundle.
> 
> **Build fix:** `webpack.config.js` sets esbuild’s `supported: { 'dynamic-import': true }` so `import()` stays dynamic while the `chrome55` target still down-levels everything else; webpack can emit named async chunks again (initial bundle drops to on the order of hundreds of KB).
> 
> **Chunk naming:** Outer plugin info files now attach `webpackChunkName` on the dynamic import (inside the `import()` call) and name chunks after the **shared tools module** (e.g. all EVM chains → `ethereum`, Cosmos family → `cosmos`, testnets share mainnet names). That replaces per-plugin-id names, missing comments, and a misplaced Piratechain magic comment so chunk filenames match what each plugin actually loads.
> 
> **Docs:** Unreleased CHANGELOG entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b2eae0ebe922c21f7d639089fe91f26aa86620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218372362051398