### PR TITLE
Migrate Axelar and Osmosis off dead RPC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fixed: (Axelar) Replace the retired `axelar.tendermintrpc.lava.build` RPC node, which answers every request with HTTP 410 "This endpoint has been discontinued.", and the unreachable `axelar-archrpc.chainode.tech` archive node. Axelar wallets could reach neither balances nor transaction history, so their sync ratio sat at 0 forever with no visible error.
+- fixed: (Osmosis) Replace the `rpc.osmosis.zone` RPC node, which now returns HTTP 403 to every request. Osmosis wallets stalled partway through their sync ratio because the balance query never completed for enabled tokens.
+
 ## 4.91.0 (2026-09-08)
 
 - added: Robinhood Chain support (`robinhood`, EVM chain 4663)

--- a/src/cosmos/info/axelarInfo.ts
+++ b/src/cosmos/info/axelarInfo.ts
@@ -20,7 +20,7 @@ const networkInfo: CosmosNetworkInfo = {
   nativeDenom: 'uaxl',
   pluginMnemonicKeyName: 'axelarMnemonic',
   rpcNode: {
-    url: 'https://axelar.tendermintrpc.lava.build',
+    url: 'https://axelar-rpc.publicnode.com:443',
     headers: {}
   },
   archiveNodes: [
@@ -29,7 +29,7 @@ const networkInfo: CosmosNetworkInfo = {
         start: 0
       },
       endpoint: {
-        url: 'https://axelar-archrpc.chainode.tech',
+        url: 'https://axelar-rpc.polkachu.com',
         headers: {}
       }
     }

--- a/src/cosmos/info/osmosisInfo.ts
+++ b/src/cosmos/info/osmosisInfo.ts
@@ -44,7 +44,7 @@ const networkInfo: CosmosNetworkInfo = {
   nativeDenom: 'uosmo',
   pluginMnemonicKeyName: 'osmosisMnemonic',
   rpcNode: {
-    url: 'https://rpc.osmosis.zone:443',
+    url: 'https://osmosis-rpc.publicnode.com:443',
     headers: {}
   },
   archiveNodes: [


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Two Cosmos chains have been pointing at RPC nodes that no longer serve traffic, which left their
wallets stuck partway through syncing with nothing surfaced to the user.

Verified from inside a running iOS build (RN 0.79.2, `edge-currency-accountbased` 4.90.1), reading
`syncRatio` live out of the app rather than inferring it from the UI:

| wallet | syncRatio |
| --- | --- |
| Axelar | **0** |
| Osmosis | **0.25** |
| Coreum / Cosmos Hub / THORChain / MAYAChain | 1 |

The dead nodes, confirmed by `fetch` from the device itself (not just curl from a laptop):

- `axelar.tendermintrpc.lava.build` → **HTTP 410**, body `"This endpoint has been discontinued."`
- `axelar-archrpc.chainode.tech` (archive) → connection failure
- `rpc.osmosis.zone:443` → **HTTP 403**, empty body, on GET and POST, with and without a browser UA

Replacements were checked for a `/status` 200, the correct chain-id, and a real `tx_search` against
the test account's own addresses:

- `osmosis-1` → `https://osmosis-rpc.publicnode.com:443`
- `axelar-dojo-1` → `https://axelar-rpc.publicnode.com:443`, archive `https://axelar-rpc.polkachu.com`

publicnode is already the working provider behind `cosmoshub`, so this keeps the family consistent.
Osmosis's QuickNode archive entry is untouched — it was not implicated.

#### Why a dead node freezes the ratio instead of raising an error

Worth a follow-up, deliberately out of scope here. `CosmosEngine.queryBalance` swallows the failure
with `this.log.warn('queryBalance error:', e)` and only calls `updateBalance` — the call that fires
`syncTracker.balanceComplete(tokenId)` — on success, or for `null` alone on the
`'does not exist on chain'` branch. `makeTokenSyncTracker` requires balance **and** history at 1 for
every `[null, ...enabledTokenIds]` entry and never lets a ratio move backwards, so any tokenId that
never receives an `updateBalance` pins its wallet below 1 permanently. That is the arithmetic behind
the two numbers above: Axelar has no enabled tokens and sits at 0; Osmosis has one (`uion`) and sits
at 0.25. A swap of endpoints fixes today's outage but not the silent-stall behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only RPC URL swaps with no engine or sync logic changes; restores wallet sync after third-party endpoint outages.
> 
> **Overview**
> **Axelar** and **Osmosis** wallets were stuck syncing because their default Tendermint RPC URLs no longer respond usefully (Axelar: HTTP 410 on Lava + unreachable archive; Osmosis: HTTP 403 on `rpc.osmosis.zone`).
> 
> This PR only updates chain info config: Axelar’s primary RPC moves to `axelar-rpc.publicnode.com` and its archive to `axelar-rpc.polkachu.com`; Osmosis’s primary RPC moves to `osmosis-rpc.publicnode.com` (QuickNode archive unchanged). **CHANGELOG** documents both fixes. Aligns with Cosmos Hub’s existing publicnode primary RPC pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a737b2e70dbc24195d4ddf8cf0aba75d5b92fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218372647140273