### PR TITLE
Bound explorer rate-limit retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: (EVM) A rate-limited block explorer no longer stops the wallet's sync until restart
 - fixed: (Axelar) Replace the retired `axelar.tendermintrpc.lava.build` RPC node, which answers every request with HTTP 410 "This endpoint has been discontinued.", and the unreachable `axelar-archrpc.chainode.tech` archive node. Axelar wallets could reach neither balances nor transaction history, so their sync ratio sat at 0 forever with no visible error.
 - fixed: (Osmosis) Replace the `rpc.osmosis.zone` RPC node, which now returns HTTP 403 to every request. Osmosis wallets stalled partway through their sync ratio because the balance query never completed for enabled tokens.
 

--- a/src/ethereum/networkAdapters/EvmScanAdapter.ts
+++ b/src/ethereum/networkAdapters/EvmScanAdapter.ts
@@ -78,6 +78,14 @@ export class EvmScanAdapter<
   /** Extra headers on every `/api` request; subclasses set them per provider */
   protected requestHeaders: Record<string, string> | undefined = undefined
 
+  /**
+   * Explorer API keys are shared by every EVM wallet, so throttle replies are
+   * routine. Unbounded retries double the wait each time and hold the engine's
+   * sync open, which also stops token detection until the app restarts. Give
+   * up after a few tries and let the next sync pass ask again.
+   */
+  protected rateLimitRetries = 3
+
   batchMulticastRpc = null
   connect = null
   disconnect = null

--- a/test/ethereum/network/evmScanRateLimitRetries.test.ts
+++ b/test/ethereum/network/evmScanRateLimitRetries.test.ts
@@ -1,0 +1,83 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import type { EthereumEngine } from '../../../src/ethereum/EthereumEngine'
+import { EvmScanAdapter } from '../../../src/ethereum/networkAdapters/EvmScanAdapter'
+import { RateLimitError } from '../../../src/ethereum/networkAdapters/networkAdapterTypes'
+
+type EngineFetch = EthereumEngine['engineFetch']
+
+describe('EvmScanAdapter rate limit retries', function () {
+  it('gives up on a throttled explorer instead of retrying forever', async function () {
+    this.timeout(20000)
+
+    let calls = 0
+    const adapter = makeAdapter(async () => {
+      ++calls
+      return fakeResponse({
+        message: 'NOTOK',
+        result: 'Max calls per sec rate limit reached (5/sec)',
+        status: '0'
+      })
+    })
+
+    const error = await rejectionOf(adapter.fetchNonce())
+    assert.instanceOf(error, RateLimitError)
+    // The first call, the backoff's own first call, then three retries:
+    assert.equal(calls, 5)
+  })
+
+  it('returns once the explorer stops throttling', async function () {
+    this.timeout(20000)
+
+    let calls = 0
+    const adapter = makeAdapter(async () => {
+      ++calls
+      return calls < 3
+        ? fakeResponse({
+            message: 'NOTOK',
+            result: 'Max rate limit reached',
+            status: '0'
+          })
+        : fakeResponse({ id: 1, jsonrpc: '2.0', result: '0x5' })
+    })
+
+    const update = await adapter.fetchNonce()
+    assert.equal(update.newNonce, '5')
+    assert.equal(calls, 3)
+  })
+})
+
+function makeAdapter(engineFetch: EngineFetch): EvmScanAdapter {
+  const engine = {
+    currencyInfo: { currencyCode: 'HYPE' },
+    engineFetch,
+    initOptions: { etherscanApiKey: 'test-api-key' },
+    log: Object.assign(() => undefined, { warn: () => undefined }),
+    networkInfo: { chainParams: { chainId: 999 } },
+    walletLocalData: {
+      publicKey: '0x3e339531147F9bBf5438a0357E59Da4CaaEaD2Ef'
+    },
+    warn: () => undefined
+  } as unknown as EthereumEngine
+  return new EvmScanAdapter(engine, {
+    type: 'evmscan',
+    servers: ['https://api.etherscan.io']
+  })
+}
+
+function fakeResponse(json: unknown): Awaited<ReturnType<EngineFetch>> {
+  return { json: async () => json, ok: true } as unknown as Awaited<
+    ReturnType<EngineFetch>
+  >
+}
+
+async function rejectionOf(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise
+  } catch (error: unknown) {
+    if (error instanceof Error) return error
+    throw error
+  }
+  throw new Error('Expected the request to reject')
+}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1218291556240202/f)

Received tokens on HyperEVM wallets went undetected until the app restarted. The cause sits in the shared EVM explorer path, which affects every chain that uses `EvmScanAdapter`.

**Cause**
- Every EVM wallet shares the same explorer API keys. Throttle replies from `api.etherscan.io` are routine as a result.
- `fetchGetEtherscan` turns a throttle reply into a `RateLimitError`. `serialServers` and `parallelServers` retry that error through `exponentialBackoff`.
- `EvmScanAdapter` inherited `rateLimitRetries = Infinity`. A throttled call therefore retried with no limit, and the delay doubled each time (1 s, 2 s, 4 s, ...).
- The stage that hit the error never finished. It held `acquireUpdates` open, and with it the engine's `syncNetwork`.
- While that call waited, the wallet's balance checker never ran again. That checker is what reports new tokens. A restart rebuilt the engine and cleared the stall.

**Change**
- `EvmScanAdapter` sets `rateLimitRetries = 3`, the value `BlockscoutAdapter` already uses. After about 7 s of backoff the call fails, and the next sync pass asks again.
- New `test/ethereum/network/evmScanRateLimitRetries.test.ts`:
  - A permanently throttled explorer rejects with `RateLimitError` after 5 calls: the first call, the backoff's own first call, then 3 retries.
  - An explorer that recovers mid-backoff still returns its result.

**Evidence**

Driven on the iOS simulator with 6 HyperEVM wallets on the edge-funds account. Temporary instrumentation recorded each sync stage and each rate-limit retry; it is not part of this branch.
- Before the change, over about 15 minutes:
  - `api.etherscan.io` throttled every wallet 25 to 50 times.
  - Stuck stages sat in backoff at retry # 8 and kept doubling.
  - Those wallets' balance checkers stopped.
- With the change, over about 8 minutes:
  - Throttling continued at 15 to 42 replies per wallet.
  - Every backoff ended by retry # 4.
  - Every wallet's balance checker ran 18 to 24 times.
  - A freshly created wallet detected a received HFUN token with no restart.

**Testing**
- `tsc` passes, and both new tests pass in the full mocha suite.
- These tests also fail on untouched master, unrelated to this branch:
  - `builtinTokens` and `Engine` hit mocha's 2000 ms timeout under host load.
  - `FTM Network Fees` depends on live network APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared EVM sync behavior for all chains using EvmScanAdapter; failed explorer calls may surface sooner instead of retrying forever, which is intentional but affects sync reliability under heavy API throttling.
> 
> **Overview**
> Fixes EVM wallets (including HyperEVM) where **incoming tokens were not detected until an app restart** when shared block-explorer API keys hit rate limits.
> 
> **`EvmScanAdapter`** now sets **`rateLimitRetries = 3`** (matching **`BlockscoutAdapter`**) instead of inheriting unbounded retries from the base adapter. Throttled explorer calls still use exponential backoff, but they **fail after a few attempts** (~7s) with **`RateLimitError`** so **`syncNetwork` is not held open indefinitely** and the balance/token checker can run on the next sync pass.
> 
> Adds **`test/ethereum/network/evmScanRateLimitRetries.test.ts`** to assert permanent throttling stops after 5 fetch attempts and that a successful reply after transient throttling still returns (e.g. nonce **`5`**). **CHANGELOG** documents the EVM sync fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79732e659a20bd9c524e809ce0bae73084b9525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->